### PR TITLE
fix: correct behavior aggregation syntax - require attribute: ""

### DIFF
--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -85,7 +85,9 @@ See **connector-config** skill for `connector_config` details.
 
 ## Behavior Conditions (Aggregations)
 
-Query behavior data from parent segment with aggregations:
+Query behavior data from parent segment with aggregations.
+
+**CRITICAL: Always use `attribute: ""` (empty string) for behavior aggregations!**
 
 ```yaml
 rule:
@@ -93,37 +95,41 @@ rule:
   conditions:
     # Count behavior occurrences
     - type: Value
-      attribute: add_to_cart_event
+      attribute: ""              # Empty string for behavior aggregations!
       operator:
         type: GreaterEqual
         value: 1
       aggregation:
         type: Count              # Count | Sum | Avg | Min | Max
-      source: cart_abandonment   # Behavior name from parent segment
+      source: behavior_email_open   # Full behavior table name (use tdx ps desc to find)
 
-    # Sum behavior values
+    # Sum behavior column values
     - type: Value
-      attribute: order_total
+      attribute: ""              # Empty string for behavior aggregations!
       operator:
         type: Greater
         value: 500
       aggregation:
         type: Sum
-      source: purchase_history
+      source: behavior_purchase
 
-    # Time-based behavior filtering
+    # Average, Min, Max also supported
     - type: Value
-      attribute: timestamp
+      attribute: ""
       operator:
         type: GreaterEqual
-        value: 30
-        unit: days               # Filter to last 30 days
+        value: 100
       aggregation:
-        type: Max
-      source: purchase_history
+        type: Average
+      source: behavior_purchase
 ```
 
-**Aggregation types**: `Count`, `Sum`, `Avg`, `Min`, `Max`
+**Finding behavior table names**: Use `tdx ps desc "ParentSegmentName"` to list available behavior tables.
+Behavior tables typically start with `behavior_` prefix (e.g., `behavior_email_open`, `behavior_purchase`).
+
+**Aggregation types**: `Count`, `Sum`, `Average`, `Min`, `Max`
+
+**Common mistake**: DO NOT use a field name in `attribute` - it must be `""` (empty string) for behavior aggregations!
 
 ## Segment References (Include/Exclude)
 

--- a/tdx-skills/validate-segment/SKILL.md
+++ b/tdx-skills/validate-segment/SKILL.md
@@ -49,19 +49,27 @@ year | quarter | month | week | day | hour | minute | second
 
 ## Behavior Aggregation Structure
 
+**CRITICAL**: When `source` is present (behavior aggregation), `attribute` MUST be `""` (empty string).
+
 ```yaml
 # Behavior condition with aggregation
 - type: Value
-  attribute: field_name          # Or "" for pure count
+  attribute: ""                  # MUST be empty string for behavior aggregations!
   operator:
     type: GreaterEqual
     value: 1
   aggregation:
-    type: Count                  # Count | Sum | Avg | Min | Max
-  source: behavior_name          # Behavior from parent segment
+    type: Count                  # Count | Sum | Average | Min | Max
+  source: behavior_email_open    # Full behavior table name (e.g., behavior_email_open, behavior_purchase)
 ```
 
-**Required fields**: `aggregation.type` and `source` must both be present
+**Required fields**:
+- `aggregation.type` and `source` must both be present
+- `attribute` must be `""` (empty string) when `source` is present
+
+**Common errors**:
+- ❌ `attribute: email_open` + `source: behavior_email_open` → Treated as attribute filter, not behavior aggregation
+- ✅ `attribute: ""` + `source: behavior_email_open` → Correct behavior aggregation
 
 ## Related Skills
 


### PR DESCRIPTION
## Problem

The `segment` and `validate-segment` skills were teaching Claude **incorrect syntax** for behavior aggregation conditions, causing it to generate broken YAML that either failed validation or produced incorrect SQL.

### Incorrect Examples in Skills

**`segment/SKILL.md` (line 96):**
```yaml
- type: Value
  attribute: add_to_cart_event  # ❌ WRONG!
  aggregation:
    type: Count
  source: cart_abandonment
```

**`validate-segment/SKILL.md` (line 55):**
```yaml
attribute: field_name  # Or "" for pure count  # ❌ Confusing!
```

### Issues Caused

When Claude generated segments with behavior conditions using these examples:
1. **API Error:** `{ "name": "", "aggregation": {...} }` → `"left_value.name": ["can't be blank"]`
2. **Wrong SQL:** `{ "name": "email_open", "aggregation": {...} }` → Treated as attribute filter instead of behavior subquery

## Solution

Updated both skills to **require `attribute: ""` (empty string) for all behavior aggregations**.

### Changes to `segment/SKILL.md`
- ✅ All examples now show `attribute: ""`
- ✅ Added CRITICAL warning about empty string requirement
- ✅ Added guidance to find behavior table names with `tdx ps desc`
- ✅ Added common mistake warning

### Changes to `validate-segment/SKILL.md`
- ✅ Clarified that `attribute` MUST be `""` when `source` is present
- ✅ Added clear error examples showing wrong vs correct

## Correct Syntax

```yaml
- type: Value
  attribute: ""                    # ✅ Empty string for behavior aggregations!
  operator:
    type: GreaterEqual
    value: 1
  aggregation:
    type: Count
  source: behavior_email_open      # ✅ Full behavior table name
```

## Testing

Verified with Claude in Treasure Studio - after updating skills, Claude now generates correct YAML with `attribute: ""` for behavior conditions.

## Related

- Related to treasure-data/tdx#1233
- Companion PR for code fix: https://github.com/treasure-data/tdx/pull/1238