### PR TITLE
docs(sql-skills): clarify optional timezone in td_interval and add td_time_string

### DIFF
--- a/sql-skills/time-filtering/SKILL.md
+++ b/sql-skills/time-filtering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: time-filtering
-description: Advanced td_interval patterns including offset dates (-1d/2025-10-01, -7d/-1d, 0M/now), td_interval_range for debugging, and partition pruning optimization.
+description: Advanced td_interval patterns including offset dates (-1d/2025-10-01, -7d/-1d, 0M/now), td_interval_range for debugging, td_time_string for display formatting, and partition pruning optimization.
 ---
 
 # TD Time Filtering - Advanced Patterns
@@ -40,6 +40,17 @@ select td_interval_range('-7d', 'UTC')              -- Returns [start, end] time
 select td_interval_range('-1d/2025-10-01', 'JST')   -- Check offset date range
 select td_interval_range('0M/now', 'JST')           -- Verify month-to-date range
 ```
+
+## td_time_string for Display
+
+```sql
+select td_time_string(time, 'd!')              -- 2025-01-15 (UTC)
+select td_time_string(time, 'd!', 'JST')       -- 2025-01-15 (JST)
+select td_time_string(time, 'M!', 'JST')       -- 2025-01
+select td_time_string(time, 'h!', 'JST')       -- 2025-01-15 10
+```
+
+Codes: `y!` `q!` `M!` `w!` `d!` `h!` `m!` `s!`. Timezone optional (defaults to UTC). Use for display/grouping only, not filtering.
 
 ## td_scheduled_time Reference
 

--- a/sql-skills/trino/SKILL.md
+++ b/sql-skills/trino/SKILL.md
@@ -10,12 +10,15 @@ description: TD Trino SQL with TD-specific functions (td_interval, td_time_range
 ### td_interval (Recommended for relative time)
 
 ```sql
-where td_interval(time, '-1d', 'JST')      -- Yesterday
+where td_interval(time, '-1d', 'JST')      -- Yesterday (JST)
+where td_interval(time, '-1d')             -- Yesterday (UTC)
 where td_interval(time, '-1w', 'JST')      -- Previous week
 where td_interval(time, '-1M', 'JST')      -- Previous month
 where td_interval(time, '-1d/-1d', 'JST')  -- 2 days ago
 where td_interval(time, '-1M/-2M', 'JST')  -- 3 months ago
 ```
+
+Timezone is optional (defaults to UTC).
 
 **Note**: Cannot use `td_scheduled_time()` as first arg. Include `td_scheduled_time()` elsewhere in query to establish reference date.
 


### PR DESCRIPTION
## Summary
- Add note that timezone parameter is optional (defaults to UTC) for `td_interval` in trino skill
- Add `td_time_string` section to time-filtering skill with examples
- Update time-filtering skill description to include `td_time_string`

## Test plan
- [ ] Verify skill triggers correctly with `/plugin install sql-skills@td-skills`
- [ ] Test that examples render correctly in skill documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)