### PR TITLE
fix: correct jump step syntax in journey skills

### DIFF
--- a/tdx-skills/journey/SKILL.md
+++ b/tdx-skills/journey/SKILL.md
@@ -52,7 +52,7 @@ journeys:
 | `decision_point` | `branches[]` with segment, next |
 | `ab_test` | `variants[]` with percentage, next (must sum to 100) |
 | `merge` | (none) |
-| `jump` | `target.journey`, `target.stage` |
+| `jump` | `target` with `journey`, `stage` |
 | `end` | (none, no next) |
 
 **Important**: `next:` is a direct field on step, not inside `with:`
@@ -81,6 +81,13 @@ steps:
         - name: Others
           excluded: true         # Default branch
           next: default-path
+
+  - type: jump
+    name: Go to Retention
+    with:
+      target:
+        journey: Retention Journey   # Target journey name
+        stage: Welcome Stage         # Target stage name
 
   - type: end
     name: Complete

--- a/tdx-skills/validate-journey/SKILL.md
+++ b/tdx-skills/validate-journey/SKILL.md
@@ -34,7 +34,7 @@ journeys:
 | `decision_point` | `branches[]` | each needs segment, next |
 | `ab_test` | `variants[]` | percentages must sum to 100 |
 | `merge` | (none) | |
-| `jump` | `target.journey`, `target.stage` | |
+| `jump` | `target` with `journey`, `stage` | target is an object |
 | `end` | (none) | no `next` or `with` |
 
 **Important**: `next:` is a direct field on step, not inside `with:`
@@ -88,6 +88,7 @@ journeys:
 journeys:
   - latest: false
   - latest: true
+
 ```
 
 ## Related Skills


### PR DESCRIPTION
## Summary

- Fix jump step documentation to show correct nested `target` object structure
- Add jump step example in journey skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)