### PR TITLE
docs: update skills for tdx v0.10-v0.12 changes

### DIFF
--- a/tdx-skills/validate-journey/SKILL.md
+++ b/tdx-skills/validate-journey/SKILL.md
@@ -6,8 +6,8 @@ description: Validates CDP journey YAML configurations against tdx schema requir
 # Journey YAML Validation
 
 ```bash
-tdx sg validate                           # Validate all segment & journey YAML files
-tdx sg validate path/to/journey.yml       # Validate specific file
+tdx journey validate                      # Validate all journey YAML files locally
+tdx journey validate path/to/journey.yml  # Validate specific file
 tdx journey push --dry-run                # Preview changes before push
 ```
 

--- a/workflow-skills/digdag/SKILL.md
+++ b/workflow-skills/digdag/SKILL.md
@@ -163,24 +163,45 @@ trigger:
 ## tdx wf Commands
 
 ```bash
-tdx wf push my_workflow              # Push to TD
-tdx wf run my_project.my_workflow    # Run immediately
-tdx wf sessions my_workflow          # List runs
-tdx wf attempt <id> tasks            # Show tasks
+# Project sync (recommended workflow)
+tdx wf pull my_project               # Pull project to local folder
+tdx wf push                          # Push local changes with diff preview
+tdx wf clone --name my_project_prod  # Clone to new project name
+
+# Context & discovery
+tdx wf use my_project                # Set default project for session
+tdx wf projects                      # List all projects
+tdx wf workflows                     # List workflows in project
+
+# Running & monitoring
+tdx wf run                           # Interactive workflow selector
+tdx wf run my_project.my_workflow    # Run specific workflow
+tdx wf sessions                      # List runs
+tdx wf attempt <id> tasks            # Show task status
 tdx wf attempt <id> logs +task_name  # View logs
 tdx wf attempt <id> retry            # Retry failed
 tdx wf attempt <id> kill             # Stop running
+
+# Secrets
+tdx wf secrets list                  # List secret keys
+tdx wf secrets set KEY=value         # Set a secret
+tdx wf secrets delete KEY            # Delete a secret
+
+# Legacy (digdag-style)
+tdx wf upload my_workflow            # Push without sync tracking
 ```
 
 ## Project Structure
 
 ```
-my_workflow/
-├── my_workflow.dig
-├── queries/
-│   └── analysis.sql
-└── scripts/
-    └── process.py
+workflows/
+└── my_project/              # Created by tdx wf pull
+    ├── tdx.json             # Sync tracking (auto-generated)
+    ├── main.dig             # Workflow definition
+    ├── queries/
+    │   └── analysis.sql
+    └── scripts/
+        └── process.py
 ```
 
 ## Schedule Options

--- a/workflow-skills/workflow-management/SKILL.md
+++ b/workflow-skills/workflow-management/SKILL.md
@@ -5,11 +5,19 @@ description: TD workflow debugging and operations. Covers tdx wf commands for mo
 
 # TD Workflow Management
 
+## Setup & Context
+
+```bash
+tdx wf use my_project                # Set default project for session
+tdx wf pull my_project               # Pull project locally for editing
+tdx wf push                          # Push changes with diff preview
+```
+
 ## Monitoring Commands
 
 ```bash
-tdx wf sessions my_project           # List runs
-tdx wf sessions my_project --status error
+tdx wf sessions                      # List runs (uses session context)
+tdx wf sessions --status error       # Filter by status
 tdx wf attempt <id> tasks            # Show task status
 tdx wf attempt <id> logs +task_name  # View logs
 ```
@@ -101,6 +109,20 @@ tdx wf attempt <id> kill                           # Stop running
       call>: main_workflow.dig
       params:
         session_date: ${dates}
+```
+
+## Secrets Management
+
+```bash
+tdx wf secrets list                  # List secret keys (values hidden)
+tdx wf secrets set API_KEY=xxx       # Set a secret
+tdx wf secrets delete API_KEY        # Delete a secret
+```
+
+**Usage in .dig files:**
+```yaml
++task:
+  sh>: curl -H "Authorization: ${secret:API_KEY}" https://api.example.com
 ```
 
 ## Common Issues


### PR DESCRIPTION
## Summary

Update skills to reflect tdx CLI changes from v0.10.0 to v0.12.0.

### Changes

**validate-journey**
- Fixed command from `tdx sg validate` to `tdx journey validate`

**digdag (workflow-skills)**
- Added new sync-style workflow commands: `wf pull`, `wf push`, `wf clone`
- Added session context: `wf use <project>`
- Added secrets management: `wf secrets list/set/delete`
- Added interactive `wf run` selector
- Updated project structure to show `tdx.json` tracking file
- Noted `wf upload` as legacy (renamed from old `wf push`)

**workflow-management**
- Added Setup & Context section with pull/push workflow
- Added Secrets Management section with usage example
- Updated monitoring commands to use session context

### Related tdx releases
- v0.10.0: Added `tdx sg validate` and `tdx journey validate` commands
- v0.11.0: Added workflow secrets, `wf use` default project
- v0.12.0: Added sync-style `wf pull/push`, `wf clone`, interactive `wf run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)