### PR TITLE
refactor: improve tdx skills naming and documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,8 +72,8 @@
       "strict": false,
       "skills": [
         "./tdx-skills/tdx-basic",
-        "./tdx-skills/tdx-parent-segment",
-        "./tdx-skills/tdx-segment"
+        "./tdx-skills/parent-segment",
+        "./tdx-skills/segment"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Skills are folders of instructions and resources that Claude loads dynamically t
 ### TDX CLI Skills
 
 - **[tdx-skills/tdx-basic](./tdx-skills/tdx-basic)** - Core [tdx](https://tdx.treasuredata.com) CLI operations for managing TD from command line: databases, tables, queries, and context management
-- **[tdx-skills/tdx-parent-segment](./tdx-skills/tdx-parent-segment)** - Manage CDP parent segments with YAML-based configuration for master tables, attributes, and behaviors
-- **[tdx-skills/tdx-segment](./tdx-skills/tdx-segment)** - Manage CDP child segments with rules, activations, and folder organization
+- **[tdx-skills/parent-segment](./tdx-skills/parent-segment)** - Manage CDP parent segments with YAML-based configuration for master tables, attributes, and behaviors
+- **[tdx-skills/segment](./tdx-skills/segment)** - Manage CDP child segments with rules, activations, and folder organization
 
 ### Field Agent Skills
 
@@ -95,8 +95,8 @@ Once installed, explicitly reference skills using the `skill` keyword to trigger
 "Use the JavaScript SDK skill to implement event tracking on my website"
 "Use the pytd skill to query TD from Python and load results into pandas"
 "Use the tdx-basic skill to list all databases in the Tokyo region"
-"Use the tdx-parent-segment skill to configure a CDP parent segment"
-"Use the tdx-segment skill to create child segments with activation rules"
+"Use the parent-segment skill to configure a CDP parent segment"
+"Use the segment skill to create child segments with activation rules"
 "Use the deployment skill to set up a production publishing workflow"
 "Use the documentation skill to create comprehensive Field Agent documentation"
 "Use the visualization skill to create a Plotly chart with TD colors"

--- a/tdx-skills/parent-segment/SKILL.md
+++ b/tdx-skills/parent-segment/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tdx-parent-segment
+name: parent-segment
 description: Manage CDP parent segments with tdx CLI using YAML-based configuration for master tables, attributes, and behaviors. Use when setting up parent segments, validating configurations, or running parent segment workflows.
 ---
 

--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tdx-segment
+name: segment
 description: Manage CDP child segments with tdx CLI using YAML-based configuration for rules and activations. Use when creating segments, setting up audience filters, or configuring data exports to external systems.
 ---
 
@@ -192,11 +192,38 @@ activations:
 
 ## Supported Operators
 
-**Comparison**: Equal, NotEqual, Greater, GreaterEqual, Less, LessEqual
-**List**: In, NotIn
-**String**: Contain, StartWith, EndWith, Regexp
-**Null**: IsNull
-**Time**: TimeWithinPast
+See [full operator reference](https://tdx.treasuredata.com/commands/segment.html#supported-operators) for complete details.
+
+### Comparison Operators
+
+- **Equal**: Exact match - `value: "active"`
+- **NotEqual**: Not equal - `value: "inactive"`
+- **Greater**: Greater than - `value: 1000`
+- **GreaterEqual**: Greater or equal - `value: 18`
+- **Less**: Less than - `value: 100`
+- **LessEqual**: Less or equal - `value: 65`
+
+### List Operators
+
+- **In**: Value in set - `values: ["US", "CA", "MX"]`
+- **NotIn**: Value not in set - `values: ["spam", "test"]`
+
+### String Operators
+
+- **Contain**: Contains substring - `values: ["@gmail.com"]`
+- **StartWith**: Starts with prefix - `values: ["Premium"]`
+- **EndWith**: Ends with suffix - `values: [".com"]`
+- **Regexp**: Regex match - `value: "^[A-Z]{2}[0-9]{4}$"`
+
+### Null Operators
+
+- **IsNull**: Field is null - (no value needed)
+
+### Time Operators
+
+- **TimeWithinPast**: Within past N units - `value: 30, unit: days`
+
+**Note**: Most operators use singular `value`, while set-based operators (In, NotIn, Contain, StartWith, EndWith) use plural `values`.
 
 ## Typical Workflow
 


### PR DESCRIPTION
Summary:
- Rename skills to remove tdx- prefix (parent-segment, segment)
- Enhance segment skill with detailed operator documentation
- Update all references in marketplace.json and README.md

Changes:
- Renamed tdx-parent-segment → parent-segment
- Renamed tdx-segment → segment
- Added comprehensive operator reference to segment skill with examples
- Updated marketplace.json with new skill paths
- Updated README.md skill links and invocation examples
- Fixed related skills references in both skill files

Test plan:
- [ ] Verify skills load correctly with new names
- [ ] Test skill invocation with new names
- [ ] Verify operator documentation is accurate
- [ ] Check all links in README work correctly