### PR TITLE
fix(tdx-skills): replace deprecated tdx context with tdx status

### DIFF
--- a/tdx-skills/tdx-basic/SKILL.md
+++ b/tdx-skills/tdx-basic/SKILL.md
@@ -29,9 +29,18 @@ Context priority: CLI flags > session > project `tdx.json` > profile > global co
 # Session context
 tdx use database mydb
 tdx use site jp01
-tdx use profile production
-tdx context              # View current
-tdx context --clear      # Clear session
+tdx profile use production   # Switch profile
+tdx status                   # View current context and auth
+tdx use --clear              # Clear session
+```
+
+### Profile Management
+
+```bash
+tdx profile list             # List all profiles
+tdx profile create staging   # Create new profile (interactive)
+tdx profile set database=dev # Set profile config
+tdx --profile staging query "..." # One-off with different profile
 ```
 
 ### Profiles (~/.config/tdx/tdx.json)


### PR DESCRIPTION
## Summary
- Replace deprecated `tdx context` command with `tdx status`
- Replace `tdx context --clear` with `tdx use --clear`
- Update `tdx use profile <name>` to `tdx profile use <name>`
- Add new "Profile Management" section with common profile commands

## Reference
https://tdx.treasuredata.com/guide/profile-management.html

## Test plan
- [ ] Verify commands match the official tdx documentation
- [ ] Ensure no remaining references to deprecated `tdx context`

🤖 Generated with [Claude Code](https://claude.com/claude-code)