### PR TITLE
feat: add connector-config skill for segment/journey activations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,8 @@
         "./tdx-skills/segment",
         "./tdx-skills/validate-segment",
         "./tdx-skills/journey",
-        "./tdx-skills/validate-journey"
+        "./tdx-skills/validate-journey",
+        "./tdx-skills/connector-config"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Skills are folders of instructions and resources that Claude loads dynamically t
 - **[tdx-skills/validate-segment](./tdx-skills/validate-segment)** - Validate segment YAML configurations against CDP API spec for correct operators, time units, and field names
 - **[tdx-skills/journey](./tdx-skills/journey)** - Create CDP journey definitions in YAML with stages, steps (wait, activation, decision_point, ab_test, merge, jump, end), and simulation workflow
 - **[tdx-skills/validate-journey](./tdx-skills/validate-journey)** - Validate journey YAML configurations for correct step types, parameters, and segment references
+- **[tdx-skills/connector-config](./tdx-skills/connector-config)** - Configure connector_config for segment/journey activations using `tdx connection schema` to discover fields
 
 ### Field Agent Skills
 
@@ -105,13 +106,14 @@ Once installed, explicitly reference skills using the `skill` keyword to trigger
 "Use the validate-segment skill to check my segment YAML for errors"
 "Use the journey skill to create a customer onboarding journey"
 "Use the validate-journey skill to check my journey YAML for errors"
+"Use the connector-config skill to configure an SFMC activation"
 "Use the deployment skill to set up a production publishing workflow"
 "Use the documentation skill to create comprehensive Field Agent documentation"
 "Use the visualization skill to create a Plotly chart with TD colors"
 ```
 
 Tips for triggering skills:
-- Include the skill name (Trino, Hive, time-filtering, Trino CLI, TD MCP, activations, digdag, dbt, JavaScript SDK, pytd, tdx, tdx-basic, validate-segment, journey, validate-journey, deployment, documentation, visualization)
+- Include the skill name (Trino, Hive, time-filtering, Trino CLI, TD MCP, activations, digdag, dbt, JavaScript SDK, pytd, tdx, tdx-basic, validate-segment, journey, validate-journey, connector-config, deployment, documentation, visualization)
 - Use the word "skill" in your request
 - Be specific about what you want to accomplish
 

--- a/tdx-skills/connector-config/SKILL.md
+++ b/tdx-skills/connector-config/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: connector-config
+description: Writes connector_config for segment/journey activations using `tdx connection schema <type>` to discover available fields. Use when configuring activations - always run schema command first to see connector-specific fields.
+---
+
+# tdx Connector Config
+
+Configure `connector_config` for activations by discovering fields with `tdx connection schema`.
+
+## Key Commands
+
+```bash
+# List connections (shows type and name)
+tdx connection list
+
+# Discover connector_config fields (ALWAYS run this first)
+tdx connection schema <connector_type>
+
+# List all connector types
+tdx connection types
+```
+
+**Schema vs Settings**: `schema` shows `connector_config` fields for activations. `settings` shows credentials for creating connections.
+
+## Workflow
+
+```bash
+# 1. Find connection type
+tdx connection list
+#   salesforce_marketing_cloud_v2  salesforce-marketing - Jane Smith
+
+# 2. Get schema
+tdx connection schema salesforce_marketing_cloud_v2
+
+# 3. Write connector_config using discovered fields
+# 4. Validate: tdx sg push --dry-run
+```
+
+## Common Connector Types
+
+### Salesforce Marketing Cloud (salesforce_marketing_cloud_v2)
+
+```yaml
+connector_config:
+  de_name: CustomerSegment           # Data Extension name (requires primary key)
+  shared_data_extension: false
+  data_operation: upsert             # upsert | replace
+  # For creating new DE:
+  create_new_de: true
+  folder_path: Segments/Marketing
+  primary_column: email
+  is_sendable: true
+  sendable_rule: Email Address       # "Subscriber Key" | "Email Address"
+  sendable_column: email
+```
+
+### Salesforce CRM (sfdc_v2)
+
+```yaml
+connector_config:
+  object: Contact
+  mode: update                       # append | truncate | update
+  unique: email                      # Key field (when mode=update)
+  upsert: true
+```
+
+### AWS S3 (s3_v2)
+
+```yaml
+connector_config:
+  bucket: my-bucket
+  path: exports/segments/data.csv
+  format: csv                        # csv | tsv | jsonl
+  compression: gz                    # none | gz
+```
+
+### BigQuery (bigquery_v2)
+
+```yaml
+connector_config:
+  project: my-gcp-project
+  dataset: marketing
+  table: segments
+  mode: APPEND                       # APPEND | REPLACE | REPLACE_BACKUP | TRUNCATE
+  auto_create_table: true
+```
+
+### Treasure Data (treasure_data)
+
+```yaml
+connector_config:
+  database_name: marketing_db
+  table_name: exported_segments
+  mode: append                       # append | replace
+```
+
+## Conditional Fields
+
+Schema output shows when fields apply:
+
+```
+unique: Key [text]
+  Show when: mode=["update"]
+```
+
+Only include `unique` when `mode` is `update`.
+
+## Related Skills
+
+- **segment** - Child segment activations
+- **journey** - Journey activations

--- a/tdx-skills/journey/SKILL.md
+++ b/tdx-skills/journey/SKILL.md
@@ -146,7 +146,7 @@ Define embedded activations in the `activations:` section. These are referenced 
 activations:
   welcome-email:                    # Key name referenced in steps
     name: Welcome Email Campaign    # Display name
-    connection: salesforce-mc       # From tdx connection list
+    connection: salesforce-marketing  # From tdx connection list
     all_columns: true               # Export all attributes
     schedule:
       type: none                    # none | daily | hourly
@@ -158,12 +158,12 @@ activations:
       email_recipients:
         - team@example.com
     connector_config:               # Connection-specific config
-      userDatabaseName: mydb
-      userTableName: welcome_emails
-      mode: append                  # append | replace
+      de_name: WelcomeEmails
+      shared_data_extension: false
+      data_operation: upsert
 ```
 
