### PR TITLE
feat: add agent skill for LLM agent development with tdx

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,7 +78,8 @@
         "./tdx-skills/validate-segment",
         "./tdx-skills/journey",
         "./tdx-skills/validate-journey",
-        "./tdx-skills/connector-config"
+        "./tdx-skills/connector-config",
+        "./tdx-skills/agent"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Skills are folders of instructions and resources that Claude loads dynamically t
 - **[tdx-skills/journey](./tdx-skills/journey)** - Create CDP journey definitions in YAML with stages, steps (wait, activation, decision_point, ab_test, merge, jump, end), and simulation workflow
 - **[tdx-skills/validate-journey](./tdx-skills/validate-journey)** - Validate journey YAML configurations for correct step types, parameters, and segment references
 - **[tdx-skills/connector-config](./tdx-skills/connector-config)** - Configure connector_config for segment/journey activations using `tdx connection schema` to discover fields
+- **[tdx-skills/agent](./tdx-skills/agent)** - Build LLM agents using `tdx agent pull/push` with YAML/Markdown config, tools, and knowledge bases
 
 ### Field Agent Skills
 
@@ -107,13 +108,14 @@ Once installed, explicitly reference skills using the `skill` keyword to trigger
 "Use the journey skill to create a customer onboarding journey"
 "Use the validate-journey skill to check my journey YAML for errors"
 "Use the connector-config skill to configure an SFMC activation"
