### PR TITLE
Fix: Enforce proactive validation in rt-setup-personalization workflow

### DIFF
--- a/realtime-skills/rt-personalization-validation/SKILL.md
+++ b/realtime-skills/rt-personalization-validation/SKILL.md
@@ -1,11 +1,27 @@
 ---
 name: rt-personalization-validation
-description: Validates RT Personalization Entity payloads before creation to prevent common API errors. Use when encountering "Attribute payload can't be blank" or other personalization creation errors, or when reviewing personalization entity JSON before API calls.
+description: Validates RT Personalization Entity payloads before creation to prevent common API errors. MUST be invoked proactively during rt-setup-personalization workflow at Step 9c before making the entity creation API call. Also use when encountering "Attribute payload can't be blank" errors or when reviewing personalization entity JSON.
 ---
 
 # RT Personalization Entity Validation
 
 Validates personalization entity payloads and provides error-free templates.
+
+## When to Use This Skill
+
+### Proactive Validation (REQUIRED)
+**During `rt-setup-personalization` workflow at Step 9c:**
+- MUST be invoked BEFORE making the personalization entity creation API call
+- Validates the complete payload JSON with actual values (not placeholders)
+- Prevents common API errors by catching issues before submission
+- This is a mandatory workflow step, not optional
+
+### Reactive Validation (Debugging)
+**After encountering API errors:**
+- When seeing "Attribute payload can't be blank" errors
+- When personalization creation fails with validation errors
+- When reviewing existing personalization configurations
+- When troubleshooting payload structure issues
 
 ## Critical Validation Rules
 

--- a/realtime-skills/rt-setup-personalization/SKILL.md
+++ b/realtime-skills/rt-setup-personalization/SKILL.md
@@ -28,6 +28,10 @@ Step 6: Define RT Attributes ✓
 Step 7: Configure RT Infrastructure ✓ (SHARED with rt-setup-triggers)
 Step 8: Create Personalization Service ✓
 Step 9: Create Personalization Entity ✓
+  9a. Get Parent Segment Folder
+  9b. Get Key Event and Attribute IDs
+  9c. Validate Payload (REQUIRED - use rt-personalization-validation skill)
+  9d. Create Entity via API
 Step 10: Verify & Test ✓
 ```
 
@@ -211,7 +215,15 @@ Error: "sections[0].payload.node_id.definition.attribute_payload": ["Attribute p
 "stringBuilder": null
 ```
 
-**For complete validation rules and error-free templates, use the `rt-personalization-validation` skill.**
+**REQUIRED VALIDATION STEP:**
+
+At Step 9c, you MUST invoke the `rt-personalization-validation` skill to validate the payload before making the API call. This is a mandatory step in the workflow, not optional. The validation skill will:
+- Check for empty arrays that should be null
+- Verify payload structure completeness
+- Validate field names and uniqueness
+- Prevent all common API errors
+
+**Do not skip Step 9c validation. Proceeding directly to the API call without validation will likely result in errors.**
 
 ---
 

--- a/realtime-skills/rt-setup-personalization/steps/08-09-personalization.md
+++ b/realtime-skills/rt-setup-personalization/steps/08-09-personalization.md
@@ -66,11 +66,37 @@ tdx api "/audiences/<ps_id>/realtime_attributes?page[size]=100" --type cdp | \
   jq '.data[] | {id, name, type}'
 ```
 
-### 9c. Create Personalization Entity
+### 9c. Validate Personalization Payload (REQUIRED)
 
-**Critical Validation Rules:**
-1. ✅ Use `null` not `[]` for unused arrays (stringBuilder, segmentPayload)
-2. ✅ At least one of attributePayload/stringBuilder must have content
+**⚠️ CRITICAL: Always validate the payload BEFORE making the API call.**
+
+**Instructions for Claude Code:**
+
+Before creating the personalization entity, you MUST:
+
+1. **Generate the complete personalization payload JSON** with actual values (not placeholders)
+2. **Use the `rt-personalization-validation` skill** to validate the payload structure
+3. **Fix any validation errors** identified by the validation skill
+4. **Verify these critical rules:**
+   - ✅ Empty arrays `[]` must be changed to `null` (most common error)
+   - ✅ At least one of `attributePayload` or `stringBuilder` has content (not null/empty)
+   - ✅ All `outputName` values are unique across the section
+   - ✅ List attributes include correct `subAttributeIdentifier`
+   - ✅ No template brackets `{{` or `}}` in stringBuilder values
+
+**Only proceed to 9d after validation passes.**
+
+**Why this matters:** The API has strict validation rules with misleading error messages. Proactive validation prevents the common "Attribute payload can't be blank" error which wastes time debugging.
+
+---
+
+### 9d. Create Personalization Entity
+
+**After validation passes in 9c**, proceed with entity creation:
+
+**Entity Creation Rules:**
+1. ✅ Use `null` not `[]` for unused arrays (validated in 9c)
+2. ✅ At least one of attributePayload/stringBuilder has content (validated in 9c)
 3. ✅ Generate unique payload node ID using UUID
 
 ```bash


### PR DESCRIPTION
## Problem

The `rt-personalization-validation` skill was only mentioned in passive documentation comments during the `rt-setup-personalization` workflow. This allowed Claude Code to skip validation and proceed directly to the API call, frequently resulting in "Attribute payload can't be blank" errors caused by empty arrays `[]` instead of `null`.

## Solution

Added **mandatory Step 9c** to explicitly invoke the `rt-personalization-validation` skill before making the personalization entity creation API call.

## Changes

### 1. rt-setup-personalization/steps/08-09-personalization.md
- **Added Step 9c: "Validate Personalization Payload (REQUIRED)"**
- Explicit instructions for Claude Code to:
  - Generate complete payload JSON
  - Invoke rt-personalization-validation skill
  - Fix validation errors before proceeding
- Renumbered entity creation to Step 9d

### 2. rt-personalization-validation/SKILL.md
- Updated description to mandate proactive invocation at Step 9c
- Added "When to Use This Skill" section:
  - **Proactive Validation (REQUIRED)**: During setup workflow
  - **Reactive Validation (Debugging)**: After API errors

### 3. rt-setup-personalization/SKILL.md
- Updated workflow overview showing Step 9 substeps including validation checkpoint
- Enhanced validation section emphasizing mandatory requirement
- Warning: "Do not skip Step 9c validation"

## Impact

- **Prevents** common "Attribute payload can't be blank" errors
- **Validates** payload structure before API submission (proactive vs reactive)
- **Catches** empty arrays and structural issues during workflow execution
- **Improves** success rate of personalization entity creation

## Testing

After these changes, Claude Code will:
1. Stop at Step 9c during rt-setup-personalization workflow
2. Automatically invoke rt-personalization-validation skill
3. Validate the complete payload structure
4. Fix any issues before making the API call in Step 9d

🤖 Generated with [Claude Code](https://claude.com/claude-code)