-Use `tdx connection list` to find available connection names.
+Use `tdx connection list` to find available connection names and `tdx connection schema <type>` to discover `connector_config` fields. See **connector-config** skill for detailed guidance.
 
 ## Segment References
 
@@ -227,6 +227,7 @@ tdx journey view "Journey Name" --include-stats
 
 ## Related Skills
 
+- **connector-config** - Configure connector_config for activations
 - **validate-journey** - Validate journey YAML syntax
 - **segment** - Manage child segments for journey criteria
 - **parent-segment** - Manage parent segment (journey context)

--- a/tdx-skills/journey/templates/basic-journey.yml
+++ b/tdx-skills/journey/templates/basic-journey.yml
@@ -57,13 +57,16 @@ segments:
         value: true
 
 # Embedded activations (optional)
+# Use `tdx connection schema <type>` to discover connector_config fields
 activations:
   welcome-email:
     name: Welcome Email Campaign
-    connection: email-connector  # From tdx connection list
+    connection: salesforce-marketing  # From tdx connection list
     all_columns: true
     schedule:
       type: none
       timezone: UTC
     connector_config:
-      mode: append
+      de_name: WelcomeEmails
+      shared_data_extension: false
+      data_operation: upsert

--- a/tdx-skills/journey/templates/complete-journey.yml
+++ b/tdx-skills/journey/templates/complete-journey.yml
@@ -155,18 +155,20 @@ segments:
         value: true
 
 # Embedded activations (journey-local)
-# Use `tdx connection list` to find available connection names
+# Use `tdx connection list` to find connection names
+# Use `tdx connection schema <type>` to discover connector_config fields
 activations:
   welcome-email:
     name: Send Welcome Email