+"Use the agent skill to create an LLM agent with knowledge base tools"
 "Use the deployment skill to set up a production publishing workflow"
 "Use the documentation skill to create comprehensive Field Agent documentation"
 "Use the visualization skill to create a Plotly chart with TD colors"
 ```
 
 Tips for triggering skills:
-- Include the skill name (Trino, Hive, time-filtering, Trino CLI, TD MCP, activations, digdag, dbt, JavaScript SDK, pytd, tdx, tdx-basic, validate-segment, journey, validate-journey, connector-config, deployment, documentation, visualization)
+- Include the skill name (Trino, Hive, time-filtering, Trino CLI, TD MCP, activations, digdag, dbt, JavaScript SDK, pytd, tdx, tdx-basic, validate-segment, journey, validate-journey, connector-config, agent, deployment, documentation, visualization)
 - Use the word "skill" in your request
 - Be specific about what you want to accomplish
 

--- a/tdx-skills/agent/SKILL.md
+++ b/tdx-skills/agent/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: agent
+description: Build LLM agents using `tdx agent pull/push` with YAML/Markdown config. Covers agent.yml structure, tools (knowledge_base, agent, web_search, image_gen), @ref syntax, and knowledge bases. Use for TD AI agent development workflow.
+---
+
+# tdx Agent - LLM Agent Development
+
+Build and manage LLM agents using `tdx agent pull/push` with YAML/Markdown configuration files.
+
+## Key Commands
+
+```bash
+# Pull project to local files (creates agents/{project}/)
+tdx agent pull "My LLM Project"
+tdx agent pull "My LLM Project" "Agent Name"  # Single agent
+
+# Push local changes to TD
+tdx agent push                                # Push all from current dir
+tdx agent push ./agents/my-project/my-agent/  # Push single agent
+tdx agent push --dry-run                      # Preview changes
+
+# Clone project (for staging/production deployment)
+tdx agent clone "Source Project" --name "New Project"
+tdx agent clone ./agents/my-project/ --name "Prod" --profile production
+
+# List/show agents
+tdx agents                                    # List in current project
+tdx agent show "Agent Name"
+```
+
+## Folder Structure
+
+```
+agents/{project-name}/
+├── tdx.json                    # {"llm_project": "Project Name"}
+├── {agent-name}/
+│   ├── agent.yml               # Agent configuration
+│   ├── prompt.md               # System prompt (markdown)
+│   └── starter_message.md      # Optional multiline starter
+├── knowledge_bases/
+│   ├── {name}.yml              # Table-based KB (TD database)
+│   └── {name}.md               # Text-based KB (plain text)
+└── prompts/
+    └── {name}.yml
+```
+
+## agent.yml
+
+```yaml
+name: Support Agent
+description: Customer support assistant
+
+model: claude-4.5-sonnet          # claude-4.5-sonnet, claude-4.5-haiku
+temperature: 0.7
+max_tool_iterations: 5
+reasoning_effort: medium          # none, minimal, low, medium, high
+
+starter_message: Hello! How can I help?
+
+tools:
+  - type: knowledge_base
+    target: '@ref(type: "knowledge_base", name: "support-kb")'
+    target_function: SEARCH       # SEARCH, LOOKUP, READ_TEXT, LIST_COLUMNS
+    function_name: search_kb
+    function_description: Search support knowledge base
+
+  - type: agent
+    target: '@ref(type: "agent", name: "sql-expert")'
+    target_function: CHAT
+    function_name: ask_sql_expert
+    function_description: Ask SQL expert for help
+    output_mode: RETURN           # RETURN (default) or SHOW
+
+  - type: web_search
+    target: '@ref(type: "web_search_tool", name: "web-search")'
+    target_function: SEARCH
+    function_name: search_web
+    function_description: Search the web
+
+  - type: image_gen
+    target: '@ref(type: "image_generator", name: "image-gen")'
+    target_function: TEXT_TO_IMAGE
+    function_name: generate_image
+    function_description: Generate an image
+
+variables:
+  - name: customer_context
+    target_knowledge_base: '@ref(type: "knowledge_base", name: "customers")'
+    target_function: LOOKUP
+    function_arguments: '{"query": "{{customer_id}}"}'
+
+outputs:
+  - name: resolution_status
+    function_name: get_status
+    function_description: Get resolution status
+    json_schema: '{"type": "object", "properties": {"status": {"type": "string"}}}'
+```
+
+## Reference Syntax
+
+All cross-resource references use `@ref(...)`:
+
+```yaml
+'@ref(type: "knowledge_base", name: "my-kb")'
+'@ref(type: "agent", name: "my-agent")'
+'@ref(type: "prompt", name: "my-prompt")'
+'@ref(type: "web_search_tool", name: "web-search")'
+'@ref(type: "image_generator", name: "image-gen")'
+```
+
+## Knowledge Bases
+
+### Table-based (.yml) - Queries TD database
+
+```yaml
+name: Product Catalog
+database: ecommerce_db
+tables:
+  - name: products
+    td_query: select * from products
+    enable_data: true
+    enable_data_index: true
+```
+
+### Text-based (.md) - Plain text content
+
+```markdown
+---
+name: Company FAQ
+---
+
+# Frequently Asked Questions
+
+## Return Policy
+We offer 30-day returns...
+```
+
+## Prompts
+
+```yaml
+name: greeting-prompt
+agent: '@ref(type: "agent", name: "support-agent")'
+system_prompt: |
+  Generate a personalized greeting...
+template: |
+  Customer: {{customer_name}}
+```
+
+## Typical Workflow
+
+```bash
+# 1. Pull project
+tdx agent pull "My Project"
+
+# 2. Edit files locally (agent.yml, prompt.md, knowledge bases)
+
+# 3. Preview changes
+tdx agent push --dry-run
+
+# 4. Push to TD
+tdx agent push
+```
+
+## Related Skills
+
+- **tdx-basic** - Core CLI operations and context management


### PR DESCRIPTION
## Summary
- Add new `agent` skill for building LLM agents using `tdx agent pull/push` workflow
- Covers YAML/Markdown configuration, tools, knowledge bases, and @ref syntax

## Changes
- **New skill**: `tdx-skills/agent/SKILL.md` (~165 lines, concise)
- **Updated**: `marketplace.json` - registers new skill
- **Updated**: `README.md` - adds agent skill entry and example invocation

## Skill Content
- Key commands: `tdx agent pull`, `push`, `clone`
- Folder structure: `agents/{project}/` layout
- `agent.yml` configuration: model, temperature, reasoning_effort, tools, variables, outputs
- Tool types: knowledge_base (SEARCH, LOOKUP, READ_TEXT), agent (CHAT), web_search, image_gen
- Reference syntax: `@ref(type: "...", name: "...")`
- Knowledge bases: table-based (.yml) and text-based (.md)

## Test plan
- [ ] Install skill locally: `/plugin install tdx-skills@td-skills`
- [ ] Test skill trigger: "Use the agent skill to create an LLM agent"
- [ ] Verify @ref syntax examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)