### PR TITLE
docs: unify value/values fields in segment skills

### DIFF
--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -209,14 +209,14 @@ See [full operator reference](https://tdx.treasuredata.com/commands/segment.html
 
 ### List Operators
 
-- **In**: Value in set - `values: ["US", "CA", "MX"]`
-- **NotIn**: Value not in set - `values: ["spam", "test"]`
+- **In**: Value in set - `value: ["US", "CA", "MX"]`
+- **NotIn**: Value not in set - `value: ["spam", "test"]`
 
 ### String Operators
 
-- **Contain**: Contains substring - `values: ["@gmail.com"]`
-- **StartWith**: Starts with prefix - `values: ["Premium"]`
-- **EndWith**: Ends with suffix - `values: [".com"]`
+- **Contain**: Contains substring - `value: ["@gmail.com"]`
+- **StartWith**: Starts with prefix - `value: ["Premium"]`
+- **EndWith**: Ends with suffix - `value: [".com"]`
 - **Regexp**: Regex match - `value: "^[A-Z]{2}[0-9]{4}$"`
 
 ### Null Operators
@@ -237,7 +237,7 @@ See [full operator reference](https://tdx.treasuredata.com/commands/segment.html
 - `minute` - Minutes
 - `second` - Seconds
 
-**Note**: Most operators use singular `value`, while set-based operators (In, NotIn, Contain, StartWith, EndWith) use plural `values`.
+**Note**: All operators use unified `value` field. For set-based operators (In, NotIn, Contain, StartWith, EndWith), provide an array. The CLI auto-detects single vs array values.
 
 ## Accessing Segment Data
 

--- a/tdx-skills/validate-segment/SKILL.md
+++ b/tdx-skills/validate-segment/SKILL.md
@@ -43,15 +43,15 @@ Each condition must have:
 **List Operators**:
 | Type | Required Fields | Value Type |
 |------|-----------------|------------|
-| `In` | `values` | array of strings/numbers |
-| `NotIn` | `values` | array of strings/numbers |
+| `In` | `value` | array of strings/numbers |
+| `NotIn` | `value` | array of strings/numbers |
 
 **String Operators**:
 | Type | Required Fields | Value Type |
 |------|-----------------|------------|
-| `Contain` | `values` | array of strings |
-| `StartWith` | `values` | array of strings |
-| `EndWith` | `values` | array of strings |
+| `Contain` | `value` | array of strings |
+| `StartWith` | `value` | array of strings |
+| `EndWith` | `value` | array of strings |
 | `Regexp` | `value` | regex pattern string |
 
 **Null Operators**:
@@ -104,7 +104,7 @@ rule:
       attribute: country
       operator:
         type: In
-        values: ["US", "CA"]  # Correct: 'values' for In operator
+        value: ["US", "CA"]  # Correct: 'value' with array for In operator
     - type: Value
       attribute: ltv
       operator:
@@ -135,17 +135,17 @@ operator:
   unit: day  # Correct: singular form
 ```
 
-**Error: Wrong field name for list operators**
+**Error: Array value for comparison operator**
 ```yaml
 # INVALID
 operator:
-  type: In
-  value: ["US", "CA"]  # Wrong: should be 'values'
+  type: Equal
+  value: ["US", "CA"]  # Wrong: Equal expects single value, use In for arrays
 
 # VALID
 operator:
   type: In
-  values: ["US", "CA"]  # Correct: plural 'values'
+  value: ["US", "CA"]  # Correct: In operator for multiple values
 ```
 
 **Error: Missing required fields**
@@ -186,8 +186,9 @@ tdx sg push
 | Check | Rule |
 |-------|------|
 | Time units | Must be singular: `day`, `month`, `year` (not `days`, `months`, `years`) |
-| List operators (In, NotIn, Contain, StartWith, EndWith) | Use `values` (plural) |
-| Comparison operators (Equal, Greater, etc.) | Use `value` (singular) |
+| All operators | Use unified `value` field (CLI auto-detects single vs array) |
+| List operators (In, NotIn, Contain, StartWith, EndWith) | Provide array in `value` field |
+| Comparison operators (Equal, Greater, etc.) | Provide single value in `value` field |
 | TimeWithinPast/TimeWithinNext | Requires both `value` and `unit` |
 | Segment kind | Must be `batch`, `realtime`, or `funnel_stage` |
 | Rule type | Must be `And` or `Or` |


### PR DESCRIPTION
## Summary

- Update `segment` and `validate-segment` skills to use unified `value` field instead of separate `value`/`values` fields
- Reflect changes from treasure-data/tdx#438 which consolidates these fields in the CLI
- The CLI now auto-detects whether to use single or array API parameters based on input type

## Changes

**segment/SKILL.md**:
- Updated operator reference to use `value` for list operators (In, NotIn, Contain, StartWith, EndWith)
- Updated note explaining unified `value` field behavior

**validate-segment/SKILL.md**:
- Updated operator tables to show `value` field for all operators
- Updated valid/invalid examples to reflect new unified syntax
- Updated quick reference card with new rules

## Related

- Closes: treasure-data/tdx#438

🤖 Generated with [Claude Code](https://claude.com/claude-code)