### PR TITLE
docs: fix journey skills format to match real-world examples

### DIFF
--- a/tdx-skills/journey/templates/basic-journey.yml
+++ b/tdx-skills/journey/templates/basic-journey.yml
@@ -1,9 +1,39 @@
 # Basic Journey Example
 # A simple onboarding journey with one stage
+# File location: ./segments/(parent-segment-name)/onboarding-journey.yml
 
 type: journey
 name: Onboarding Journey
+
+journeys:
+  - stages:
+      - name: Welcome
+        entry_criteria:
+          name: New Customers
+          segment: new-customers
+        steps:
+          - type: wait
+            name: Wait 1 Day
+            with:
+              duration: 1
+              unit: day  # day | week (singular only)
+          - type: activation
+            name: Send Welcome Email
+            next: Complete  # Direct field for branching
+            with:
+              activation: welcome-email  # References key in activations:
+          - type: end
+            name: Complete
+    state: draft  # Push as draft first, use simulation to validate
+
 description: 30-day customer onboarding
+
+reentry: no_reentry  # no_reentry | reentry_unless_goal_achieved | reentry_always
+
+# Journey-level goal (optional)
+goal:
+  name: Completed Onboarding
+  segment: completed-users
 
 # Embedded segments (journey-local)
 segments:
@@ -26,32 +56,14 @@ segments:
         type: Equal
         value: true
 
-# Journey-level goal (optional)
-goal:
-  name: Completed Onboarding
-  segment: completed-users
-
-# Reentry mode: no_reentry | reentry_unless_goal_achieved | reentry_always
-reentry: no_reentry
-
-# Journey versions (unified format)
-journeys:
-  - state: draft  # Push as draft first, use simulation to validate
-    latest: true
-    stages:
-      - name: Welcome
-        entry_criteria:
-          name: New Customers
-          segment: new-customers
-        steps:
-          - type: wait
-            name: Wait 1 Day
-            with:
-              duration: 1
-              unit: day  # day | week
-          - type: activation
-            name: Send Welcome Email
-            with:
-              activation: welcome-email  # From tdx connection list
-          - type: end
-            name: Complete
+# Embedded activations (optional)
+activations:
+  welcome-email:
+    name: Welcome Email Campaign
+    connection: email-connector  # From tdx connection list
+    all_columns: true
+    schedule:
+      type: none
+      timezone: UTC
+    connector_config:
+      mode: append

--- a/tdx-skills/journey/templates/complete-journey.yml
+++ b/tdx-skills/journey/templates/complete-journey.yml
@@ -1,63 +1,13 @@
 # Complete Journey Example
 # Multi-stage retention campaign with all features
+# File location: ./segments/(parent-segment-name)/retention-journey.yml
 
 type: journey
 name: Customer Retention Journey
-description: Multi-stage retention campaign
-
-# Embedded segments (journey-local)
-# These are defined within the journey and referenced by key name
-segments:
-  new-customers:
-    description: Customers in last 30 days
-    rule:
-      type: Value
-      attribute: created_at
-      operator:
-        type: TimeWithinPast
-        value: 30
-        unit: day
-
-  engaged-users:
-    description: Users who opened email
-    rule:
-      type: Value
-      attribute: email_opened
-      operator:
-        type: Equal
-        value: true
-
-# Embedded activations (journey-local)
-# Use `tdx connection list` to find available connection names
-activations:
-  welcome-email:
-    name: Send Welcome Email
-    connection: salesforce-marketing  # From tdx connection list
-    connector_config:
-      template: welcome_template
-
-  reminder-email:
-    name: Send Reminder Email
-    connection: salesforce-marketing
-    connector_config:
-      template: reminder_template
-
-# Journey-level settings
-goal:
-  name: Made Purchase
-  segment: ref:Purchasers  # External segment reference (use ref: prefix)
-  target:  # Optional: jump when goal met
-    journey: Post-Purchase Journey
-    stage: Thank You
-
-reentry: reentry_unless_goal_achieved
 
 # Journey versions
 journeys:
-  - version: v1
-    state: draft  # Push as draft, validate with simulation before launching
-    latest: true
-    stages:
+  - stages:
       # Stage 1: Welcome Stage
       - name: Welcome Stage
         description: Initial customer engagement
@@ -166,3 +116,87 @@ journeys:
 
           - type: end
             name: Stage Complete
+    version: v1
+    state: draft  # Push as draft, validate with simulation before launching
+    latest: true
+
+description: Multi-stage retention campaign
+
+reentry: reentry_unless_goal_achieved
+
+# Journey-level goal (optional)
+goal:
+  name: Made Purchase
+  segment: ref:Purchasers  # External segment reference (use ref: prefix)
+  target:  # Optional: jump when goal met
+    journey: Post-Purchase Journey
+    stage: Thank You
+
+# Embedded segments (journey-local)
+# These are defined within the journey and referenced by key name
+segments:
+  new-customers:
+    description: Customers in last 30 days
+    rule:
+      type: Value
+      attribute: created_at
+      operator:
+        type: TimeWithinPast
+        value: 30
+        unit: day
+
+  engaged-users:
+    description: Users who opened email
+    rule:
+      type: Value
+      attribute: email_opened
+      operator:
+        type: Equal
+        value: true
+
+# Embedded activations (journey-local)
+# Use `tdx connection list` to find available connection names
+activations:
+  welcome-email:
+    name: Send Welcome Email
+    connection: salesforce-marketing  # From tdx connection list
+    all_columns: true
+    schedule:
+      type: none
+      timezone: UTC
+    connector_config:
+      template: welcome_template
+      mode: append
+
+  reminder-email:
+    name: Send Reminder Email
+    connection: salesforce-marketing
+    all_columns: true
+    schedule:
+      type: none
+      timezone: UTC
+    connector_config:
+      template: reminder_template
+      mode: append
+
+  discount-email:
+    name: Discount Offer Email
+    connection: salesforce-marketing
+    all_columns: true
+    schedule:
+      type: none
+      timezone: UTC
+    connector_config:
+      template: discount_template
+      mode: append
+
+  trial-email:
+    name: Free Trial Email
+    connection: salesforce-marketing
+    all_columns: true
+    schedule:
+      type: none
+      timezone: UTC
+    connector_config:
+      template: trial_template
+      mode: append


### PR DESCRIPTION
## Summary

- Add **file structure documentation** (`./segments/parent-segment/*.yml`) to journey and validate-journey skills
- Document `next` as a **direct field on steps** (not inside `with:`), matching real YAML examples
- Add **activations section** with full configuration examples (connection, connector_config, schedule, notification)
- Update templates to match **real YAML structure** (journeys first, metadata last)
- Add file location and step `next` field to Quick Reference Card in validate-journey

## Changes

### `tdx-skills/journey/SKILL.md`
- Added File Structure section
- Updated Step Examples to show `next:` as direct field
- Added Activations Section with full definition example

### `tdx-skills/validate-journey/SKILL.md`
- Added File Location section
- Added Section 4a. Step Structure clarifying `next` placement
- Updated Validation Workflow to include `tdx sg use` command
- Updated Quick Reference Card

### Templates
- Reorganized to match real-world file structure
- Added full `activations:` section examples
- Added file location comments

## Test plan

- [ ] Review that templates match examples in `seg-demo/segments/leo_demo/`
- [ ] Verify skill triggers correctly with journey-related questions
- [ ] Test validate-journey skill catches format errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)