### PR TITLE
Add Web Search tool example to agent skill

### DIFF
--- a/tdx-skills/agent/SKILL.md
+++ b/tdx-skills/agent/SKILL.md
@@ -99,6 +99,20 @@ outputs:
     json_schema: '{"type": "object", "properties": {"status": {"type": "string"}}}'
 ```
 
+## Tools
+
+### Web Search
+
+```yaml
+- type: web_search
+  target: '@ref(type: "web_search_tool", name: "web-search")'
+  target_function: SEARCH
+  function_name: search_web
+  function_description: Search the web
+```
+
+For detailed setup including Web Search Tool instance creation, see the [Web Search Tool Setup Guide](https://docs.treasuredata.com/treasure-code/book/14-agents-web-search).
+
 ## Reference Syntax
 
 All cross-resource references use `@ref(...)`. The `name` must exactly match the `name:` field in the target resource's YAML or frontmatter (NOT the folder name).


### PR DESCRIPTION
## Summary

Add Web Search tool example to the agent skill documentation.

- Add Web Search YAML configuration example to Tools section
- Link to detailed setup guide in official docs

## Related PR

- td-documents: treasure-data/td-documents#336

## Notes

This PR adds a reference to the Web Search Tool setup guide, which is being added in the related td-documents PR.

The two PRs should be merged together to maintain consistency across documentation and skill examples.

## Known Issue: CodeQL Actions Check Failure

⚠️ **The `Analyze (actions)` check failure is expected and can be safely ignored.**

This is a known issue with CodeQL scanning on documentation-only repositories:
- td-skills is a documentation-only repository (SKILL.md + YAML files)
- CodeQL expects JavaScript/TypeScript code for Actions analysis, but none exists here
- This failure occurs on all PRs in this repository and is not specific to this change
- Other important checks (JavaScript, Python, label checks) all pass ✅

**This does not block merging** - the PR content (SKILL.md documentation update) is safe and unaffected by this check.

## Test plan

- [x] Verify YAML example syntax is correct
- [ ] Check external link to docs.treasuredata.com (will be live after td-documents PR is merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
