### PR TITLE
feat: add document-skills/pptx for HTML-to-PPTX presentation generation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -123,6 +123,15 @@
       ]
     },
     {
+      "name": "document-skills",
+      "description": "Document creation skills including PowerPoint presentation generation using HTML-to-PPTX conversion pipeline with agent-browser for rendering and PptxGenJS for assembly",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./document-skills/pptx"
+      ]
+    },
+    {
       "name": "template-skill",
       "description": "Template for creating new TD-specific Claude Code skills with best practices and standard structure",
       "source": "./",

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -65,11 +65,14 @@ mkdir -p ./tmp/slides
 
 ### Step 2: Validate with agent-browser
 
-Use the bundled validation script for quick checks:
+**CRITICAL: Set viewport to match slide dimensions before any operation.**
 
 ```bash
+# Set viewport to exactly 960x540 (720pt x 405pt at 96dpi)
+agent-browser set viewport 960 540
+
 agent-browser open "file://$(pwd)/tmp/slides/slide-0.html"
-cat scripts/validate.js | agent-browser eval --stdin --json
+cat $SKILL_DIR/scripts/validate.js | agent-browser eval --stdin --json
 ```
 
 Returns `{ "valid": true/false, "errors": [...] }`. Fix any errors before proceeding.
@@ -85,16 +88,19 @@ agent-browser screenshot ./tmp/slides/slide-0.png --json
 Use the bundled extraction script to get all element positions, styles, and placeholder coordinates:
 
 ```bash
-cat scripts/extract-dom.js | agent-browser eval --stdin --json
+cat $SKILL_DIR/scripts/extract-dom.js | agent-browser eval --stdin --json
 ```
 
 The `data.result` field contains JSON: `{ background, elements, placeholders, errors }`.
 Save each slide's extracted data to a JSON file for the build step.
 
-For gradient backgrounds, also capture a screenshot to use as the rasterized background:
+For gradient backgrounds, rasterize **only the background** (hide content to avoid double-rendering text):
 
 ```bash
+# Hide all content, screenshot background only, then restore
+agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='hidden')"
 agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
+agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"
 ```
 
 ### Step 4: Assemble PPTX
@@ -146,9 +152,11 @@ SKILL_DIR="$(dirname "$(find ~/.claude -path '*/document-skills/pptx/SKILL.md' 2
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
+| **Background doesn't fill slide** | Viewport wider than 960px, screenshot includes whitespace | `agent-browser set viewport 960 540` before any operation |
+| **Text appears doubled/overlapping** | Screenshot used as bg includes rendered text | Hide content before bg screenshot: `visibility='hidden'` |
 | agent-browser command not found | Not installed | `npx agent-browser@latest install` |
 | Text missing in PPTX | Text directly in `<div>` | Wrap in `<p>` or `<h1>`-`<h6>` |
-| Gradient background blank | Not rasterized | Take screenshot, set `bgImagePath` in config |
+| Gradient background blank | Not rasterized | Hide content, screenshot, set `bgImagePath` in config |
 | Overflow validation fails | Content exceeds 720pt x 405pt | Reduce font sizes, padding, or content |
 | Bottom margin error | Text within 0.5in of bottom | Add `padding-bottom: 48pt` to content area |
 | PPTX file corrupted | Inset box-shadow used | Use outer shadows only |

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -34,6 +34,8 @@ agent-browser install
 npm install pptxgenjs sharp
 ```
 
+**Important:** Always run agent-browser via Bash CLI, not MCP tools. Even if agent-browser MCP Connector is available, this skill requires `--stdin` piping and shell variable expansion that MCP tools cannot handle.
+
 ## Pipeline Overview
 
 ```

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -39,7 +39,8 @@ npx agent-browser@latest install
 1. Generate HTML slides (720pt x 405pt, strict element rules)
 2. Validate and render via agent-browser (screenshot for visual review)
 3. Extract DOM positions via agent-browser eval (getBoundingClientRect)
-4. Assemble PPTX with PptxGenJS using extracted coordinates
+4. Build config.json, render placeholders, preview with `open` command
+5. Assemble PPTX with PptxGenJS using extracted coordinates
 ```
 
 ## Workflow
@@ -103,15 +104,38 @@ agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
 agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"
 ```
 
-### Step 4: Assemble PPTX
+### Step 4: Build config.json and Preview
 
-Create a `config.json` that references each slide's extracted data and placeholder definitions, then run the bundled build script:
+Create a `config.json` that references each slide's extracted data and placeholder definitions. See [references/pptxgenjs.md](references/pptxgenjs.md) for config.json format.
+
+Then render placeholders for visual preview before final PPTX assembly:
 
 ```bash
-node scripts/build-pptx.js config.json output.pptx
+# For each slide with placeholders: render preview
+agent-browser open "file://$(pwd)/tmp/slides/slide-0.html"
+agent-browser set viewport 960 540
+
+# Set placeholder data and inject Chart.js
+agent-browser eval "window.__PLACEHOLDERS__ = $(jq '.slides[0].placeholders' tmp/config.json)"
+agent-browser eval "var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"
+agent-browser wait 2000
+
+# Render placeholders and screenshot for review
+cat $SKILL_DIR/scripts/render-placeholders.js | agent-browser eval --stdin --json
+agent-browser wait 1000
+agent-browser screenshot ./tmp/slides/slide-0-preview.png --json
+open ./tmp/slides/slide-0-preview.png
 ```
 
-See [references/pptxgenjs.md](references/pptxgenjs.md) for config.json format and details.
+Review the preview image. If adjustments are needed, regenerate the HTML and repeat from Step 2.
+
+### Step 5: Assemble PPTX
+
+Once all slides are reviewed, run the bundled build script:
+
+```bash
+node $SKILL_DIR/scripts/build-pptx.js tmp/config.json ./output/presentation.pptx
+```
 
 ## Placeholder System
 
@@ -146,6 +170,7 @@ SKILL_DIR="$(dirname "$(find ~/.claude -path '*/document-skills/pptx/SKILL.md' 2
 |--------|----------|---------|
 | `validate.js` | `cat $SKILL_DIR/scripts/validate.js \| agent-browser eval --stdin --json` | Quick HTML validation |
 | `extract-dom.js` | `cat $SKILL_DIR/scripts/extract-dom.js \| agent-browser eval --stdin --json` | Full DOM extraction |
+| `render-placeholders.js` | `cat $SKILL_DIR/scripts/render-placeholders.js \| agent-browser eval --stdin --json` | Placeholder preview rendering |
 | `build-pptx.js` | `node $SKILL_DIR/scripts/build-pptx.js config.json output.pptx` | PPTX assembly |
 
 ## Troubleshooting

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -57,11 +57,12 @@ Key constraints:
 - Bottom margin: keep 36pt+ from bottom edge
 - Placeholders: `<div class="placeholder" id="chart1" style="width:300pt;height:200pt;">`
 
-Save each slide as a separate HTML file:
+Save each slide as a separate HTML file under a presentation-specific directory:
 
 ```bash
-mkdir -p ./tmp/slides
-# Write slide-0.html, slide-1.html, etc.
+# Use a URL-safe slug of the presentation title (e.g., "q4-results", "product-roadmap")
+mkdir -p ./tmp/slides/{title}
+# Write slide-0.html, slide-1.html, etc. into that directory
 ```
 
 ### Step 2: Validate with agent-browser
@@ -72,7 +73,7 @@ mkdir -p ./tmp/slides
 # Set viewport to exactly 960x540 (720pt x 405pt at 96dpi)
 agent-browser set viewport 960 540
 
-agent-browser open "file://$(pwd)/tmp/slides/slide-0.html"
+agent-browser open "file://$(pwd)/tmp/slides/{title}/slide-0.html"
 cat $SKILL_DIR/scripts/validate.js | agent-browser eval --stdin --json
 ```
 
@@ -81,7 +82,7 @@ Returns `{ "valid": true/false, "errors": [...] }`. Fix any errors before procee
 Take a screenshot for visual review:
 
 ```bash
-agent-browser screenshot ./tmp/slides/slide-0.png --json
+agent-browser screenshot ./tmp/slides/{title}/slide-0.png --json
 ```
 
 ### Step 3: Extract DOM Positions
@@ -100,7 +101,7 @@ For gradient backgrounds, rasterize **only the background** (hide content to avo
 ```bash
 # Hide all content, screenshot background only, then restore
 agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='hidden')"
-agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
+agent-browser screenshot ./tmp/slides/{title}/slide-0-bg.png --json
 agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"
 ```
 
@@ -112,19 +113,19 @@ Then render placeholders for visual preview before final PPTX assembly:
 
 ```bash
 # For each slide with placeholders: render preview
-agent-browser open "file://$(pwd)/tmp/slides/slide-0.html"
+agent-browser open "file://$(pwd)/tmp/slides/{title}/slide-0.html"
 agent-browser set viewport 960 540
 
 # Set placeholder data and inject Chart.js
-agent-browser eval "window.__PLACEHOLDERS__ = $(jq '.slides[0].placeholders' tmp/config.json)"
+agent-browser eval "window.__PLACEHOLDERS__ = $(jq '.slides[0].placeholders' tmp/slides/{title}/config.json)"
 agent-browser eval "var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"
 agent-browser wait 2000
 
 # Render placeholders and screenshot for review
 cat $SKILL_DIR/scripts/render-placeholders.js | agent-browser eval --stdin --json
 agent-browser wait 1000
-agent-browser screenshot ./tmp/slides/slide-0-preview.png --json
-open ./tmp/slides/slide-0-preview.png
+agent-browser screenshot ./tmp/slides/{title}/slide-0-preview.png --json
+open ./tmp/slides/{title}/slide-0-preview.png
 ```
 
 Review the preview image. If adjustments are needed, regenerate the HTML and repeat from Step 2.
@@ -134,7 +135,7 @@ Review the preview image. If adjustments are needed, regenerate the HTML and rep
 Once all slides are reviewed, run the bundled build script:
 
 ```bash
-node $SKILL_DIR/scripts/build-pptx.js tmp/config.json ./output/presentation.pptx
+node $SKILL_DIR/scripts/build-pptx.js tmp/slides/{title}/config.json ./output/{title}.pptx
 ```
 
 ## Placeholder System

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -128,10 +128,12 @@ agent-browser wait 2000
 cat $SKILL_DIR/scripts/render-placeholders.js | agent-browser eval --stdin --json
 agent-browser wait 1000
 agent-browser screenshot ./tmp/slides/{title}/slide-0-preview.png --json
+
+# IMPORTANT: Always open the preview image so the user can review it
 open ./tmp/slides/{title}/slide-0-preview.png
 ```
 
-Review the preview image. If adjustments are needed, regenerate the HTML and repeat from Step 2.
+**You MUST run `open` after each screenshot** to display the preview to the user. Do not skip this step — the user needs to visually confirm each slide before proceeding to PPTX assembly.
 
 ### Step 5: Assemble PPTX
 

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: pptx
+description: >
+  Use this skill any time the user wants to create a new PowerPoint presentation, slide deck,
+  pitch deck, or .pptx file from scratch. Covers creating business presentations, quarterly
+  reports, project proposals, product roadmaps, training materials, and any multi-slide
+  document destined for PowerPoint. Works by generating HTML/CSS slides (which LLMs excel at),
+  rendering them in agent-browser for pixel-accurate DOM position extraction, and assembling
+  the final PPTX with native PowerPoint charts, tables, and images via PptxGenJS.
+  Includes bundled scripts for validation, DOM extraction, and PPTX assembly.
+  Do NOT use this skill for editing existing PPTX files, converting other formats to PPTX,
+  or extracting content from PPTX files.
+---
+
+# HTML-to-PPTX Presentation Generator
+
+Generate professional PowerPoint files by writing HTML/CSS slides and converting them to PPTX with pixel-accurate positioning.
+
+**Why HTML?** LLMs excel at HTML/CSS. Instead of wrestling with PptxGenJS's coordinate system directly, write HTML slides and let the browser compute exact element positions via `getBoundingClientRect()`.
+
+## When to Use
+
+- User asks to **create** a presentation, slide deck, or .pptx file
+- User needs slides for a report, proposal, roadmap, or pitch
+- User wants charts, tables, or images in PowerPoint format
+
+**Do NOT use for:** editing existing .pptx, converting formats, or reading/extracting from .pptx.
+
+## Prerequisites
+
+```bash
+npm install pptxgenjs sharp
+npx agent-browser@latest install
+```
+
+## Pipeline Overview
+
+```
+1. Generate HTML slides (720pt x 405pt, strict element rules)
+2. Validate and render via agent-browser (screenshot for visual review)
+3. Extract DOM positions via agent-browser eval (getBoundingClientRect)
+4. Assemble PPTX with PptxGenJS using extracted coordinates
+```
+
+## Workflow
+
+### Step 1: Generate HTML Slides
+
+Write HTML following the rules in [references/html-rules.md](references/html-rules.md). Use templates from [references/slide-templates.md](references/slide-templates.md).
+
+Key constraints:
+- Body: `width: 720pt; height: 405pt; margin: 0; padding: 0`
+- Text MUST be in `<p>`, `<h1>`-`<h6>`, `<ul>/<ol>` (text in `<div>` won't convert)
+- No `<br>` tags, no manual bullet symbols
+- Web-safe fonts only (Arial recommended)
+- Bottom margin: keep 36pt+ from bottom edge
+- Placeholders: `<div class="placeholder" id="chart1" style="width:300pt;height:200pt;">`
+
+Save each slide as a separate HTML file:
+
+```bash
+mkdir -p ./tmp/slides
+# Write slide-0.html, slide-1.html, etc.
+```
+
+### Step 2: Validate with agent-browser
+
+Use the bundled validation script for quick checks:
+
+```bash
+agent-browser open "file://$(pwd)/tmp/slides/slide-0.html"
+cat scripts/validate.js | agent-browser eval --stdin --json
+```
+
+Returns `{ "valid": true/false, "errors": [...] }`. Fix any errors before proceeding.
+
+Take a screenshot for visual review:
+
+```bash
+agent-browser screenshot ./tmp/slides/slide-0.png --json
+```
+
+### Step 3: Extract DOM Positions
+
+Use the bundled extraction script to get all element positions, styles, and placeholder coordinates:
+
+```bash
+cat scripts/extract-dom.js | agent-browser eval --stdin --json
+```
+
+The `data.result` field contains JSON: `{ background, elements, placeholders, errors }`.
+Save each slide's extracted data to a JSON file for the build step.
+
+For gradient backgrounds, also capture a screenshot to use as the rasterized background:
+
+```bash
+agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
+```
+
+### Step 4: Assemble PPTX
+
+Create a `config.json` that references each slide's extracted data and placeholder definitions, then run the bundled build script:
+
+```bash
+node scripts/build-pptx.js config.json output.pptx
+```
+
+See [references/pptxgenjs.md](references/pptxgenjs.md) for config.json format and details.
+
+## Placeholder System
+
+Placeholders reserve space in HTML for native PowerPoint content (charts, tables, images). The `<div>` defines position/size; PptxGenJS fills the content.
+
+```html
+<div class="placeholder" id="chart1" style="width: 300pt; height: 200pt;"></div>
+```
+
+Three types supported: `chart` (bar, line, pie, doughnut, scatter), `table`, and `image`. See [references/pptxgenjs.md](references/pptxgenjs.md) for complete placeholder JSON formats.
+
+## Design Consistency
+
+The title slide (slide 0) establishes the visual language. Apply consistently:
+
+| Element | Rule |
+|---------|------|
+| Header bar | Same height and background color on all slides |
+| Content padding | Same padding values across slides |
+| Font sizes | h1: 28pt, h2: 20pt, body: 16pt, caption: 12pt |
+| Colors | Primary for headers, secondary for subheadings, accent for highlights |
+
+## Scripts
+
+All scripts are in this skill's `scripts/` directory. Find the skill path and use it:
+
+```bash
+SKILL_DIR="$(dirname "$(find ~/.claude -path '*/document-skills/pptx/SKILL.md' 2>/dev/null | head -1)")"
+```
+
+| Script | Run with | Purpose |
+|--------|----------|---------|
+| `validate.js` | `cat $SKILL_DIR/scripts/validate.js \| agent-browser eval --stdin --json` | Quick HTML validation |
+| `extract-dom.js` | `cat $SKILL_DIR/scripts/extract-dom.js \| agent-browser eval --stdin --json` | Full DOM extraction |
+| `build-pptx.js` | `node $SKILL_DIR/scripts/build-pptx.js config.json output.pptx` | PPTX assembly |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| agent-browser command not found | Not installed | `npx agent-browser@latest install` |
+| Text missing in PPTX | Text directly in `<div>` | Wrap in `<p>` or `<h1>`-`<h6>` |
+| Gradient background blank | Not rasterized | Take screenshot, set `bgImagePath` in config |
+| Overflow validation fails | Content exceeds 720pt x 405pt | Reduce font sizes, padding, or content |
+| Bottom margin error | Text within 0.5in of bottom | Add `padding-bottom: 48pt` to content area |
+| PPTX file corrupted | Inset box-shadow used | Use outer shadows only |
+
+## Reference Files
+
+- [HTML Rules](references/html-rules.md) - Complete HTML generation constraints
+- [Slide Templates](references/slide-templates.md) - Templates for each slide type
+- [PptxGenJS Conversion](references/pptxgenjs.md) - Config format, placeholder JSON, and conversion details

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -29,8 +29,9 @@ Generate professional PowerPoint files by writing HTML/CSS slides and converting
 ## Prerequisites
 
 ```bash
+npm install -g agent-browser
+agent-browser install
 npm install pptxgenjs sharp
-npx agent-browser@latest install
 ```
 
 ## Pipeline Overview
@@ -180,7 +181,7 @@ SKILL_DIR="$(dirname "$(find ~/.claude -path '*/document-skills/pptx/SKILL.md' 2
 |---------|-------|-----|
 | **Background doesn't fill slide** | Viewport wider than 960px, screenshot includes whitespace | `agent-browser set viewport 960 540` before any operation |
 | **Text appears doubled/overlapping** | Screenshot used as bg includes rendered text | Hide content before bg screenshot: `visibility='hidden'` |
-| agent-browser command not found | Not installed | `npx agent-browser@latest install` |
+| agent-browser command not found | Not installed | `npm install -g agent-browser && agent-browser install` |
 | Text missing in PPTX | Text directly in `<div>` | Wrap in `<p>` or `<h1>`-`<h6>` |
 | Gradient background blank | Not rasterized | Hide content, screenshot, set `bgImagePath` in config |
 | Overflow validation fails | Content exceeds 720pt x 405pt | Reduce font sizes, padding, or content |

--- a/document-skills/pptx/references/html-rules.md
+++ b/document-skills/pptx/references/html-rules.md
@@ -1,0 +1,187 @@
+# HTML Rules for PPTX Conversion
+
+These rules ensure HTML slides convert accurately to PowerPoint. Violations cause missing text, broken layouts, or file corruption.
+
+## Slide Dimensions
+
+```css
+body {
+  width: 720pt;
+  height: 405pt;
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+}
+```
+
+720pt x 405pt = 10" x 5.625" = standard 16:9 PowerPoint layout.
+
+## Text Elements
+
+All visible text MUST be inside these elements:
+
+| Element | Usage |
+|---------|-------|
+| `<p>` | Paragraphs, body text |
+| `<h1>` - `<h6>` | Headings |
+| `<ul>`, `<ol>` with `<li>` | Lists |
+| `<pre>` | Code blocks (monospace) |
+
+### Critical: Text in `<div>` is Invisible
+
+```html
+<!-- WRONG: text disappears in PPTX -->
+<div>This text will not appear</div>
+<div style="font-size: 16pt;">Also invisible</div>
+
+<!-- CORRECT: wrap in text element -->
+<div>
+  <p>This text will appear</p>
+</div>
+```
+
+The converter extracts text only from `<p>`, `<h1>`-`<h6>`, `<li>`, and `<pre>` tags.
+
+## Forbidden Patterns
+
+### No `<br>` Tags
+
+```html
+<!-- WRONG -->
+<p>Line 1<br>Line 2<br>Line 3</p>
+
+<!-- CORRECT -->
+<p>Line 1</p>
+<p>Line 2</p>
+<p>Line 3</p>
+```
+
+### No Manual Bullet Symbols
+
+```html
+<!-- WRONG -->
+<p>* Item 1</p>
+<p>- Item 2</p>
+
+<!-- CORRECT -->
+<ul>
+  <li>Item 1</li>
+  <li>Item 2</li>
+</ul>
+```
+
+### No Elements Beyond Slide Bounds
+
+All elements must fit within 720pt x 405pt. No decorative shapes extending beyond edges.
+
+```html
+<!-- WRONG: extends beyond slide -->
+<div style="position: absolute; top: -50pt; right: -50pt; width: 200pt; height: 200pt; border-radius: 50%; background: #ccc;"></div>
+
+<!-- CORRECT: use gradient instead -->
+<body style="background: linear-gradient(135deg, #1A365D 0%, #2B6CB0 100%);">
+```
+
+## Bottom Margin
+
+Keep text at least 36pt (0.5 inches) from the bottom edge. Use `padding-bottom: 48pt` on content containers.
+
+```css
+.content {
+  flex: 1;
+  padding: 30pt;
+  padding-bottom: 48pt; /* safety margin */
+}
+```
+
+## Web-Safe Fonts Only
+
+Arial, Helvetica, Times New Roman, Georgia, Courier New, Verdana, Tahoma, Trebuchet MS, Impact.
+
+Other fonts will be substituted unpredictably in PowerPoint.
+
+## Shape Styling
+
+Backgrounds, borders, border-radius, and box-shadow work ONLY on `<div>` elements:
+
+```html
+<!-- CORRECT: shape with text -->
+<div style="background: #f0f0f0; border-radius: 8pt; padding: 20pt; border: 1pt solid #ccc;">
+  <p>Content here</p>
+</div>
+
+<!-- WRONG: background on text element (ignored in PPTX) -->
+<p style="background: #f0f0f0;">Content</p>
+```
+
+## CSS Gradients
+
+Supported on `<body>` and `<div>` elements. Automatically rasterized to PNG during conversion.
+
+```css
+body { background: linear-gradient(135deg, #1A365D 0%, #2B6CB0 100%); }
+```
+
+Radial gradients also supported:
+```css
+body { background: radial-gradient(circle at top right, #1A365D 0%, #2B6CB0 100%); }
+```
+
+## Placeholders
+
+Reserve space for native PowerPoint content (charts, tables, images).
+
+```html
+<div class="placeholder" id="chart1"
+     style="width: 300pt; height: 200pt; position: absolute; left: 150pt; top: 100pt;">
+</div>
+```
+
+Requirements:
+- Must have `class="placeholder"`
+- Must have unique `id`
+- Must have explicit `width` and `height` in pt
+- Position with `position: absolute` or within flex layout
+- Content is empty (PptxGenJS fills it)
+
+## Overflow Validation
+
+Check after rendering:
+
+```javascript
+const body = document.body;
+const s = window.getComputedStyle(body);
+const overflowX = body.scrollWidth > parseFloat(s.width) + 1;
+const overflowY = body.scrollHeight > parseFloat(s.height) + 1;
+```
+
+If overflow detected:
+- Horizontal: reduce font-size, padding, or element widths
+- Vertical: reduce content, remove elements, or decrease spacing
+- Check for absolute-positioned elements extending beyond bounds
+
+## Supported CSS Properties
+
+| Property | Where | Notes |
+|----------|-------|-------|
+| `font-size`, `font-family`, `color` | Text elements | Converted to PPTX text props |
+| `font-weight: bold`, `font-style: italic` | Text elements | |
+| `text-align` | Text elements | left, center, right |
+| `text-decoration: underline` | Text elements | |
+| `text-transform` | Text elements | uppercase, lowercase, capitalize |
+| `line-height` | Text elements | Converted to lineSpacing |
+| `background`, `background-color` | `<div>`, `<body>` | Gradients rasterized to PNG |
+| `border`, `border-radius` | `<div>` | Converted to PPTX shape borders |
+| `box-shadow` | `<div>` | Converted to PPTX shadow |
+| `text-shadow` | Text elements | Converted to PPTX text shadow |
+| `opacity` | Any | Converted to transparency |
+| `transform: rotate()` | Text elements | 90, 270 for vertical text |
+| `padding`, `margin` | Any | Used for positioning |
+
+## Color Format
+
+Use hex colors without `#` prefix in PptxGenJS: `"4472C4"` not `"#4472C4"`.
+
+In HTML, use standard CSS colors. The converter handles the conversion.

--- a/document-skills/pptx/references/pptxgenjs.md
+++ b/document-skills/pptx/references/pptxgenjs.md
@@ -222,7 +222,8 @@ for i in 0 1 2; do
   cat $SKILL_DIR/scripts/render-placeholders.js | agent-browser eval --stdin --json
   agent-browser wait 1000
   agent-browser screenshot "./tmp/slides/${TITLE}/slide-${i}-preview.png" --json
-  open "./tmp/slides/${TITLE}/slide-${i}-preview.png"  # Visual review
+  # IMPORTANT: Always open preview for user to review before proceeding
+  open "./tmp/slides/${TITLE}/slide-${i}-preview.png"
 done
 
 # 5. Assemble PPTX

--- a/document-skills/pptx/references/pptxgenjs.md
+++ b/document-skills/pptx/references/pptxgenjs.md
@@ -1,0 +1,188 @@
+# PptxGenJS Conversion Reference
+
+Conversion details for the bundled scripts in `scripts/`.
+
+## Unit Conversions
+
+```
+1px = 0.75pt
+96px = 1 inch
+PptxGenJS positions (x, y, w, h) = inches
+PptxGenJS font sizes = points
+PptxGenJS colors = hex without # ("4472C4" not "#4472C4")
+PptxGenJS margin array = [left, right, bottom, top] (NOT CSS order)
+```
+
+## Scripts Overview
+
+### validate.js
+
+Quick validation before full extraction. Run:
+
+```bash
+agent-browser open "file://$(pwd)/tmp/slides/slide-0.html"
+cat scripts/validate.js | agent-browser eval --stdin --json
+```
+
+Returns: `{ "valid": true/false, "errors": ["..."] }`
+
+Checks: body dimensions, overflow, `<br>` tags, unwrapped text in divs, manual bullets, backgrounds on text elements, placeholder sizing, bottom margin, web-safe fonts, out-of-bounds elements.
+
+### extract-dom.js
+
+Full DOM extraction. Run after opening the HTML in agent-browser:
+
+```bash
+cat scripts/extract-dom.js | agent-browser eval --stdin --json
+```
+
+The `data.result` field (string) parses to:
+
+```json
+{
+  "background": { "type": "color", "value": "FFFFFF" },
+  "elements": [
+    { "type": "shape", "position": { "x": 0, "y": 0, "w": 10, "h": 0.83 }, "fill": "1A365D", ... },
+    { "type": "h1", "text": "Title", "position": { "x": 0.31, "y": 0.25, ... }, "style": { "fontSize": 21, ... } },
+    { "type": "list", "items": [...], "position": {...}, "style": {...} }
+  ],
+  "placeholders": [
+    { "id": "chart1", "x": 3.96, "y": 1.04, "w": 3.33, "h": 2.71 }
+  ],
+  "errors": []
+}
+```
+
+Element types extracted:
+- `shape` — DIVs with background/border (converted to PptxGenJS shapes)
+- `gradientDiv` — DIVs with CSS gradient (need rasterization)
+- `line` — Partial borders (non-uniform border sides)
+- `image` — `<img>` tags
+- `list` — `<ul>`/`<ol>` with nested items and inline formatting
+- `pre` — Code blocks with monospace font
+- `p`, `h1`-`h6` — Text elements with full style extraction
+
+### build-pptx.js
+
+Assembles PPTX from extracted data. Run:
+
+```bash
+node scripts/build-pptx.js config.json output.pptx
+```
+
+## config.json Format
+
+```json
+{
+  "slides": [
+    {
+      "extracted": {
+        "background": { "type": "gradient", "css": "linear-gradient(...)" },
+        "elements": [ ... ],
+        "placeholders": [ { "id": "chart1", "x": 3.96, "y": 1.04, "w": 3.33, "h": 2.71 } ]
+      },
+      "bgImagePath": "./tmp/slides/slide-0-bg.png",
+      "placeholders": [
+        {
+          "id": "chart1",
+          "type": "chart",
+          "chartType": "bar",
+          "chartData": {
+            "series": [{ "name": "Revenue", "labels": ["Q1","Q2","Q3","Q4"], "values": [1200,1500,1800,2100] }],
+            "options": { "title": "Quarterly Revenue", "showLegend": false }
+          }
+        }
+      ]
+    },
+    {
+      "extracted": { "background": { "type": "color", "value": "F5F5F5" }, "elements": [...], "placeholders": [] },
+      "placeholders": []
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `extracted` | Yes | Output from `extract-dom.js` (parsed from `data.result`) |
+| `bgImagePath` | No | Path to rasterized gradient background image |
+| `placeholders` | No | Array of placeholder content definitions |
+
+### Placeholder Definition Types
+
+**Chart:**
+```json
+{ "id": "chart1", "type": "chart", "chartType": "bar|line|pie|doughnut|scatter",
+  "chartData": { "series": [{ "name": "...", "labels": [...], "values": [...] }],
+                 "options": { "title": "...", "showLegend": true, "categoryAxisTitle": "...", "valueAxisTitle": "...", "colors": ["4472C4","ED7D31"] } } }
+```
+
+**Table:**
+```json
+{ "id": "table1", "type": "table",
+  "tableData": { "headers": ["Col1","Col2"], "rows": [["a","b"],["c","d"]],
+                 "options": { "headerBackground": "4472C4", "headerColor": "FFFFFF" } } }
+```
+
+**Image:**
+```json
+{ "id": "img1", "type": "image",
+  "imageData": { "url": "https://images.unsplash.com/photo-xxx?w=800", "alt": "Description" } }
+```
+
+## Gradient Rasterization
+
+CSS gradients (body or div) can't be directly represented in PowerPoint. Rasterize by screenshot:
+
+```bash
+# Body gradient → full-page screenshot as background
+agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
+
+# Div gradient → get box coordinates, then crop
+agent-browser get box "#gradient-div-id" --json
+# Use sharp to crop the region from the full screenshot
+```
+
+Set `bgImagePath` in config.json for body gradients. For div gradients, add `rasterizedPath` to the element in the extracted data before passing to build-pptx.js.
+
+## Workflow Example
+
+```bash
+# 1. Generate HTML slides (write slide-0.html, slide-1.html, ...)
+mkdir -p ./tmp/slides
+
+# 2. For each slide: validate → extract → screenshot
+for i in 0 1 2; do
+  agent-browser open "file://$(pwd)/tmp/slides/slide-${i}.html"
+
+  # Validate
+  cat scripts/validate.js | agent-browser eval --stdin --json
+
+  # Screenshot (also serves as gradient background if needed)
+  agent-browser screenshot "./tmp/slides/slide-${i}.png" --json
+
+  # Extract DOM
+  cat scripts/extract-dom.js | agent-browser eval --stdin --json
+  # → save data.result to ./tmp/slides/slide-${i}.json
+done
+
+# 3. Build config.json from extracted data + placeholder definitions
+# 4. Assemble
+node scripts/build-pptx.js ./tmp/config.json ./output/presentation.pptx
+agent-browser close
+```
+
+## Common Pitfalls
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Text missing in PPTX | Text directly in `<div>` | Wrap in `<p>` or `<h1>`-`<h6>` |
+| Wrong font size | Using px in PptxGenJS | Convert: `px * 0.75 = pt` |
+| Element mispositioned | Wrong unit | Positions must be inches: `px / 96` |
+| Colors with `#` | PptxGenJS no-prefix | `"4472C4"` not `"#4472C4"` |
+| Single-line text wraps | Width underestimate | build-pptx.js auto-adds 2% |
+| Gradient blank | Not rasterized | Screenshot → set bgImagePath |
+| Inset shadow corrupts | PptxGenJS limitation | extract-dom.js skips inset shadows |
+| margin array order | Not CSS order | `[left, right, bottom, top]` |

--- a/document-skills/pptx/references/pptxgenjs.md
+++ b/document-skills/pptx/references/pptxgenjs.md
@@ -134,15 +134,25 @@ node scripts/build-pptx.js config.json output.pptx
 
 ## Gradient Rasterization
 
-CSS gradients (body or div) can't be directly represented in PowerPoint. Rasterize by screenshot:
+CSS gradients can't be directly represented in PowerPoint. Rasterize by screenshot with **content hidden** to avoid double-rendering text:
 
 ```bash
-# Body gradient → full-page screenshot as background
-agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
+# CRITICAL: Set viewport to slide dimensions first
+agent-browser set viewport 960 540
 
-# Div gradient → get box coordinates, then crop
+# Hide all content, screenshot background only, then restore
+agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='hidden')"
+agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
+agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"
+```
+
+**Why hide content?** The screenshot includes rendered text. If used as background, text appears twice: once in the background image and once as PptxGenJS text elements.
+
+For **div gradients**, get the box coordinates and crop from the hidden-content screenshot:
+
+```bash
 agent-browser get box "#gradient-div-id" --json
-# Use sharp to crop the region from the full screenshot
+# Use sharp to crop: sharp(screenshot).extract({left, top, width, height}).toFile(output)
 ```
 
 Set `bgImagePath` in config.json for body gradients. For div gradients, add `rasterizedPath` to the element in the extracted data before passing to build-pptx.js.
@@ -150,6 +160,9 @@ Set `bgImagePath` in config.json for body gradients. For div gradients, add `ras
 ## Workflow Example
 
 ```bash
+# 0. CRITICAL: Set viewport to match slide dimensions (720pt = 960px, 405pt = 540px)
+agent-browser set viewport 960 540
+
 # 1. Generate HTML slides (write slide-0.html, slide-1.html, ...)
 mkdir -p ./tmp/slides
 
@@ -158,19 +171,24 @@ for i in 0 1 2; do
   agent-browser open "file://$(pwd)/tmp/slides/slide-${i}.html"
 
   # Validate
-  cat scripts/validate.js | agent-browser eval --stdin --json
+  cat $SKILL_DIR/scripts/validate.js | agent-browser eval --stdin --json
 
-  # Screenshot (also serves as gradient background if needed)
+  # Visual review screenshot
   agent-browser screenshot "./tmp/slides/slide-${i}.png" --json
 
-  # Extract DOM
-  cat scripts/extract-dom.js | agent-browser eval --stdin --json
+  # For gradient backgrounds: hide content, screenshot bg only, restore
+  agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='hidden')"
+  agent-browser screenshot "./tmp/slides/slide-${i}-bg.png" --json
+  agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"
+
+  # Extract DOM positions
+  cat $SKILL_DIR/scripts/extract-dom.js | agent-browser eval --stdin --json
   # → save data.result to ./tmp/slides/slide-${i}.json
 done
 
 # 3. Build config.json from extracted data + placeholder definitions
 # 4. Assemble
-node scripts/build-pptx.js ./tmp/config.json ./output/presentation.pptx
+node $SKILL_DIR/scripts/build-pptx.js ./tmp/config.json ./output/presentation.pptx
 agent-browser close
 ```
 
@@ -178,11 +196,13 @@ agent-browser close
 
 | Issue | Cause | Fix |
 |-------|-------|-----|
+| **Background doesn't fill slide** | Viewport wider than 960px | `agent-browser set viewport 960 540` before any operation |
+| **Text doubled/overlapping** | Screenshot bg includes text | Hide content before bg screenshot (`visibility='hidden'`) |
 | Text missing in PPTX | Text directly in `<div>` | Wrap in `<p>` or `<h1>`-`<h6>` |
 | Wrong font size | Using px in PptxGenJS | Convert: `px * 0.75 = pt` |
 | Element mispositioned | Wrong unit | Positions must be inches: `px / 96` |
 | Colors with `#` | PptxGenJS no-prefix | `"4472C4"` not `"#4472C4"` |
 | Single-line text wraps | Width underestimate | build-pptx.js auto-adds 2% |
-| Gradient blank | Not rasterized | Screenshot → set bgImagePath |
+| Gradient blank | Not rasterized | Hide content → screenshot → set bgImagePath |
 | Inset shadow corrupts | PptxGenJS limitation | extract-dom.js skips inset shadows |
 | margin array order | Not CSS order | `[left, right, bottom, top]` |

--- a/document-skills/pptx/references/pptxgenjs.md
+++ b/document-skills/pptx/references/pptxgenjs.md
@@ -20,7 +20,7 @@ PptxGenJS margin array = [left, right, bottom, top] (NOT CSS order)
 Quick validation before full extraction. Run:
 
 ```bash
-agent-browser open "file://$(pwd)/tmp/slides/slide-0.html"
+agent-browser open "file://$(pwd)/tmp/slides/{title}/slide-0.html"
 cat scripts/validate.js | agent-browser eval --stdin --json
 ```
 
@@ -94,7 +94,7 @@ node scripts/build-pptx.js config.json output.pptx
         "elements": [ ... ],
         "placeholders": [ { "id": "chart1", "x": 3.96, "y": 1.04, "w": 3.33, "h": 2.71 } ]
       },
-      "bgImagePath": "./tmp/slides/slide-0-bg.png",
+      "bgImagePath": "./tmp/slides/{title}/slide-0-bg.png",
       "placeholders": [
         {
           "id": "chart1",
@@ -155,7 +155,7 @@ agent-browser set viewport 960 540
 
 # Hide all content, screenshot background only, then restore
 agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='hidden')"
-agent-browser screenshot ./tmp/slides/slide-0-bg.png --json
+agent-browser screenshot ./tmp/slides/{title}/slide-0-bg.png --json
 agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"
 ```
 
@@ -176,38 +176,42 @@ Set `bgImagePath` in config.json for body gradients. For div gradients, add `ras
 # 0. CRITICAL: Set viewport to match slide dimensions (720pt = 960px, 405pt = 540px)
 agent-browser set viewport 960 540
 
+# Use a URL-safe slug of the presentation title (e.g., "q4-results")
+TITLE="q4-results"
+
 # 1. Generate HTML slides (write slide-0.html, slide-1.html, ...)
-mkdir -p ./tmp/slides
+mkdir -p ./tmp/slides/${TITLE}
 
 # 2. For each slide: validate → extract → screenshot
 for i in 0 1 2; do
-  agent-browser open "file://$(pwd)/tmp/slides/slide-${i}.html"
+  agent-browser open "file://$(pwd)/tmp/slides/${TITLE}/slide-${i}.html"
 
   # Validate
   cat $SKILL_DIR/scripts/validate.js | agent-browser eval --stdin --json
 
   # Visual review screenshot
-  agent-browser screenshot "./tmp/slides/slide-${i}.png" --json
+  agent-browser screenshot "./tmp/slides/${TITLE}/slide-${i}.png" --json
 
   # For gradient backgrounds: hide content, screenshot bg only, restore
   agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='hidden')"
-  agent-browser screenshot "./tmp/slides/slide-${i}-bg.png" --json
+  agent-browser screenshot "./tmp/slides/${TITLE}/slide-${i}-bg.png" --json
   agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"
 
   # Extract DOM positions
   cat $SKILL_DIR/scripts/extract-dom.js | agent-browser eval --stdin --json
-  # → save data.result to ./tmp/slides/slide-${i}.json
+  # → save data.result to ./tmp/slides/${TITLE}/slide-${i}.json
 done
 
 # 3. Build config.json from extracted data + placeholder definitions
+# → save to ./tmp/slides/${TITLE}/config.json
 
 # 4. Preview: render placeholders into HTML and screenshot for review
 for i in 0 1 2; do
-  agent-browser open "file://$(pwd)/tmp/slides/slide-${i}.html"
+  agent-browser open "file://$(pwd)/tmp/slides/${TITLE}/slide-${i}.html"
   agent-browser set viewport 960 540
 
   # Set placeholder data from config.json
-  agent-browser eval "window.__PLACEHOLDERS__ = $(jq ".slides[${i}].placeholders" ./tmp/config.json)"
+  agent-browser eval "window.__PLACEHOLDERS__ = $(jq ".slides[${i}].placeholders" ./tmp/slides/${TITLE}/config.json)"
 
   # Inject Chart.js for chart rendering
   agent-browser eval "var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"
@@ -216,12 +220,12 @@ for i in 0 1 2; do
   # Render placeholders and take preview screenshot
   cat $SKILL_DIR/scripts/render-placeholders.js | agent-browser eval --stdin --json
   agent-browser wait 1000
-  agent-browser screenshot "./tmp/slides/slide-${i}-preview.png" --json
-  open "./tmp/slides/slide-${i}-preview.png"  # Visual review
+  agent-browser screenshot "./tmp/slides/${TITLE}/slide-${i}-preview.png" --json
+  open "./tmp/slides/${TITLE}/slide-${i}-preview.png"  # Visual review
 done
 
 # 5. Assemble PPTX
-node $SKILL_DIR/scripts/build-pptx.js ./tmp/config.json ./output/presentation.pptx
+node $SKILL_DIR/scripts/build-pptx.js ./tmp/slides/${TITLE}/config.json ./output/${TITLE}.pptx
 agent-browser close
 ```
 

--- a/document-skills/pptx/references/pptxgenjs.md
+++ b/document-skills/pptx/references/pptxgenjs.md
@@ -62,6 +62,19 @@ Element types extracted:
 - `pre` — Code blocks with monospace font
 - `p`, `h1`-`h6` — Text elements with full style extraction
 
+### render-placeholders.js
+
+Renders chart/table/image content into placeholder divs for visual preview. Prerequisites: set `window.__PLACEHOLDERS__` and inject Chart.js CDN before running.
+
+```bash
+agent-browser eval "window.__PLACEHOLDERS__ = <JSON array>"
+agent-browser eval "var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"
+agent-browser wait 2000
+cat scripts/render-placeholders.js | agent-browser eval --stdin --json
+```
+
+Returns: `{ "rendered": <number>, "errors": ["..."] }`
+
 ### build-pptx.js
 
 Assembles PPTX from extracted data. Run:
@@ -187,7 +200,27 @@ for i in 0 1 2; do
 done
 
 # 3. Build config.json from extracted data + placeholder definitions
-# 4. Assemble
+
+# 4. Preview: render placeholders into HTML and screenshot for review
+for i in 0 1 2; do
+  agent-browser open "file://$(pwd)/tmp/slides/slide-${i}.html"
+  agent-browser set viewport 960 540
+
+  # Set placeholder data from config.json
+  agent-browser eval "window.__PLACEHOLDERS__ = $(jq ".slides[${i}].placeholders" ./tmp/config.json)"
+
+  # Inject Chart.js for chart rendering
+  agent-browser eval "var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"
+  agent-browser wait 2000
+
+  # Render placeholders and take preview screenshot
+  cat $SKILL_DIR/scripts/render-placeholders.js | agent-browser eval --stdin --json
+  agent-browser wait 1000
+  agent-browser screenshot "./tmp/slides/slide-${i}-preview.png" --json
+  open "./tmp/slides/slide-${i}-preview.png"  # Visual review
+done
+
+# 5. Assemble PPTX
 node $SKILL_DIR/scripts/build-pptx.js ./tmp/config.json ./output/presentation.pptx
 agent-browser close
 ```

--- a/document-skills/pptx/references/pptxgenjs.md
+++ b/document-skills/pptx/references/pptxgenjs.md
@@ -21,7 +21,7 @@ Quick validation before full extraction. Run:
 
 ```bash
 agent-browser open "file://$(pwd)/tmp/slides/{title}/slide-0.html"
-cat scripts/validate.js | agent-browser eval --stdin --json
+cat $SKILL_DIR/scripts/validate.js | agent-browser eval --stdin --json
 ```
 
 Returns: `{ "valid": true/false, "errors": ["..."] }`
@@ -33,7 +33,7 @@ Checks: body dimensions, overflow, `<br>` tags, unwrapped text in divs, manual b
 Full DOM extraction. Run after opening the HTML in agent-browser:
 
 ```bash
-cat scripts/extract-dom.js | agent-browser eval --stdin --json
+cat $SKILL_DIR/scripts/extract-dom.js | agent-browser eval --stdin --json
 ```
 
 The `data.result` field (string) parses to:
@@ -70,7 +70,7 @@ Renders chart/table/image content into placeholder divs for visual preview. Prer
 agent-browser eval "window.__PLACEHOLDERS__ = <JSON array>"
 agent-browser eval "var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"
 agent-browser wait 2000
-cat scripts/render-placeholders.js | agent-browser eval --stdin --json
+cat $SKILL_DIR/scripts/render-placeholders.js | agent-browser eval --stdin --json
 ```
 
 Returns: `{ "rendered": <number>, "errors": ["..."] }`
@@ -80,7 +80,7 @@ Returns: `{ "rendered": <number>, "errors": ["..."] }`
 Assembles PPTX from extracted data. Run:
 
 ```bash
-node scripts/build-pptx.js config.json output.pptx
+node $SKILL_DIR/scripts/build-pptx.js config.json output.pptx
 ```
 
 ## config.json Format
@@ -192,7 +192,8 @@ for i in 0 1 2; do
   # Visual review screenshot
   agent-browser screenshot "./tmp/slides/${TITLE}/slide-${i}.png" --json
 
-  # For gradient backgrounds: hide content, screenshot bg only, restore
+  # For gradient backgrounds only: hide content, screenshot bg only, restore
+  # Skip these 3 commands for solid-color backgrounds
   agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='hidden')"
   agent-browser screenshot "./tmp/slides/${TITLE}/slide-${i}-bg.png" --json
   agent-browser eval "document.querySelectorAll('body > *').forEach(e => e.style.visibility='')"

--- a/document-skills/pptx/references/slide-templates.md
+++ b/document-skills/pptx/references/slide-templates.md
@@ -1,0 +1,220 @@
+# Slide Type Templates
+
+Complete HTML templates for each slide type. All follow [HTML rules](html-rules.md).
+
+## Common Structure
+
+Every slide shares this base:
+
+```html
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8">
+<style>
+html { background: #ffffff; }
+body {
+  width: 720pt; height: 405pt; margin: 0; padding: 0;
+  font-family: Arial, sans-serif;
+  display: flex; flex-direction: column;
+}
+.header { background: {{primaryColor}}; padding: 24pt 30pt; }
+.header h1 { color: #ffffff; font-size: 28pt; margin: 0; }
+.content { flex: 1; padding: 30pt; padding-bottom: 48pt; }
+</style>
+</head>
+<body>
+  <!-- slide content -->
+</body>
+</html>
+```
+
+## title
+
+Opening slide. Use gradient background, centered large text.
+
+```html
+<body style="background: linear-gradient(135deg, {{primaryColor}} 0%, {{secondaryColor}} 100%);">
+  <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%; text-align: center; padding: 60pt;">
+    <h1 style="color: #ffffff; font-size: 48pt; margin: 0 0 24pt 0;">Presentation Title</h1>
+    <p style="color: #ffffff; font-size: 24pt; margin: 0; opacity: 0.9;">Subtitle or tagline</p>
+  </div>
+</body>
+```
+
+## agenda
+
+Numbered list of topics.
+
+```html
+<div class="header"><h1>Agenda</h1></div>
+<div class="content">
+  <ol style="font-size: 18pt; color: #333333; margin: 0; padding-left: 30pt; line-height: 2.2;">
+    <li>Introduction and Context</li>
+    <li>Market Analysis</li>
+    <li>Product Strategy</li>
+    <li>Financial Projections</li>
+    <li>Next Steps</li>
+  </ol>
+</div>
+```
+
+## content
+
+Standard text with optional side content. Two-column layout with flex.
+
+```html
+<div class="header"><h1>Key Features</h1></div>
+<div class="content" style="display: flex; gap: 30pt;">
+  <div style="flex: 1;">
+    <h2 style="color: {{primaryColor}}; font-size: 20pt; margin: 0 0 16pt 0;">Overview</h2>
+    <ul style="font-size: 16pt; color: #333333; margin: 0; padding-left: 24pt;">
+      <li style="margin-bottom: 12pt;">Feature 1: Brief description</li>
+      <li style="margin-bottom: 12pt;">Feature 2: Brief description</li>
+      <li style="margin-bottom: 12pt;">Feature 3: Brief description</li>
+    </ul>
+  </div>
+  <div style="flex: 1;">
+    <div id="image1" class="placeholder" style="width: 100%; height: 250pt;"></div>
+  </div>
+</div>
+```
+
+## chart
+
+Data visualization with chart placeholder.
+
+```html
+<div class="header"><h1>Sales Performance</h1></div>
+<div class="content">
+  <div id="chart1" class="placeholder" style="width: 100%; height: 260pt;"></div>
+  <p style="font-size: 12pt; color: #999999; margin: 12pt 0 0 0;">Source: Internal sales data, Q1-Q4 2024</p>
+</div>
+```
+
+## table
+
+Structured data display.
+
+```html
+<div class="header"><h1>Quarterly Results</h1></div>
+<div class="content">
+  <div id="table1" class="placeholder" style="width: 100%; height: 260pt;"></div>
+  <p style="font-size: 12pt; color: #999999; margin: 12pt 0 0 0;">*All figures in millions</p>
+</div>
+```
+
+## comparison
+
+Side-by-side comparison with visual separation.
+
+```html
+<div class="header"><h1>Option A vs Option B</h1></div>
+<div class="content" style="display: flex; gap: 20pt;">
+  <div style="flex: 1; background: #f8f9fa; border-radius: 8pt; padding: 20pt;">
+    <h2 style="color: {{primaryColor}}; font-size: 20pt; margin: 0 0 16pt 0;">Option A</h2>
+    <ul style="font-size: 15pt; color: #333333; margin: 0; padding-left: 20pt;">
+      <li style="margin-bottom: 10pt;">Advantage 1</li>
+      <li style="margin-bottom: 10pt;">Advantage 2</li>
+      <li style="margin-bottom: 10pt;">Advantage 3</li>
+    </ul>
+  </div>
+  <div style="flex: 1; background: #f8f9fa; border-radius: 8pt; padding: 20pt;">
+    <h2 style="color: {{secondaryColor}}; font-size: 20pt; margin: 0 0 16pt 0;">Option B</h2>
+    <ul style="font-size: 15pt; color: #333333; margin: 0; padding-left: 20pt;">
+      <li style="margin-bottom: 10pt;">Advantage 1</li>
+      <li style="margin-bottom: 10pt;">Advantage 2</li>
+      <li style="margin-bottom: 10pt;">Advantage 3</li>
+    </ul>
+  </div>
+</div>
+```
+
+## timeline
+
+Horizontal timeline with milestones.
+
+```html
+<div class="header"><h1>Product Roadmap</h1></div>
+<div class="content" style="display: flex; justify-content: space-between; align-items: flex-start; gap: 16pt;">
+  <div style="flex: 1; text-align: center;">
+    <div style="background: {{primaryColor}}; color: white; border-radius: 50%; width: 56pt; height: 56pt; display: flex; align-items: center; justify-content: center; margin: 0 auto 12pt; font-size: 14pt;">
+      <p style="color: #ffffff; margin: 0; font-size: 14pt;">Q1</p>
+    </div>
+    <p style="font-weight: bold; font-size: 15pt; margin: 0 0 6pt 0;">Phase 1</p>
+    <p style="font-size: 13pt; color: #666666; margin: 0;">Initial launch and validation</p>
+  </div>
+  <div style="flex: 1; text-align: center;">
+    <div style="background: {{secondaryColor}}; color: white; border-radius: 50%; width: 56pt; height: 56pt; display: flex; align-items: center; justify-content: center; margin: 0 auto 12pt; font-size: 14pt;">
+      <p style="color: #ffffff; margin: 0; font-size: 14pt;">Q2</p>
+    </div>
+    <p style="font-weight: bold; font-size: 15pt; margin: 0 0 6pt 0;">Phase 2</p>
+    <p style="font-size: 13pt; color: #666666; margin: 0;">Feature expansion</p>
+  </div>
+  <div style="flex: 1; text-align: center;">
+    <div style="background: {{accentColor}}; color: white; border-radius: 50%; width: 56pt; height: 56pt; display: flex; align-items: center; justify-content: center; margin: 0 auto 12pt; font-size: 14pt;">
+      <p style="color: #ffffff; margin: 0; font-size: 14pt;">Q3</p>
+    </div>
+    <p style="font-weight: bold; font-size: 15pt; margin: 0 0 6pt 0;">Phase 3</p>
+    <p style="font-size: 13pt; color: #666666; margin: 0;">Market expansion</p>
+  </div>
+</div>
+```
+
+## conclusion
+
+Summary with call-to-action.
+
+```html
+<div class="header"><h1>Key Takeaways</h1></div>
+<div class="content">
+  <ul style="font-size: 18pt; color: #333333; margin: 0 0 30pt 0; padding-left: 24pt; line-height: 2.0;">
+    <li>Key point 1: Brief summary of main insight</li>
+    <li>Key point 2: Brief summary of second insight</li>
+    <li>Key point 3: Brief summary of third insight</li>
+  </ul>
+  <div style="padding: 20pt; background: #f0f4f8; border-left: 4pt solid {{accentColor}}; border-radius: 0 8pt 8pt 0;">
+    <p style="font-weight: bold; font-size: 18pt; margin: 0 0 8pt 0; color: {{primaryColor}};">Next Steps</p>
+    <p style="margin: 0; font-size: 16pt; color: #333333;">Contact us for a detailed discussion and implementation plan.</p>
+  </div>
+</div>
+```
+
+## Color Palettes
+
+Replace `{{primaryColor}}`, `{{secondaryColor}}`, `{{accentColor}}` with theme colors:
+
+| Theme | Primary | Secondary | Accent |
+|-------|---------|-----------|--------|
+| Corporate | #1A365D | #2B6CB0 | #E53E3E |
+| Modern | #2D3748 | #4A5568 | #38B2AC |
+| Vibrant | #553C9A | #6B46C1 | #ED8936 |
+| Nature | #22543D | #38A169 | #D69E2E |
+| Ocean | #1A365D | #3182CE | #63B3ED |
+
+## Layout Patterns
+
+```html
+<!-- Two equal columns -->
+<div style="display: flex; gap: 30pt;">
+  <div style="flex: 1;"><!-- Left --></div>
+  <div style="flex: 1;"><!-- Right --></div>
+</div>
+
+<!-- Content with sidebar (2:1) -->
+<div style="display: flex; gap: 30pt;">
+  <div style="flex: 2;"><!-- Main --></div>
+  <div style="flex: 1;"><!-- Sidebar --></div>
+</div>
+
+<!-- Three columns -->
+<div style="display: flex; gap: 20pt;">
+  <div style="flex: 1;"><!-- Col 1 --></div>
+  <div style="flex: 1;"><!-- Col 2 --></div>
+  <div style="flex: 1;"><!-- Col 3 --></div>
+</div>
+
+<!-- Centered content -->
+<div style="display: flex; justify-content: center; align-items: center; height: 100%;">
+  <div style="text-align: center; max-width: 500pt;"><!-- Content --></div>
+</div>
+```

--- a/document-skills/pptx/scripts/build-pptx.js
+++ b/document-skills/pptx/scripts/build-pptx.js
@@ -67,7 +67,7 @@ async function main() {
 
       // Lines (partial borders)
       if (el.type === 'line') {
-        slide.addShape(pptx.ShapeType.line, {
+        slide.addShape(pptx.ShapeType ? pptx.ShapeType.line : 'line', {
           x: el.x1, y: el.y1, w: el.x2 - el.x1, h: el.y2 - el.y1,
           line: { color: el.color, width: el.width }
         });
@@ -86,13 +86,18 @@ async function main() {
       // Shapes (div backgrounds/borders)
       if (el.type === 'shape') {
         const opts = { x: pos.x, y: pos.y, w: pos.w, h: pos.h };
-        if (el.rectRadius > 0) opts.shape = pptx.ShapeType.roundRect;
+        // Circle (border-radius >= 50%) → ellipse, otherwise roundRect
+        if (el.isCircle) {
+          opts.shape = pptx.ShapeType ? pptx.ShapeType.ellipse : 'ellipse';
+        } else if (el.rectRadius > 0) {
+          opts.shape = pptx.ShapeType ? pptx.ShapeType.roundRect : 'roundRect';
+          opts.rectRadius = el.rectRadius;
+        }
         if (el.fill) {
           opts.fill = { color: el.fill };
           if (el.transparency != null) opts.fill.transparency = el.transparency;
         }
         if (el.line) opts.line = el.line;
-        if (el.rectRadius > 0) opts.rectRadius = el.rectRadius;
         if (el.shadow) opts.shadow = el.shadow;
         slide.addText(el.text || '', opts);
         continue;

--- a/document-skills/pptx/scripts/build-pptx.js
+++ b/document-skills/pptx/scripts/build-pptx.js
@@ -9,7 +9,7 @@
 //   "slides": [
 //     {
 //       "extracted": { "background": {...}, "elements": [...], "placeholders": [...] },
-//       "bgImagePath": "./tmp/slides/slide-0-bg.png",  // optional, for gradient backgrounds
+//       "bgImagePath": "./tmp/slides/{title}/slide-0-bg.png",  // optional, for gradient backgrounds
 //       "placeholders": [                                // optional, placeholder content definitions
 //         { "id": "chart1", "type": "chart", "chartType": "bar", "chartData": {...} },
 //         { "id": "table1", "type": "table", "tableData": {...} },

--- a/document-skills/pptx/scripts/build-pptx.js
+++ b/document-skills/pptx/scripts/build-pptx.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+// build-pptx.js
+// Assemble PPTX from extracted DOM data.
+//
+// Usage: node build-pptx.js <config.json> [output.pptx]
+//
+// config.json format:
+// {
+//   "slides": [
+//     {
+//       "extracted": { "background": {...}, "elements": [...], "placeholders": [...] },
+//       "bgImagePath": "./tmp/slides/slide-0-bg.png",  // optional, for gradient backgrounds
+//       "placeholders": [                                // optional, placeholder content definitions
+//         { "id": "chart1", "type": "chart", "chartType": "bar", "chartData": {...} },
+//         { "id": "table1", "type": "table", "tableData": {...} },
+//         { "id": "image1", "type": "image", "imageData": { "url": "...", "alt": "..." } }
+//       ]
+//     }
+//   ]
+// }
+
+const fs = require('fs');
+const path = require('path');
+
+async function main() {
+  const configPath = process.argv[2];
+  const outputPath = process.argv[3] || './output.pptx';
+
+  if (!configPath) {
+    console.error('Usage: node build-pptx.js <config.json> [output.pptx]');
+    process.exit(1);
+  }
+
+  // Dynamic imports for ESM packages
+  const PptxGenJS = require('pptxgenjs');
+  let sharp;
+  try { sharp = require('sharp'); } catch { sharp = null; }
+
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  const pptx = new PptxGenJS();
+  pptx.layout = 'LAYOUT_16x9';
+
+  for (let i = 0; i < config.slides.length; i++) {
+    const slideConfig = config.slides[i];
+    const { extracted, bgImagePath, placeholders: pDefs } = slideConfig;
+    const slide = pptx.addSlide();
+
+    // --- Background ---
+    if (bgImagePath && fs.existsSync(bgImagePath)) {
+      slide.background = { path: path.resolve(bgImagePath) };
+    } else if (extracted.background.type === 'color') {
+      slide.background = { color: extracted.background.value };
+    }
+    // gradient without bgImagePath: caller must rasterize first
+
+    // --- Elements ---
+    for (const el of extracted.elements) {
+      const pos = el.position;
+
+      // Gradient divs (rasterized images)
+      if (el.type === 'gradientDiv') {
+        if (el.rasterizedPath && fs.existsSync(el.rasterizedPath)) {
+          slide.addImage({ path: path.resolve(el.rasterizedPath), x: pos.x, y: pos.y, w: pos.w, h: pos.h });
+        }
+        continue;
+      }
+
+      // Lines (partial borders)
+      if (el.type === 'line') {
+        slide.addShape(pptx.ShapeType.line, {
+          x: el.x1, y: el.y1, w: el.x2 - el.x1, h: el.y2 - el.y1,
+          line: { color: el.color, width: el.width }
+        });
+        continue;
+      }
+
+      // Images
+      if (el.type === 'image') {
+        const imgPath = el.src.startsWith('file://') ? el.src.replace('file://', '') : el.src;
+        try {
+          slide.addImage({ path: imgPath, x: pos.x, y: pos.y, w: pos.w, h: pos.h });
+        } catch (e) { console.error(`Failed to add image: ${e.message}`); }
+        continue;
+      }
+
+      // Shapes (div backgrounds/borders)
+      if (el.type === 'shape') {
+        const opts = { x: pos.x, y: pos.y, w: pos.w, h: pos.h };
+        if (el.rectRadius > 0) opts.shape = pptx.ShapeType.roundRect;
+        if (el.fill) {
+          opts.fill = { color: el.fill };
+          if (el.transparency != null) opts.fill.transparency = el.transparency;
+        }
+        if (el.line) opts.line = el.line;
+        if (el.rectRadius > 0) opts.rectRadius = el.rectRadius;
+        if (el.shadow) opts.shadow = el.shadow;
+        slide.addText(el.text || '', opts);
+        continue;
+      }
+
+      // Lists
+      if (el.type === 'list') {
+        const s = el.style;
+        slide.addText(el.items, {
+          x: pos.x, y: pos.y, w: pos.w, h: pos.h,
+          fontSize: s.fontSize, fontFace: s.fontFace, color: s.color,
+          align: s.align, valign: 'top',
+          lineSpacing: s.lineSpacing,
+          paraSpaceBefore: s.paraSpaceBefore, paraSpaceAfter: s.paraSpaceAfter,
+          margin: s.margin
+        });
+        continue;
+      }
+
+      // Code blocks (PRE)
+      if (el.type === 'pre') {
+        const s = el.style;
+        const opts = {
+          x: pos.x, y: pos.y, w: pos.w, h: pos.h,
+          fontSize: s.fontSize, fontFace: s.fontFace, color: s.color,
+          align: s.align, valign: 'top',
+          lineSpacing: s.lineSpacing,
+          paraSpaceBefore: s.paraSpaceBefore, paraSpaceAfter: s.paraSpaceAfter,
+          margin: s.margin, inset: 0
+        };
+        if (s.transparency != null) opts.transparency = s.transparency;
+        if (s.shadow) opts.shadow = s.shadow;
+        slide.addText(el.text, opts);
+        continue;
+      }
+
+      // Text elements (p, h1-h6)
+      const s = el.style;
+      // Single-line width adjustment
+      const lineH = s.lineSpacing || s.fontSize * 1.2;
+      const isSingleLine = pos.h <= (lineH * 1.5) / 72;
+      let adjX = pos.x, adjW = pos.w;
+      if (isSingleLine) {
+        const inc = pos.w * 0.02;
+        if (s.align === 'center') { adjX -= inc / 2; adjW += inc; }
+        else if (s.align === 'right') { adjX -= inc; adjW += inc; }
+        else { adjW += inc; }
+      }
+
+      const opts = {
+        x: adjX, y: pos.y, w: adjW, h: pos.h,
+        fontSize: s.fontSize, fontFace: s.fontFace || 'Arial', color: s.color,
+        bold: s.bold, italic: s.italic, underline: s.underline,
+        valign: 'top',
+        lineSpacing: s.lineSpacing,
+        paraSpaceBefore: s.paraSpaceBefore, paraSpaceAfter: s.paraSpaceAfter,
+        inset: 0
+      };
+      if (s.align) opts.align = s.align;
+      if (s.margin) opts.margin = s.margin;
+      if (s.rotate != null) opts.rotate = s.rotate;
+      if (s.transparency != null) opts.transparency = s.transparency;
+      if (s.shadow) opts.shadow = s.shadow;
+
+      slide.addText(el.text, opts);
+    }
+
+    // --- Placeholders ---
+    for (const pDef of pDefs || []) {
+      const pos = extracted.placeholders.find(p => p.id === pDef.id);
+      if (!pos) { console.warn(`No position for placeholder "${pDef.id}"`); continue; }
+      await addPlaceholder(slide, pptx, pDef, pos, sharp);
+    }
+  }
+
+  // Write output
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+
+  const buffer = await pptx.write({ outputType: 'nodebuffer' });
+  fs.writeFileSync(outputPath, buffer);
+  console.log(`PPTX saved: ${outputPath} (${config.slides.length} slides)`);
+}
+
+async function addPlaceholder(slide, pptx, def, pos, sharp) {
+  const { x, y, w, h } = pos;
+
+  if (def.type === 'chart' && def.chartData) {
+    const chartTypeMap = {
+      bar: pptx.ChartType.bar, line: pptx.ChartType.line, pie: pptx.ChartType.pie,
+      doughnut: pptx.ChartType.doughnut, scatter: pptx.ChartType.scatter
+    };
+    const chartData = def.chartData.series.map(s => ({ name: s.name, labels: s.labels, values: s.values }));
+    const opts = {
+      x, y, w, h,
+      showTitle: !!def.chartData.options?.title,
+      title: def.chartData.options?.title || '',
+      showLegend: def.chartData.options?.showLegend ?? true,
+      showCatAxisTitle: !!def.chartData.options?.categoryAxisTitle,
+      catAxisTitle: def.chartData.options?.categoryAxisTitle || '',
+      showValAxisTitle: !!def.chartData.options?.valueAxisTitle,
+      valAxisTitle: def.chartData.options?.valueAxisTitle || ''
+    };
+    if (def.chartData.options?.colors) opts.chartColors = def.chartData.options.colors;
+    slide.addChart(chartTypeMap[def.chartType] || pptx.ChartType.bar, chartData, opts);
+  }
+
+  else if (def.type === 'table' && def.tableData) {
+    const rows = [];
+    rows.push(def.tableData.headers.map(header => ({
+      text: header,
+      options: {
+        bold: true,
+        fill: { color: def.tableData.options?.headerBackground || '4472C4' },
+        color: def.tableData.options?.headerColor || 'FFFFFF'
+      }
+    })));
+    for (const row of def.tableData.rows) {
+      rows.push(row.map(cell => ({ text: cell })));
+    }
+    slide.addTable(rows, { x, y, w, border: { pt: 1, color: 'CCCCCC' }, fontFace: 'Arial', fontSize: 12 });
+  }
+
+  else if (def.type === 'image' && def.imageData) {
+    try {
+      const resp = await fetch(def.imageData.url);
+      const buf = Buffer.from(await resp.arrayBuffer());
+
+      if (sharp) {
+        const meta = await sharp(buf).metadata();
+        if (meta.width && meta.height) {
+          const imgAsp = meta.width / meta.height;
+          const contAsp = w / h;
+          let fx, fy, fw, fh;
+          if (imgAsp > contAsp) { fw = w; fh = w / imgAsp; fx = x; fy = y + (h - fh) / 2; }
+          else { fh = h; fw = h * imgAsp; fx = x + (w - fw) / 2; fy = y; }
+          const mime = meta.format === 'png' ? 'image/png' : 'image/jpeg';
+          slide.addImage({ data: `data:${mime};base64,${buf.toString('base64')}`, x: fx, y: fy, w: fw, h: fh });
+          return;
+        }
+      }
+      // Fallback without sharp
+      slide.addImage({ data: `data:image/jpeg;base64,${buf.toString('base64')}`, x, y, w, h });
+    } catch (e) {
+      console.error(`Failed to add image "${def.id}": ${e.message}`);
+    }
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/document-skills/pptx/scripts/build-pptx.js
+++ b/document-skills/pptx/scripts/build-pptx.js
@@ -170,7 +170,7 @@ async function main() {
 
   // Write output
   const outputDir = path.dirname(outputPath);
-  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+  fs.mkdirSync(outputDir, { recursive: true });
 
   const buffer = await pptx.write({ outputType: 'nodebuffer' });
   fs.writeFileSync(outputPath, buffer);

--- a/document-skills/pptx/scripts/extract-dom.js
+++ b/document-skills/pptx/scripts/extract-dom.js
@@ -16,9 +16,9 @@
   const pxToPoints = s => parseFloat(s) * PT_PER_PX;
 
   const rgbToHex = rgb => {
-    if (rgb === 'rgba(0, 0, 0, 0)' || rgb === 'transparent') return 'FFFFFF';
+    if (rgb === 'rgba(0, 0, 0, 0)' || rgb === 'transparent') return null;
     const m = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-    return m ? m.slice(1).map(n => parseInt(n).toString(16).padStart(2, '0')).join('') : 'FFFFFF';
+    return m ? m.slice(1).map(n => parseInt(n).toString(16).padStart(2, '0')).join('') : null;
   };
 
   const extractAlpha = rgb => {
@@ -154,7 +154,7 @@
   const hasGradient = bgImage && (bgImage.includes('linear-gradient') || bgImage.includes('radial-gradient'));
   const background = hasGradient
     ? { type: 'gradient', css: bgImage }
-    : { type: 'color', value: rgbToHex(bodyStyle.backgroundColor) };
+    : { type: 'color', value: rgbToHex(bodyStyle.backgroundColor) || 'FFFFFF' };
 
   // Elements
   const elements = [];
@@ -162,7 +162,7 @@
   const textTags = ['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI', 'PRE'];
   const processed = new Set();
 
-  document.querySelectorAll('*').forEach(el => {
+  document.querySelectorAll('div, p, h1, h2, h3, h4, h5, h6, ul, ol, li, pre, img, .placeholder').forEach(el => {
     if (processed.has(el)) return;
 
     // Validate: text elements must not have bg/border/shadow (except PRE)
@@ -178,7 +178,7 @@
     }
 
     // Placeholders
-    if (el.className && typeof el.className === 'string' && el.className.includes('placeholder')) {
+    if (el.classList && el.classList.contains('placeholder')) {
       const rect = el.getBoundingClientRect();
       if (rect.width === 0 || rect.height === 0) { errors.push('Placeholder "' + (el.id || 'unnamed') + '" has zero size'); }
       else { placeholders.push({ id: el.id || 'placeholder-' + placeholders.length, x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) }); }

--- a/document-skills/pptx/scripts/extract-dom.js
+++ b/document-skills/pptx/scripts/extract-dom.js
@@ -227,13 +227,15 @@
         const shadow = parseBoxShadow(cs.boxShadow);
         const radiusVal = parseFloat(cs.borderRadius);
         if (hasBg || hasUniformBorder) {
+          const isCircle = cs.borderRadius.includes('%') && radiusVal >= 50;
           elements.push({
             type: 'shape',
             position: { x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) },
             fill: hasBg ? rgbToHex(cs.backgroundColor) : null,
             transparency: hasBg ? extractAlpha(cs.backgroundColor) : null,
             line: hasUniformBorder ? { color: rgbToHex(cs.borderColor), width: pxToPoints(cs.borderWidth), dashType: getBorderDashType(cs.borderStyle) } : null,
-            rectRadius: radiusVal > 0 ? (cs.borderRadius.includes('%') ? (radiusVal >= 50 ? 1 : radiusVal / 100 * pxToInch(Math.min(rect.width, rect.height))) : radiusVal / PX_PER_IN) : 0,
+            isCircle,
+            rectRadius: isCircle ? 0 : (radiusVal > 0 ? (cs.borderRadius.includes('%') ? radiusVal / 100 * pxToInch(Math.min(rect.width, rect.height)) : radiusVal / PX_PER_IN) : 0),
             shadow
           });
         }

--- a/document-skills/pptx/scripts/extract-dom.js
+++ b/document-skills/pptx/scripts/extract-dom.js
@@ -1,0 +1,420 @@
+// extract-dom.js
+// Run via: cat extract-dom.js | agent-browser eval --stdin --json
+//
+// Returns JSON string with:
+//   { background, elements, placeholders, errors }
+//
+// background: { type: 'color'|'gradient', value?: hex, css?: gradientCSS }
+// elements[]: { type, position: {x,y,w,h in inches}, style, text|items|src }
+// placeholders[]: { id, x, y, w, h } (inches)
+// errors[]: validation error strings
+
+(() => {
+  const PT_PER_PX = 0.75;
+  const PX_PER_IN = 96;
+  const pxToInch = px => px / PX_PER_IN;
+  const pxToPoints = s => parseFloat(s) * PT_PER_PX;
+
+  const rgbToHex = rgb => {
+    if (rgb === 'rgba(0, 0, 0, 0)' || rgb === 'transparent') return 'FFFFFF';
+    const m = rgb.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    return m ? m.slice(1).map(n => parseInt(n).toString(16).padStart(2, '0')).join('') : 'FFFFFF';
+  };
+
+  const extractAlpha = rgb => {
+    const m = rgb.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\)/);
+    return m ? Math.round((1 - parseFloat(m[1])) * 100) : null;
+  };
+
+  const SINGLE_WEIGHT_FONTS = ['impact'];
+  const shouldSkipBold = ff => {
+    if (!ff) return false;
+    return SINGLE_WEIGHT_FONTS.includes(ff.toLowerCase().replace(/['"]/g, '').split(',')[0].trim());
+  };
+
+  const getBorderDashType = style => {
+    if (style === 'dashed') return 'dash';
+    if (style === 'dotted') return 'dot';
+    if (style === 'none' || style === 'hidden') return null;
+    return 'solid';
+  };
+
+  const parseTextShadow = ts => {
+    if (!ts || ts === 'none') return null;
+    const re = /^(-?\d+(?:\.\d+)?(?:px|pt|em)?)\s+(-?\d+(?:\.\d+)?(?:px|pt|em)?)\s*(-?\d+(?:\.\d+)?(?:px|pt|em)?)?\s*(.*)$/;
+    const m = ts.match(re);
+    if (!m) return null;
+    const hOff = parseFloat(m[1]) || 0;
+    const vOff = parseFloat(m[2]) || 0;
+    const blur = parseFloat(m[3]) || 0;
+    const colorStr = m[4] || 'rgba(0,0,0,0.5)';
+    const angle = ((Math.round(Math.atan2(vOff, hOff) * 180 / Math.PI) % 360) + 360) % 360;
+    const dist = Math.sqrt(hOff * hOff + vOff * vOff);
+    const color = rgbToHex(colorStr);
+    const alphaM = colorStr.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\)/);
+    return { type: 'outer', angle, blur: blur * PT_PER_PX, offset: dist * PT_PER_PX, color, opacity: alphaM ? parseFloat(alphaM[1]) : 1 };
+  };
+
+  const parseBoxShadow = bs => {
+    if (!bs || bs === 'none' || bs.includes('inset')) return null;
+    const colorM = bs.match(/rgba?\([^)]+\)/);
+    const parts = bs.match(/([-\d.]+)(px|pt)/g);
+    if (!parts || parts.length < 2) return null;
+    const ox = parseFloat(parts[0]), oy = parseFloat(parts[1]);
+    const blur = parts.length > 2 ? parseFloat(parts[2]) : 0;
+    let angle = 0;
+    if (ox !== 0 || oy !== 0) { angle = Math.atan2(oy, ox) * 180 / Math.PI; if (angle < 0) angle += 360; }
+    const offset = Math.sqrt(ox * ox + oy * oy) * PT_PER_PX;
+    let opacity = 0.5;
+    if (colorM) { const om = colorM[0].match(/[\d.]+\)$/); if (om) opacity = parseFloat(om[0].replace(')', '')); }
+    return { type: 'outer', angle: Math.round(angle), blur: blur * PT_PER_PX, color: colorM ? rgbToHex(colorM[0]) : '000000', offset, opacity };
+  };
+
+  const applyTextTransform = (text, tt) => {
+    if (tt === 'uppercase') return text.toUpperCase();
+    if (tt === 'lowercase') return text.toLowerCase();
+    if (tt === 'capitalize') return text.replace(/\b\w/g, c => c.toUpperCase());
+    return text;
+  };
+
+  const getRotation = (transform, writingMode) => {
+    let angle = 0;
+    if (writingMode === 'vertical-rl') angle = 90;
+    else if (writingMode === 'vertical-lr') angle = 270;
+    if (transform && transform !== 'none') {
+      const rm = transform.match(/rotate\((-?\d+(?:\.\d+)?)deg\)/);
+      if (rm) angle += parseFloat(rm[1]);
+      else {
+        const mm = transform.match(/matrix\(([^)]+)\)/);
+        if (mm) { const v = mm[1].split(',').map(parseFloat); angle += Math.round(Math.atan2(v[1], v[0]) * 180 / Math.PI); }
+      }
+    }
+    angle = angle % 360;
+    if (angle < 0) angle += 360;
+    return angle === 0 ? null : angle;
+  };
+
+  const getPositionAndSize = (el, rect, rotation) => {
+    if (rotation === null) return { x: rect.left, y: rect.top, w: rect.width, h: rect.height };
+    const isVertical = rotation === 90 || rotation === 270;
+    if (isVertical) {
+      const cx = rect.left + rect.width / 2, cy = rect.top + rect.height / 2;
+      return { x: cx - rect.height / 2, y: cy - rect.width / 2, w: rect.height, h: rect.width };
+    }
+    const cx = rect.left + rect.width / 2, cy = rect.top + rect.height / 2;
+    return { x: cx - el.offsetWidth / 2, y: cy - el.offsetHeight / 2, w: el.offsetWidth, h: el.offsetHeight };
+  };
+
+  const parseInlineFormatting = (element, baseOptions = {}) => {
+    const runs = [];
+    element.childNodes.forEach(node => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.textContent.replace(/\s+/g, ' ');
+        runs.push({ text, options: { ...baseOptions } });
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        let text = node.textContent.trim();
+        if (text) {
+          const options = { ...baseOptions };
+          const cs = window.getComputedStyle(node);
+          if ((node.tagName === 'B' || node.tagName === 'STRONG') && !shouldSkipBold(cs.fontFamily)) options.bold = true;
+          if (node.tagName === 'I' || node.tagName === 'EM') options.italic = true;
+          if (node.tagName === 'U') options.underline = true;
+          if (['SPAN','B','STRONG','I','EM','U'].includes(node.tagName)) {
+            if ((cs.fontWeight === 'bold' || parseInt(cs.fontWeight) >= 600) && !shouldSkipBold(cs.fontFamily)) options.bold = true;
+            if (cs.fontStyle === 'italic') options.italic = true;
+            if (cs.textDecoration && cs.textDecoration.includes('underline')) options.underline = true;
+            if (cs.color && cs.color !== 'rgb(0, 0, 0)') { options.color = rgbToHex(cs.color); const t = extractAlpha(cs.color); if (t !== null) options.transparency = t; }
+            if (cs.fontSize) options.fontSize = pxToPoints(cs.fontSize);
+            if (cs.textTransform && cs.textTransform !== 'none') text = applyTextTransform(text, cs.textTransform);
+          }
+          runs.push({ text, options });
+        }
+      }
+    });
+    if (runs.length > 0) { runs[0].text = runs[0].text.replace(/^\s+/, ''); runs[runs.length - 1].text = runs[runs.length - 1].text.replace(/\s+$/, ''); }
+    return runs.filter(r => r.text.length > 0);
+  };
+
+  // --- Main extraction ---
+  const body = document.body;
+  const bodyStyle = window.getComputedStyle(body);
+  const errors = [];
+
+  // Overflow check
+  const bw = parseFloat(bodyStyle.width), bh = parseFloat(bodyStyle.height);
+  const owX = Math.max(0, body.scrollWidth - bw - 1), owY = Math.max(0, body.scrollHeight - bh - 1);
+  if (owX > 0) errors.push('Horizontal overflow: ' + (owX * PT_PER_PX).toFixed(1) + 'pt');
+  if (owY > 0) errors.push('Vertical overflow: ' + (owY * PT_PER_PX).toFixed(1) + 'pt (leave 0.5in bottom margin)');
+
+  // <br> check
+  if (document.querySelectorAll('br').length > 0) errors.push('<br> tags found — use separate <p>/<li> elements');
+
+  // Background
+  const bgImage = bodyStyle.backgroundImage;
+  const hasGradient = bgImage && (bgImage.includes('linear-gradient') || bgImage.includes('radial-gradient'));
+  const background = hasGradient
+    ? { type: 'gradient', css: bgImage }
+    : { type: 'color', value: rgbToHex(bodyStyle.backgroundColor) };
+
+  // Elements
+  const elements = [];
+  const placeholders = [];
+  const textTags = ['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI', 'PRE'];
+  const processed = new Set();
+
+  document.querySelectorAll('*').forEach(el => {
+    if (processed.has(el)) return;
+
+    // Validate: text elements must not have bg/border/shadow (except PRE)
+    if (textTags.includes(el.tagName) && el.tagName !== 'PRE') {
+      const cs = window.getComputedStyle(el);
+      const hasBg = cs.backgroundColor && cs.backgroundColor !== 'rgba(0, 0, 0, 0)';
+      const hasBorder = ['borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth'].some(p => parseFloat(cs[p]) > 0);
+      const hasShadow = cs.boxShadow && cs.boxShadow !== 'none';
+      if (hasBg || hasBorder || hasShadow) {
+        errors.push('<' + el.tagName.toLowerCase() + '> has ' + (hasBg ? 'background' : hasBorder ? 'border' : 'shadow') + ' — only <div> supports these');
+        return;
+      }
+    }
+
+    // Placeholders
+    if (el.className && typeof el.className === 'string' && el.className.includes('placeholder')) {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) { errors.push('Placeholder "' + (el.id || 'unnamed') + '" has zero size'); }
+      else { placeholders.push({ id: el.id || 'placeholder-' + placeholders.length, x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) }); }
+      processed.add(el);
+      return;
+    }
+
+    // Images
+    if (el.tagName === 'IMG') {
+      const rect = el.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        elements.push({ type: 'image', src: el.src, position: { x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) } });
+        processed.add(el);
+      }
+      return;
+    }
+
+    // DIVs → shapes
+    if (el.tagName === 'DIV') {
+      const cs = window.getComputedStyle(el);
+      const hasBg = cs.backgroundColor && cs.backgroundColor !== 'rgba(0, 0, 0, 0)';
+      const borders = ['borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth'].map(p => parseFloat(cs[p]) || 0);
+      const hasBorder = borders.some(b => b > 0);
+      const hasUniformBorder = hasBorder && borders.every(b => b === borders[0]);
+      const divBg = cs.backgroundImage;
+      const divGradient = divBg && (divBg.includes('linear-gradient') || divBg.includes('radial-gradient'));
+
+      // Validate: unwrapped text in div
+      for (const node of el.childNodes) {
+        if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
+          errors.push('DIV contains unwrapped text "' + node.textContent.trim().substring(0, 50) + '" — wrap in <p>/<h1>-<h6>');
+        }
+      }
+
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+
+      if (divGradient) {
+        elements.push({
+          type: 'gradientDiv', elementId: el.id || 'gradient-' + elements.length, css: divBg,
+          position: { x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) }
+        });
+      }
+
+      if (hasBg || hasBorder) {
+        const shadow = parseBoxShadow(cs.boxShadow);
+        const radiusVal = parseFloat(cs.borderRadius);
+        if (hasBg || hasUniformBorder) {
+          elements.push({
+            type: 'shape',
+            position: { x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) },
+            fill: hasBg ? rgbToHex(cs.backgroundColor) : null,
+            transparency: hasBg ? extractAlpha(cs.backgroundColor) : null,
+            line: hasUniformBorder ? { color: rgbToHex(cs.borderColor), width: pxToPoints(cs.borderWidth), dashType: getBorderDashType(cs.borderStyle) } : null,
+            rectRadius: radiusVal > 0 ? (cs.borderRadius.includes('%') ? (radiusVal >= 50 ? 1 : radiusVal / 100 * pxToInch(Math.min(rect.width, rect.height))) : radiusVal / PX_PER_IN) : 0,
+            shadow
+          });
+        }
+
+        // Partial borders → individual lines
+        if (hasBorder && !hasUniformBorder) {
+          const x = pxToInch(rect.left), y = pxToInch(rect.top), w = pxToInch(rect.width), h = pxToInch(rect.height);
+          if (borders[0] > 0) elements.push({ type: 'line', x1: x, y1: y, x2: x + w, y2: y, width: pxToPoints(cs.borderTopWidth + 'px'), color: rgbToHex(cs.borderTopColor) });
+          if (borders[1] > 0) elements.push({ type: 'line', x1: x + w, y1: y, x2: x + w, y2: y + h, width: pxToPoints(cs.borderRightWidth + 'px'), color: rgbToHex(cs.borderRightColor) });
+          if (borders[2] > 0) elements.push({ type: 'line', x1: x, y1: y + h, x2: x + w, y2: y + h, width: pxToPoints(cs.borderBottomWidth + 'px'), color: rgbToHex(cs.borderBottomColor) });
+          if (borders[3] > 0) elements.push({ type: 'line', x1: x, y1: y, x2: x, y2: y + h, width: pxToPoints(cs.borderLeftWidth + 'px'), color: rgbToHex(cs.borderLeftColor) });
+        }
+
+        processed.add(el);
+        return;
+      }
+    }
+
+    // Lists (UL/OL)
+    if (el.tagName === 'UL' || el.tagName === 'OL') {
+      if (el.parentElement && el.parentElement.tagName === 'LI') { processed.add(el); return; }
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return;
+
+      const ulCs = window.getComputedStyle(el);
+      const textIndent = pxToPoints(ulCs.paddingLeft) * 0.5;
+      const items = [];
+
+      const processItems = (listEl, level) => {
+        const lis = Array.from(listEl.children).filter(c => c.tagName === 'LI');
+        lis.forEach((li, idx) => {
+          const isLast = idx === lis.length - 1;
+          let text = '';
+          for (const node of li.childNodes) {
+            if (node.nodeType === Node.TEXT_NODE) text += node.textContent;
+            else if (node.nodeType === Node.ELEMENT_NODE && !['UL', 'OL'].includes(node.tagName)) text += node.textContent;
+          }
+          text = text.trim().replace(/^[•\-\*▪▸]\s*/, '');
+          const nested = Array.from(li.children).find(c => c.tagName === 'UL' || c.tagName === 'OL');
+
+          // Check for inline formatting
+          const hasFormatting = Array.from(li.children).some(c => ['B', 'I', 'U', 'STRONG', 'EM', 'SPAN'].includes(c.tagName));
+          if (hasFormatting && text) {
+            const tempDiv = document.createElement('div');
+            for (const node of li.childNodes) {
+              if (node.nodeType === Node.TEXT_NODE) tempDiv.appendChild(node.cloneNode());
+              else if (node.nodeType === Node.ELEMENT_NODE && !['UL', 'OL'].includes(node.tagName)) tempDiv.appendChild(node.cloneNode(true));
+            }
+            const runs = parseInlineFormatting(tempDiv, { breakLine: false });
+            if (runs.length > 0) {
+              runs[0].text = runs[0].text.replace(/^[•\-\*▪▸]\s*/, '');
+              runs[0].options.bullet = { indent: textIndent };
+              runs[0].options.indentLevel = level;
+              runs[runs.length - 1].options.breakLine = !!nested || !isLast;
+            }
+            items.push(...runs);
+          } else if (text) {
+            items.push({ text, options: { bullet: { indent: textIndent }, indentLevel: level, breakLine: !!nested || !isLast } });
+          }
+
+          if (nested) { processed.add(nested); processItems(nested, level + 1); }
+          processed.add(li);
+        });
+      };
+      processItems(el, 0);
+
+      const firstLi = el.querySelector('li');
+      const liCs = window.getComputedStyle(firstLi || el);
+      elements.push({
+        type: 'list', items,
+        position: { x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) },
+        style: {
+          fontSize: pxToPoints(liCs.fontSize),
+          fontFace: liCs.fontFamily.split(',')[0].replace(/['"]/g, '').trim(),
+          color: rgbToHex(liCs.color), transparency: extractAlpha(liCs.color),
+          align: liCs.textAlign === 'start' ? 'left' : liCs.textAlign,
+          lineSpacing: liCs.lineHeight !== 'normal' ? pxToPoints(liCs.lineHeight) : null,
+          paraSpaceBefore: 0, paraSpaceAfter: pxToPoints(liCs.marginBottom),
+          margin: [textIndent * 0.5, 0, 0, 0]
+        }
+      });
+      processed.add(el);
+      return;
+    }
+
+    // PRE (code blocks)
+    if (el.tagName === 'PRE') {
+      const rect = el.getBoundingClientRect();
+      const text = el.textContent;
+      if (rect.width === 0 || rect.height === 0 || !text) return;
+      const cs = window.getComputedStyle(el);
+      const hasBg = cs.backgroundColor && cs.backgroundColor !== 'rgba(0, 0, 0, 0)';
+      const hasBorder = parseFloat(cs.borderWidth) > 0;
+
+      if (hasBg || hasBorder) {
+        elements.push({
+          type: 'shape', text: '',
+          position: { x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) },
+          fill: hasBg ? rgbToHex(cs.backgroundColor) : null, transparency: hasBg ? extractAlpha(cs.backgroundColor) : null,
+          line: hasBorder ? { color: rgbToHex(cs.borderColor), width: pxToPoints(cs.borderWidth), dashType: getBorderDashType(cs.borderStyle) } : null,
+          rectRadius: parseFloat(cs.borderRadius) > 0 ? parseFloat(cs.borderRadius) / PX_PER_IN : 0,
+          shadow: parseBoxShadow(cs.boxShadow)
+        });
+      }
+
+      const style = {
+        fontSize: pxToPoints(cs.fontSize), fontFace: 'Courier New', color: rgbToHex(cs.color),
+        align: 'left', lineSpacing: pxToPoints(cs.lineHeight), paraSpaceBefore: 0, paraSpaceAfter: 0,
+        margin: [pxToPoints(cs.paddingLeft), pxToPoints(cs.paddingRight), pxToPoints(cs.paddingBottom), pxToPoints(cs.paddingTop)]
+      };
+      const tr = extractAlpha(cs.color); if (tr !== null) style.transparency = tr;
+      const ts = parseTextShadow(cs.textShadow); if (ts) style.shadow = ts;
+
+      elements.push({ type: 'pre', text, position: { x: pxToInch(rect.left), y: pxToInch(rect.top), w: pxToInch(rect.width), h: pxToInch(rect.height) }, style });
+      processed.add(el);
+      return;
+    }
+
+    // Text elements (P, H1-H6)
+    if (!textTags.includes(el.tagName)) return;
+    const rect = el.getBoundingClientRect();
+    const text = el.textContent.trim();
+    if (rect.width === 0 || rect.height === 0 || !text) return;
+
+    // Validate manual bullets
+    if (el.tagName !== 'LI' && /^[•\-\*▪▸○●◆◇■□]\s/.test(text.trimStart())) {
+      errors.push('<' + el.tagName.toLowerCase() + '> has manual bullet "' + text.substring(0, 20) + '..." — use <ul>/<ol>');
+      return;
+    }
+
+    const cs = window.getComputedStyle(el);
+    const rotation = getRotation(cs.transform, cs.writingMode);
+    const pos = getPositionAndSize(el, rect, rotation);
+
+    const baseStyle = {
+      fontSize: pxToPoints(cs.fontSize),
+      fontFace: cs.fontFamily.split(',')[0].replace(/['"]/g, '').trim(),
+      color: rgbToHex(cs.color),
+      align: cs.textAlign === 'start' ? 'left' : cs.textAlign,
+      lineSpacing: pxToPoints(cs.lineHeight),
+      paraSpaceBefore: pxToPoints(cs.marginTop),
+      paraSpaceAfter: pxToPoints(cs.marginBottom),
+      margin: [pxToPoints(cs.paddingLeft), pxToPoints(cs.paddingRight), pxToPoints(cs.paddingBottom), pxToPoints(cs.paddingTop)]
+    };
+    const tr = extractAlpha(cs.color); if (tr !== null) baseStyle.transparency = tr;
+    if (rotation !== null) baseStyle.rotate = rotation;
+    const ts = parseTextShadow(cs.textShadow); if (ts) baseStyle.shadow = ts;
+
+    const hasFormatting = el.querySelector('b, i, u, strong, em, span');
+    if (hasFormatting) {
+      const runs = parseInlineFormatting(el);
+      const adjustedStyle = { ...baseStyle };
+      if (adjustedStyle.lineSpacing) {
+        const maxFs = Math.max(adjustedStyle.fontSize, ...runs.map(r => r.options?.fontSize || 0));
+        if (maxFs > adjustedStyle.fontSize) adjustedStyle.lineSpacing = maxFs * (adjustedStyle.lineSpacing / adjustedStyle.fontSize);
+      }
+      const tt = cs.textTransform;
+      const transformed = runs.map(r => ({ ...r, text: applyTextTransform(r.text, tt) }));
+      elements.push({ type: el.tagName.toLowerCase(), text: transformed, position: { x: pxToInch(pos.x), y: pxToInch(pos.y), w: pxToInch(pos.w), h: pxToInch(pos.h) }, style: adjustedStyle });
+    } else {
+      const isBold = cs.fontWeight === 'bold' || parseInt(cs.fontWeight) >= 600;
+      elements.push({
+        type: el.tagName.toLowerCase(), text: applyTextTransform(text, cs.textTransform),
+        position: { x: pxToInch(pos.x), y: pxToInch(pos.y), w: pxToInch(pos.w), h: pxToInch(pos.h) },
+        style: { ...baseStyle, bold: isBold && !shouldSkipBold(cs.fontFamily), italic: cs.fontStyle === 'italic', underline: cs.textDecoration.includes('underline') }
+      });
+    }
+    processed.add(el);
+  });
+
+  // Bottom margin validation
+  const slideHeightIn = bh / PX_PER_IN;
+  for (const el of elements) {
+    if (['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'list'].includes(el.type)) {
+      const bottom = el.position.y + el.position.h;
+      if (slideHeightIn - bottom < 0.5 && (el.style?.fontSize || 0) > 12) {
+        const preview = typeof el.text === 'string' ? el.text.substring(0, 50) : '(list)';
+        errors.push('Text "' + preview + '" too close to bottom (' + (slideHeightIn - bottom).toFixed(2) + 'in, need 0.5in)');
+      }
+    }
+  }
+
+  return JSON.stringify({ background, elements, placeholders, errors });
+})()

--- a/document-skills/pptx/scripts/render-placeholders.js
+++ b/document-skills/pptx/scripts/render-placeholders.js
@@ -1,0 +1,136 @@
+// render-placeholders.js
+// Render chart/table/image content into placeholder divs for visual preview.
+// Run via: cat render-placeholders.js | agent-browser eval --stdin --json
+//
+// Prerequisites (run before this script):
+//   1. Set placeholder data:
+//      agent-browser eval "window.__PLACEHOLDERS__ = <JSON array>"
+//   2. Inject Chart.js CDN:
+//      agent-browser eval "var s=document.createElement('script');s.src='https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';document.head.appendChild(s)"
+//   3. Wait for Chart.js to load:
+//      agent-browser wait 2000
+//
+// Returns JSON: { rendered: number, errors: string[] }
+
+(() => {
+  const placeholders = window.__PLACEHOLDERS__;
+  if (!placeholders || !Array.isArray(placeholders)) {
+    return JSON.stringify({ rendered: 0, errors: ['window.__PLACEHOLDERS__ not set or not an array'] });
+  }
+
+  const errors = [];
+  let rendered = 0;
+
+  for (const p of placeholders) {
+    const el = document.getElementById(p.id);
+    if (!el) {
+      errors.push('Element #' + p.id + ' not found');
+      continue;
+    }
+
+    try {
+      if (p.type === 'chart' && p.chartData) {
+        renderChart(el, p);
+        rendered++;
+      } else if (p.type === 'table' && p.tableData) {
+        renderTable(el, p);
+        rendered++;
+      } else if (p.type === 'image' && p.imageData) {
+        renderImage(el, p);
+        rendered++;
+      }
+    } catch (e) {
+      errors.push(p.id + ': ' + (e.message || String(e)));
+    }
+  }
+
+  return JSON.stringify({ rendered, errors });
+
+  function renderChart(el, p) {
+    const Chart = window.Chart;
+    if (!Chart) {
+      errors.push('Chart.js not loaded — did you inject the CDN and wait?');
+      return;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    el.innerHTML = '';
+    el.appendChild(canvas);
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const chartData = p.chartData;
+    const typeMap = { bar: 'bar', line: 'line', pie: 'pie', doughnut: 'doughnut', scatter: 'scatter' };
+    const labels = chartData.series[0] ? chartData.series[0].labels : [];
+    const datasets = chartData.series.map((series, i) => {
+      const ds = { label: series.name, data: series.values };
+      if (chartData.options && chartData.options.colors && chartData.options.colors[i]) {
+        ds.backgroundColor = '#' + chartData.options.colors[i];
+        ds.borderColor = '#' + chartData.options.colors[i];
+      }
+      return ds;
+    });
+
+    new Chart(ctx, {
+      type: typeMap[p.chartType || 'bar'] || 'bar',
+      data: { labels: labels, datasets: datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        animation: false,
+        plugins: {
+          title: {
+            display: !!(chartData.options && chartData.options.title),
+            text: (chartData.options && chartData.options.title) || ''
+          },
+          legend: {
+            display: chartData.options ? (chartData.options.showLegend !== false) : true
+          }
+        }
+      }
+    });
+  }
+
+  function renderTable(el, p) {
+    const td = p.tableData;
+    const headerBg = (td.options && td.options.headerBackground) || '4472C4';
+    const headerColor = (td.options && td.options.headerColor) || 'FFFFFF';
+    const altRows = td.options && td.options.alternateRowColors;
+
+    let html = '<table style="width:100%;border-collapse:collapse;font-family:Arial,sans-serif;font-size:12px;">';
+
+    // Header
+    html += '<thead><tr style="background:#' + headerBg + ';color:#' + headerColor + ';">';
+    td.headers.forEach(function(h) {
+      html += '<th style="padding:8px;border:1px solid #ccc;text-align:left;">' + h + '</th>';
+    });
+    html += '</tr></thead><tbody>';
+
+    // Rows
+    td.rows.forEach(function(row, i) {
+      const bg = altRows && i % 2 === 1 ? '#f5f5f5' : '#ffffff';
+      html += '<tr style="background:' + bg + ';">';
+      row.forEach(function(cell) {
+        html += '<td style="padding:8px;border:1px solid #ccc;">' + cell + '</td>';
+      });
+      html += '</tr>';
+    });
+    html += '</tbody></table>';
+
+    el.innerHTML = html;
+  }
+
+  function renderImage(el, p) {
+    const img = document.createElement('img');
+    img.src = p.imageData.url;
+    img.alt = p.imageData.alt || '';
+    img.style.width = '100%';
+    img.style.height = '100%';
+    img.style.objectFit = 'contain';
+    el.innerHTML = '';
+    el.appendChild(img);
+  }
+})()

--- a/document-skills/pptx/scripts/render-placeholders.js
+++ b/document-skills/pptx/scripts/render-placeholders.js
@@ -29,16 +29,17 @@
     }
 
     try {
+      let ok = false;
       if (p.type === 'chart' && p.chartData) {
-        renderChart(el, p);
-        rendered++;
+        ok = renderChart(el, p);
       } else if (p.type === 'table' && p.tableData) {
         renderTable(el, p);
-        rendered++;
+        ok = true;
       } else if (p.type === 'image' && p.imageData) {
         renderImage(el, p);
-        rendered++;
+        ok = true;
       }
+      if (ok) rendered++;
     } catch (e) {
       errors.push(p.id + ': ' + (e.message || String(e)));
     }
@@ -50,7 +51,7 @@
     const Chart = window.Chart;
     if (!Chart) {
       errors.push('Chart.js not loaded — did you inject the CDN and wait?');
-      return;
+      return false;
     }
 
     const canvas = document.createElement('canvas');
@@ -92,6 +93,7 @@
         }
       }
     });
+    return true;
   }
 
   function renderTable(el, p) {

--- a/document-skills/pptx/scripts/validate.js
+++ b/document-skills/pptx/scripts/validate.js
@@ -1,0 +1,96 @@
+// validate.js
+// Lightweight HTML validation for PPTX conversion.
+// Run via: cat validate.js | agent-browser eval --stdin --json
+//
+// Returns JSON: { valid: bool, errors: string[] }
+// Use this for quick checks before running full extraction.
+
+(() => {
+  const PT_PER_PX = 0.75;
+  const PX_PER_IN = 96;
+  const errors = [];
+  const body = document.body;
+  const cs = window.getComputedStyle(body);
+
+  // Check body dimensions
+  const w = parseFloat(cs.width), h = parseFloat(cs.height);
+  const expectedW = 720 / PT_PER_PX; // 960px
+  const expectedH = 405 / PT_PER_PX; // 540px
+  if (Math.abs(w - expectedW) > 2 || Math.abs(h - expectedH) > 2) {
+    errors.push('Body dimensions: ' + (w * PT_PER_PX).toFixed(0) + 'pt x ' + (h * PT_PER_PX).toFixed(0) + 'pt (expected 720pt x 405pt)');
+  }
+
+  // Overflow
+  if (body.scrollWidth > w + 1) errors.push('Horizontal overflow: ' + ((body.scrollWidth - w) * PT_PER_PX).toFixed(1) + 'pt');
+  if (body.scrollHeight > h + 1) errors.push('Vertical overflow: ' + ((body.scrollHeight - h) * PT_PER_PX).toFixed(1) + 'pt');
+
+  // <br> tags
+  const brCount = document.querySelectorAll('br').length;
+  if (brCount > 0) errors.push(brCount + ' <br> tag(s) found — use separate elements');
+
+  // Unwrapped text in DIVs
+  document.querySelectorAll('div').forEach(div => {
+    for (const node of div.childNodes) {
+      if (node.nodeType === Node.TEXT_NODE && node.textContent.trim()) {
+        errors.push('Unwrapped text in <div>: "' + node.textContent.trim().substring(0, 40) + '"');
+      }
+    }
+  });
+
+  // Manual bullet symbols
+  document.querySelectorAll('p, h1, h2, h3, h4, h5, h6').forEach(el => {
+    const text = el.textContent.trim();
+    if (/^[•\-\*▪▸○●◆◇■□]\s/.test(text)) {
+      errors.push('Manual bullet in <' + el.tagName.toLowerCase() + '>: "' + text.substring(0, 30) + '" — use <ul>/<ol>');
+    }
+  });
+
+  // Text elements with backgrounds/borders
+  ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li'].forEach(tag => {
+    document.querySelectorAll(tag).forEach(el => {
+      const s = window.getComputedStyle(el);
+      if (s.backgroundColor && s.backgroundColor !== 'rgba(0, 0, 0, 0)') {
+        errors.push('<' + tag + '> has background-color — move to parent <div>');
+      }
+    });
+  });
+
+  // Placeholder validation
+  document.querySelectorAll('.placeholder').forEach(el => {
+    const rect = el.getBoundingClientRect();
+    if (!el.id) errors.push('Placeholder missing id attribute');
+    if (rect.width === 0 || rect.height === 0) errors.push('Placeholder "' + (el.id || '?') + '" has zero ' + (rect.width === 0 ? 'width' : 'height'));
+  });
+
+  // Bottom margin check
+  const slideH = h / PX_PER_IN;
+  document.querySelectorAll('p, h1, h2, h3, h4, h5, h6, ul, ol').forEach(el => {
+    const rect = el.getBoundingClientRect();
+    const bottomIn = (rect.top + rect.height) / PX_PER_IN;
+    const fontSize = parseFloat(window.getComputedStyle(el).fontSize) * PT_PER_PX;
+    if (fontSize > 12 && slideH - bottomIn < 0.5) {
+      errors.push('<' + el.tagName.toLowerCase() + '> too close to bottom: ' + (slideH - bottomIn).toFixed(2) + 'in (need 0.5in)');
+    }
+  });
+
+  // Non-web-safe fonts
+  const webSafe = ['arial', 'helvetica', 'times new roman', 'georgia', 'courier new', 'verdana', 'tahoma', 'trebuchet ms', 'impact', 'sans-serif', 'serif', 'monospace'];
+  const usedFonts = new Set();
+  document.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, pre').forEach(el => {
+    const ff = window.getComputedStyle(el).fontFamily.split(',')[0].replace(/['"]/g, '').trim().toLowerCase();
+    if (ff && !webSafe.includes(ff)) usedFonts.add(ff);
+  });
+  if (usedFonts.size > 0) errors.push('Non-web-safe fonts: ' + Array.from(usedFonts).join(', '));
+
+  // Elements beyond bounds
+  document.querySelectorAll('div, img').forEach(el => {
+    const rect = el.getBoundingClientRect();
+    if (rect.left < -1 || rect.top < -1 || rect.right > w + 1 || rect.bottom > h + 1) {
+      const tag = el.tagName.toLowerCase();
+      const id = el.id ? '#' + el.id : '';
+      errors.push('<' + tag + id + '> extends beyond slide bounds');
+    }
+  });
+
+  return JSON.stringify({ valid: errors.length === 0, errors });
+})()

--- a/document-skills/pptx/scripts/validate.js
+++ b/document-skills/pptx/scripts/validate.js
@@ -45,15 +45,29 @@
     }
   });
 
-  // Text elements with backgrounds/borders
-  ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li'].forEach(tag => {
-    document.querySelectorAll(tag).forEach(el => {
-      const s = window.getComputedStyle(el);
-      if (s.backgroundColor && s.backgroundColor !== 'rgba(0, 0, 0, 0)') {
-        errors.push('<' + tag + '> has background-color — move to parent <div>');
-      }
-    });
+  // Combined text element checks: backgrounds, bottom margin, fonts
+  const slideH = h / PX_PER_IN;
+  const webSafe = ['arial', 'helvetica', 'times new roman', 'georgia', 'courier new', 'verdana', 'tahoma', 'trebuchet ms', 'impact', 'sans-serif', 'serif', 'monospace'];
+  const usedFonts = new Set();
+  document.querySelectorAll('p, h1, h2, h3, h4, h5, h6, ul, ol, li, pre').forEach(el => {
+    const s = window.getComputedStyle(el);
+    const tag = el.tagName.toLowerCase();
+    // Background check
+    if (s.backgroundColor && s.backgroundColor !== 'rgba(0, 0, 0, 0)' && tag !== 'pre') {
+      errors.push('<' + tag + '> has background-color — move to parent <div>');
+    }
+    // Bottom margin check
+    const rect = el.getBoundingClientRect();
+    const bottomIn = (rect.top + rect.height) / PX_PER_IN;
+    const fontSize = parseFloat(s.fontSize) * PT_PER_PX;
+    if (fontSize > 12 && slideH - bottomIn < 0.5) {
+      errors.push('<' + tag + '> too close to bottom: ' + (slideH - bottomIn).toFixed(2) + 'in (need 0.5in)');
+    }
+    // Font check
+    const ff = s.fontFamily.split(',')[0].replace(/['"]/g, '').trim().toLowerCase();
+    if (ff && !webSafe.includes(ff)) usedFonts.add(ff);
   });
+  if (usedFonts.size > 0) errors.push('Non-web-safe fonts: ' + Array.from(usedFonts).join(', '));
 
   // Placeholder validation
   document.querySelectorAll('.placeholder').forEach(el => {
@@ -61,26 +75,6 @@
     if (!el.id) errors.push('Placeholder missing id attribute');
     if (rect.width === 0 || rect.height === 0) errors.push('Placeholder "' + (el.id || '?') + '" has zero ' + (rect.width === 0 ? 'width' : 'height'));
   });
-
-  // Bottom margin check
-  const slideH = h / PX_PER_IN;
-  document.querySelectorAll('p, h1, h2, h3, h4, h5, h6, ul, ol').forEach(el => {
-    const rect = el.getBoundingClientRect();
-    const bottomIn = (rect.top + rect.height) / PX_PER_IN;
-    const fontSize = parseFloat(window.getComputedStyle(el).fontSize) * PT_PER_PX;
-    if (fontSize > 12 && slideH - bottomIn < 0.5) {
-      errors.push('<' + el.tagName.toLowerCase() + '> too close to bottom: ' + (slideH - bottomIn).toFixed(2) + 'in (need 0.5in)');
-    }
-  });
-
-  // Non-web-safe fonts
-  const webSafe = ['arial', 'helvetica', 'times new roman', 'georgia', 'courier new', 'verdana', 'tahoma', 'trebuchet ms', 'impact', 'sans-serif', 'serif', 'monospace'];
-  const usedFonts = new Set();
-  document.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, pre').forEach(el => {
-    const ff = window.getComputedStyle(el).fontFamily.split(',')[0].replace(/['"]/g, '').trim().toLowerCase();
-    if (ff && !webSafe.includes(ff)) usedFonts.add(ff);
-  });
-  if (usedFonts.size > 0) errors.push('Non-web-safe fonts: ' + Array.from(usedFonts).join(', '));
 
   // Elements beyond bounds
   document.querySelectorAll('div, img').forEach(el => {

--- a/tests/trigger-tests.yml
+++ b/tests/trigger-tests.yml
@@ -147,6 +147,20 @@ tests:
   - prompt: "Manage Engage campaigns using tdx engage commands"
     expected: engage
 
+  # === Document Skills ===
+
+  - prompt: "Create a PowerPoint presentation about our Q4 results"
+    expected: pptx
+
+  - prompt: "Generate a .pptx slide deck for my project proposal"
+    expected: pptx
+
+  - prompt: "Make a pitch deck with charts showing our growth metrics"
+    expected: pptx
+
+  - prompt: "I need slides for my team meeting tomorrow"
+    expected: pptx
+
   # === Documentation Skills ===
 
   - prompt: "Generate documentation for my golden layer tables"


### PR DESCRIPTION
## Summary

- Add new `document-skills/pptx` skill that generates PowerPoint files via an HTML-to-PPTX pipeline: write HTML/CSS slides → validate and render in agent-browser → extract DOM positions → assemble PPTX with PptxGenJS
- Includes 4 bundled scripts: `validate.js` (HTML validation), `extract-dom.js` (DOM position extraction), `render-placeholders.js` (chart/table/image preview), `build-pptx.js` (PPTX assembly)
- Supports native PowerPoint charts (bar/line/pie/doughnut/scatter), tables, images via placeholder system
- Reference docs for HTML rules, slide templates, and PptxGenJS conversion details
- Registered in marketplace.json and trigger tests added

## Test plan

- [ ] Run `./tests/run-tests.sh` to verify trigger tests pass for pptx skill
- [ ] Install skill and test with a sample presentation prompt
- [ ] Verify generated PPTX opens correctly in PowerPoint/Keynote
- [ ] Test slides with: solid backgrounds, gradient backgrounds, charts, tables, circle shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)