### PR TITLE
fix(tdx-skills): clarify agent skill gotchas

### DIFF
--- a/tdx-skills/agent/SKILL.md
+++ b/tdx-skills/agent/SKILL.md
@@ -53,7 +53,7 @@ agents/{project-name}/
 ```yaml
 name: Support Agent
 
-model: claude-4-sonnet            # claude-4-sonnet, claude-4-haiku
+model: claude-4.5-sonnet            # Run `tdx llm models` for current list
 temperature: 1                    # REQUIRED: must be 1 when reasoning_effort is set
 max_tool_iterations: 5
 reasoning_effort: medium          # none, minimal, low, medium, high (requires temperature: 1)
@@ -62,13 +62,13 @@ starter_message: Hello! How can I help?
 
 tools:
   - type: knowledge_base
-    target: '@ref(type: "knowledge_base", name: "support-kb")'
-    target_function: SEARCH       # SEARCH, LOOKUP, READ_TEXT, LIST_COLUMNS
+    target: '@ref(type: "knowledge_base", name: "Support KB")'
+    target_function: SEARCH       # SEARCH, LOOKUP, or LIST_COLUMNS (table-based KB only)
     function_name: search_kb
     function_description: Search support knowledge base
 
   - type: agent
-    target: '@ref(type: "agent", name: "sql-expert")'
+    target: '@ref(type: "agent", name: "SQL Expert")'
     target_function: CHAT
     function_name: ask_sql_expert
     function_description: Ask SQL expert for help
@@ -101,11 +101,15 @@ outputs:
 
 ## Reference Syntax
 
-All cross-resource references use `@ref(...)`:
+All cross-resource references use `@ref(...)`. The `name` must exactly match the `name:` field in the target resource's YAML or frontmatter (NOT the folder name).
 
 ```yaml
-'@ref(type: "knowledge_base", name: "my-kb")'
-'@ref(type: "agent", name: "my-agent")'
+# If KB file has "name: Product FAQ", use that exact name:
+'@ref(type: "knowledge_base", name: "Product FAQ")'
+
+# If agent.yml has "name: SQL Expert", use that exact name:
+'@ref(type: "agent", name: "SQL Expert")'
+
 '@ref(type: "prompt", name: "my-prompt")'
 '@ref(type: "web_search_tool", name: "web-search")'
 '@ref(type: "image_generator", name: "image-gen")'
@@ -114,6 +118,8 @@ All cross-resource references use `@ref(...)`:
 ## Knowledge Bases
 
 ### Table-based (.yml) - Queries TD database
+
+Available `target_function`: `SEARCH`, `LOOKUP`, `LIST_COLUMNS`
 
 ```yaml
 name: Product Catalog
@@ -126,6 +132,8 @@ tables:
 ```
 
 ### Text-based (.md) - Plain text content
+
+Available `target_function`: `READ_TEXT`
 
 ```markdown
 ---
@@ -152,20 +160,25 @@ template: |
 ## Typical Workflow
 
 ```bash
-# 1. Pull project
+# 1. Create project (if new)
+tdx llm project create "My Project"
+
+# 2. Pull project (if existing)
 tdx agent pull "My Project"
 
-# 2. Edit files locally (agent.yml, prompt.md, knowledge bases)
+# 3. Edit files locally (agent.yml, prompt.md, knowledge bases)
 
-# 3. Preview changes
+# 4. Preview changes
 tdx agent push --dry-run
 
-# 4. Push to TD
+# 5. Push to TD
 tdx agent push
 
-# 5. Test with tdx chat
+# 6. Test with tdx chat
 tdx chat --agent "My Project/My Agent" "Hello, test message"
 ```
+
+**Push scope:** `tdx agent push ./project/` pushes all agents and knowledge bases. `tdx agent push ./project/agent-name/` pushes only that agent (knowledge bases are NOT included).
 
 ## Testing Agents
 
@@ -184,16 +197,18 @@ tdx chat --agent "project-name/Agent Name" "Follow-up question"
 
 ## Extended Thinking (Reasoning)
 
+Reasoning is only supported by certain models. Check model capabilities with `tdx llm models`. If you get errors about reasoning not being supported, omit `reasoning_effort` or set it to `none`.
+
 To enable extended thinking/reasoning, you must set `temperature: 1`:
 
 ```yaml
 # With reasoning enabled
-model: claude-4-sonnet
+model: claude-4.5-sonnet
 temperature: 1                    # REQUIRED when using reasoning_effort
 reasoning_effort: medium          # none, minimal, low, medium, high
 
 # Without reasoning (flexible temperature)
-model: claude-4-sonnet
+model: claude-4.5-sonnet
 temperature: 0.7                  # Can be any value 0-1
 # reasoning_effort: omit or set to none
 ```


### PR DESCRIPTION
## Summary
- Clarify that `@ref` `name` must match the resource's `name:` field, not the folder name
- Document which `target_function` values work with each KB type (table vs text)
- Replace hardcoded model list with `tdx llm models` recommendation
- Add `tdx llm project create` to the typical workflow
- Document push scope (project root vs agent subfolder)
- Note that reasoning is only supported by certain models

## Context
These issues were discovered while building and pushing an example agent project end-to-end using the skill. Each fix addresses a real error encountered during that session.

## Test plan
- [ ] Build a new agent project from scratch following the updated skill
- [ ] Verify `@ref` naming guidance prevents 422 errors
- [ ] Verify text KB uses `READ_TEXT` and table KB uses `SEARCH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)