### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for td-skills repository
+* @treasure-data/devai @treasure-data/developers @treasure-data/product @treasure-data/support-engineer


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with default owners for all files: `@treasure-data/devai`, `@treasure-data/developers`, `@treasure-data/product`, `@treasure-data/support-engineer`

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)