-    connection: salesforce-marketing  # From tdx connection list
+    connection: salesforce-marketing  # salesforce_marketing_cloud_v2 connection
     all_columns: true
     schedule:
       type: none
       timezone: UTC
     connector_config:
-      template: welcome_template
-      mode: append
+      de_name: WelcomeEmails
+      shared_data_extension: false
+      data_operation: upsert
 
   reminder-email:
     name: Send Reminder Email
@@ -176,8 +178,9 @@ activations:
       type: none
       timezone: UTC
     connector_config:
-      template: reminder_template
-      mode: append
+      de_name: ReminderEmails
+      shared_data_extension: false
+      data_operation: upsert
 
   discount-email:
     name: Discount Offer Email
@@ -187,8 +190,9 @@ activations:
       type: none
       timezone: UTC
     connector_config:
-      template: discount_template
-      mode: append
+      de_name: DiscountOffers
+      shared_data_extension: false
+      data_operation: upsert
 
   trial-email:
     name: Free Trial Email
@@ -198,5 +202,6 @@ activations:
       type: none
       timezone: UTC
     connector_config:
-      template: trial_template
-      mode: append
+      de_name: TrialOffers
+      shared_data_extension: false
+      data_operation: upsert

--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -162,10 +162,12 @@ activations:
 
 ### Activation with Connector Config
 
+Use `tdx connection schema <type>` to discover available fields for `connector_config`. See **connector-config** skill for detailed guidance.
+
 ```yaml
 activations:
-  - name: Salesforce Contact Sync
-    connection: salesforce-prod
+  - name: SFMC Contact Sync
+    connection: salesforce-marketing
     columns:
       - email
       - first_name
@@ -173,9 +175,9 @@ activations:
       type: daily
       timezone: America/Los_Angeles
     connector_config:
-      object: Contact
-      mode: upsert
-      external_id: email
+      de_name: ContactSync
+      shared_data_extension: false
+      data_operation: upsert
 ```
 
 ### Activation with Notifications
@@ -335,6 +337,7 @@ tdx connections
 
 ## Related Skills
 
+- **tdx-skills/connector-config** - Configure connector_config for activations
 - **tdx-skills/validate-segment** - Validate segment YAML syntax against CDP API spec
 - **tdx-skills/parent-segment** - Manage parent segments and master tables
 - **tdx-skills/tdx-basic** - Core tdx CLI operations and global options


### PR DESCRIPTION
## Summary
- Add new `connector-config` skill that teaches how to configure `connector_config` for segment and journey activations
- Use `tdx connection schema <type>` to discover available fields for each connector type
- Update segment and journey skills to reference the new connector-config skill
- Fix connector_config examples to use real SFMC fields (salesforce_marketing_cloud_v2)

## Changes
- **New skill**: `tdx-skills/connector-config/SKILL.md` - comprehensive guide for configuring connector_config
- **Updated**: `tdx-skills/segment/SKILL.md` - adds reference and fixes SFMC example
- **Updated**: `tdx-skills/journey/SKILL.md` - adds reference and fixes SFMC example
- **Updated**: journey templates to use correct SFMC connector_config fields
- **Updated**: `marketplace.json` - registers new skill

## Connector Examples Included
- `salesforce_marketing_cloud_v2` (SFMC) - de_name, shared_data_extension, data_operation
- `sfdc_v2` (Salesforce CRM) - object, mode, unique, upsert
- `s3_v2` (AWS S3) - bucket, path, format, compression
- `bigquery_v2` (BigQuery) - project, dataset, table, mode
- `treasure_data` (TD transfer) - database_name, table_name, mode

## Test plan
- [ ] Install skill locally: `/plugin install tdx-skills@td-skills`
- [ ] Verify `tdx connection schema salesforce_marketing_cloud_v2` shows expected fields
- [ ] Test skill triggers with: "Use the connector-config skill to configure an SFMC activation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)