### PR TITLE
docs(tdx-skills): add tdx sg validate command

### DIFF
--- a/tdx-skills/validate-journey/SKILL.md
+++ b/tdx-skills/validate-journey/SKILL.md
@@ -5,7 +5,11 @@ description: Validates CDP journey YAML configurations against tdx schema requir
 
 # Journey YAML Validation
 
-Validate with `tdx journey push --dry-run` before pushing.
+```bash
+tdx sg validate                           # Validate all segment & journey YAML files
+tdx sg validate path/to/journey.yml       # Validate specific file
+tdx journey push --dry-run                # Preview changes before push
+```
 
 ## Required Structure
 
@@ -59,53 +63,6 @@ journeys:
 
 - Embedded: `segment: my-segment` (defined in `segments:` section)
 - External: `segment: ref:Existing Segment` (use `ref:` prefix)
-
-## Common Errors
-
-```yaml
-# WRONG: missing type: journey
-name: My Journey
-journeys: [...]
-# CORRECT
-type: journey
-name: My Journey
-
-# WRONG: plural wait unit
-unit: days
-# CORRECT
-unit: day                    # day | week only
-
-# WRONG: invalid step type
-type: delay
-# CORRECT
-type: wait
-
-# WRONG: end step with next
-- type: end
-  next: another-step
-# CORRECT
-- type: end
-  name: Complete
-
-# WRONG: percentages don't sum to 100
-variants:
-  - percentage: 40
-  - percentage: 40
-# CORRECT
-variants:
-  - percentage: 50
-  - percentage: 50
-
-# WRONG: multiple latest: true
-journeys:
-  - latest: true
-  - latest: true
-# CORRECT: exactly one
-journeys:
-  - latest: false
-  - latest: true
-
-```
 
 ## Related Skills
 

--- a/tdx-skills/validate-segment/SKILL.md
+++ b/tdx-skills/validate-segment/SKILL.md
@@ -5,7 +5,11 @@ description: Validates CDP segment YAML configurations against the TD CDP API sp
 
 # Segment YAML Validation
 
-Validate with `tdx sg push --dry-run` before pushing.
+```bash
+tdx sg validate                           # Validate all YAML files locally
+tdx sg validate path/to/segment.yml       # Validate specific file
+tdx sg push --dry-run                     # Preview changes before push
+```
 
 ## Required Structure
 


### PR DESCRIPTION
## Summary

- Add `tdx sg validate` command to **validate-segment** and **validate-journey** skills
- Remove WRONG/CORRECT examples from validate-journey to avoid confusing AI

## Changes

```bash
tdx sg validate                           # Validate all YAML files locally
tdx sg validate path/to/segment.yml       # Validate specific file
```

This new command validates segment and journey YAML files locally before pushing, catching errors early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)