### PR TITLE
Fix trino skill backtick error causing shell operator warning

### DIFF
--- a/sql-skills/trino/SKILL.md
+++ b/sql-skills/trino/SKILL.md
@@ -126,7 +126,7 @@ TD_TIME_STRING(time, 's', 'UTC')      -- Returns: 2018-09-13 16:45:34+0000
 - `h!` = yyyy-MM-dd HH (hour)
 - `m!` = yyyy-MM-dd HH:mm (minute)
 - `s!` = yyyy-MM-dd HH:mm:ss (second)
-- Without `!` includes timezone offset
+- Without the exclamation mark suffix, timezone offset is included
 
 **TD_TIME_FORMAT** - Format timestamps (Legacy, use TD_TIME_STRING instead):
 ```sql


### PR DESCRIPTION
## Summary
- Fixed backtick formatting error in trino skill that was causing Claude Code to interpret `!` as a shell operator
- Changed line 129 from "Without \`!\` includes timezone offset" to "Without the exclamation mark suffix, timezone offset is included"

## Problem
The backtick-wrapped exclamation mark was triggering this error:
```
Error: Bash command permission check failed for pattern "!` includes timezone offset
```

## Solution
Replaced the backtick formatting with plain text to avoid shell operator interpretation while maintaining clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)