### PR TITLE
feat: add llm-workflow skill and reorganize workflow-skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -76,6 +76,7 @@
       "strict": false,
       "skills": [
         "./workflow-skills/digdag",
+        "./workflow-skills/llm-workflow",
         "./workflow-skills/workflow-management",
         "./workflow-skills/dbt"
       ]

--- a/tests/trigger-tests.yml
+++ b/tests/trigger-tests.yml
@@ -75,6 +75,9 @@ tests:
   - prompt: "Create a digdag workflow for daily ETL"
     expected: digdag
 
+  - prompt: "Build a workflow that summarizes KPIs with LLM and posts to Slack"
+    expected: llm-workflow
+
   # === SDK Skills ===
 
   - prompt: "Query TD from Python using pytd"

--- a/workflow-skills/digdag/SKILL.md
+++ b/workflow-skills/digdag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: digdag
-description: Write .dig workflow files for Treasure Workflow. Covers creating new workflows (create_workflow MCP tool), importing existing workflows (register_workflow), digdag YAML syntax, td> operator, session variables, _parallel/_retry/_error directives, and TD platform constraints. Use when creating, editing, or deploying TD workflows. Also trigger on mentions of digdag, .dig files, td> operator, workflow scheduling, or any request to build a new ETL pipeline or data workflow on Treasure Data.
+description: Write .dig workflow files for Treasure Workflow. Covers creating new workflows (create_workflow MCP tool), importing existing workflows (register_workflow), digdag YAML syntax, td> operator, session variables, _parallel/_retry/_error directives, and TD platform constraints. Use when creating, editing, or deploying TD workflows. Also trigger on mentions of digdag, .dig files, td> operator, workflow scheduling, or any request to build a new data ETL pipeline on Treasure Data. For workflows with LLM processing or Slack/email notification, see the llm-workflow skill.
 ---
 
 # Treasure Workflow (Digdag)
@@ -174,7 +174,7 @@ Runtime params: `tdx wf start project workflow -p target_date=2026-04-01`
 
 ## mail> on TD
 
-TD's built-in SMTP relay handles delivery. Do not configure `mail.host`, `mail.port`, `mail.username`, or `mail.password` secrets — they are not needed on the TD platform.
+TD's built-in SMTP relay handles delivery. No SMTP secrets needed on TD platform.
 
 ```yaml
 +send_report:
@@ -184,71 +184,9 @@ TD's built-in SMTP relay handles delivery. Do not configure `mail.host`, `mail.p
   html: true
 ```
 
-## LLM in Workflows
+## LLM and Notification
 
-LLM calls in TD workflows always go through `http>`. There are two options — **always ask the user which to use** before writing the workflow:
-
-| Option | Prerequisites | Best for |
-|---|---|---|
-| **Raw LLM** (TD LLM Proxy) | None — works immediately with `td.apikey` | Simple summarization, classification, formatting |
-| **TD Agent** (webhook) | Agent pre-created in TD Console, webhook URL obtained | Complex tasks requiring tools, knowledge bases, or multi-turn reasoning |
-
-Do not use `py>`, external API calls, or direct Anthropic endpoints for LLM invocation.
-
-For advanced patterns (response parsing, conditional branching, Slack/email reports): [patterns-llm.md](references/patterns-llm.md)
-
-### Option 1: Raw LLM (no setup required)
-
-Call TD LLM Proxy directly. Set the endpoint to match the user's TD region.
-
-```yaml
-_export:
-  # Set to user's region: us01 | treasuredata.co.jp | eu01 | ap02 | ap03
-  llm_endpoint: https://llm-proxy.us01.treasuredata.com/v1/messages
-
-+ask_llm:
-  http>: ${llm_endpoint}
-  method: POST
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 1024
-    messages:
-      - role: user
-        content: "Summarize today's data quality report"
-  content_format: json
-  store_content: true
-```
-
-Response in `${http.last_content}` (JSON string). Available models: `claude-haiku-4-5-20251001`, `claude-sonnet-4-6`, `claude-opus-4-6`.
-
-| Region | Endpoint |
-|---|---|
-| US | `https://llm-proxy.us01.treasuredata.com` |
-| JP | `https://llm-proxy.treasuredata.co.jp` |
-| EU | `https://llm-proxy.eu01.treasuredata.com` |
-| AP02 | `https://llm-proxy.ap02.treasuredata.com` |
-| AP03 | `https://llm-proxy.ap03.treasuredata.com` |
-
-### Option 2: TD Agent (requires pre-setup)
-
-Call a pre-built TD Agent via its webhook URL. The user must provide:
-1. **Agent created** in TD Console (with tools, knowledge bases, system prompt configured)
-2. **Webhook URL** obtained from the agent settings
-
-```yaml
-+call_agent:
-  http>: ${secret:agent.webhook_url}
-  method: POST
-  headers:
-    - content-type: application/json
-  content:
-    message: "Analyze sales activity for ${session_date}"
-  content_format: json
-  store_content: true
-```
+For LLM calls (TD LLM Proxy, TD Agent) and notification patterns (Slack, email), see the **llm-workflow** skill. It covers end-to-end patterns: data pipeline → LLM summarize → Slack/Mail notify.
 
 ## Common Pitfalls
 

--- a/workflow-skills/digdag/references/operators.md
+++ b/workflow-skills/digdag/references/operators.md
@@ -264,6 +264,74 @@ Poll a table until it has enough records in the session time range.
 
 ---
 
+### td_partial_delete>: Delete Records by Time Range
+
+Delete records within a time range. Use before `insert_into` for idempotent writes.
+
+```yaml
++delete_old:
+  td_partial_delete>: target_table
+  database: analytics
+  from: ${session_date}
+  to: ${next_session_date}
+```
+
+| Parameter | Description |
+|---|---|
+| `td_partial_delete>:` | Table name |
+| `database:` | Target database |
+| `from:` | Start time (inclusive, ISO 8601 or `yyyy-MM-dd`) |
+| `to:` | End time (exclusive) |
+
+**Secrets:** `td.apikey`
+
+---
+
+### td_table_export>: Export Table to Cloud Storage
+
+Export a table to S3, GCS, or Azure Blob.
+
+```yaml
++export:
+  td_table_export>: analytics.events
+  file_format: jsonl.gz
+  from: "2026-01-01 00:00:00 +0900"
+  to: "2026-01-02 00:00:00 +0900"
+```
+
+| Parameter | Description |
+|---|---|
+| `td_table_export>:` | `database.table` |
+| `file_format:` | `jsonl.gz`, `msgpack.gz`, `json.gz` |
+| `from:` | Start time (inclusive) |
+| `to:` | End time (exclusive) |
+
+Requires a result export target configured on the table in TD Console.
+
+**Secrets:** `td.apikey`
+
+---
+
+### td_result_export>: Re-export Job Results
+
+Re-export results from a previously completed job to a configured destination.
+
+```yaml
++reexport:
+  td_result_export>: 12345678
+  result_connection: my_s3_connection
+```
+
+| Parameter | Description |
+|---|---|
+| `td_result_export>:` | Job ID |
+| `result_connection:` | Connection name configured in TD Console |
+| `result_settings:` | Additional settings map |
+
+**Secrets:** `td.apikey`
+
+---
+
 ## Workflow Control Operators
 
 ### if>: Conditional Execution
@@ -334,6 +402,63 @@ Exposes `${i}` (0-indexed) in each iteration.
 
 ---
 
+### for_range>: Iterate Over Numeric Range
+
+Like `loop>` but with explicit start/end/step. Exposes `${range.from}`, `${range.to}`, `${range.index}`.
+
+```yaml
++by_range:
+  for_range>:
+    from: 0
+    to: 10
+    step: 2
+  _do:
+    +run:
+      echo>: "Index ${range.index}, value ${range.from}"
+```
+
+| Parameter | Description |
+|---|---|
+| `from:` | Start value (inclusive) |
+| `to:` | End value (exclusive) |
+| `step:` | Increment (default: 1) |
+| `_do:` | Subtasks per iteration |
+| `_parallel:` | Run iterations concurrently |
+
+---
+
+### wait>: Wait for Duration
+
+Pause workflow execution for a specified duration.
+
+```yaml
++pause:
+  wait>: 300
+```
+
+| Parameter | Description |
+|---|---|
+| `wait>:` | Duration in seconds |
+
+---
+
+### require>: Require Another Workflow Session
+
+Wait for another workflow's session to complete before proceeding.
+
+```yaml
++depend:
+  require>: upstream_project/upstream_workflow
+```
+
+| Parameter | Description |
+|---|---|
+| `require>:` | `project/workflow` to wait for |
+| `session_time:` | Override session time to wait for |
+| `timeout:` | Max wait time in seconds |
+
+---
+
 ### call>: Call Another Workflow
 
 ```yaml
@@ -390,6 +515,12 @@ Called workflow uses its subdirectory as working directory. Adjust relative file
 | `retry:` | true (GET) | Auto-retry on failure |
 
 **Secrets:** `http.authorization`, `http.user`, `http.password`
+
+---
+
+### http_call>: HTTP Request (alias)
+
+Alias for `http>`. Use `http>` instead — same parameters and behavior.
 
 ---
 

--- a/workflow-skills/digdag/references/scaffold.md
+++ b/workflow-skills/digdag/references/scaffold.md
@@ -177,6 +177,8 @@ pytd
 |---|---|---|---|
 | `td.apikey` | `ACCOUNT_ID/KEY` (e.g., `1234/abcdef01...`) | `td>`, `td_ddl>`, `td_load>`, `td_for_each>`, `td_wait>`, `td_run>`, `http>` with LLM Proxy | TD Console → My Settings → API Keys |
 | `slack.webhook` | `https://hooks.slack.com/services/...` | Error/success notifications via `http>` | Slack App → Incoming Webhooks |
+| `slack.bot_user_oauth_token` | `xoxb-...` | Slack Bot API (`chat.postMessage`) | Slack App → OAuth & Permissions |
+| `td.webhook_key` | Basic auth key | TD Agent webhook calls | TD Console → AI Agents → Webhook Settings |
 | `mail.host`, `mail.port`, `mail.username`, `mail.password` | SMTP credentials | `mail>` operator (local digdag only — **not needed on TD platform**) | Your SMTP provider |
 | `langfuse.public`, `langfuse.secret`, `langfuse.host` | Langfuse keys | `py>` with Langfuse | Langfuse dashboard → Settings |
 

--- a/workflow-skills/digdag/references/scaffold.md
+++ b/workflow-skills/digdag/references/scaffold.md
@@ -180,7 +180,6 @@ pytd
 | `slack.bot_user_oauth_token` | `xoxb-...` | Slack Bot API (`chat.postMessage`) | Slack App → OAuth & Permissions |
 | `td.webhook_key` | Basic auth key | TD Agent webhook calls | TD Console → AI Agents → Webhook Settings |
 | `mail.host`, `mail.port`, `mail.username`, `mail.password` | SMTP credentials | `mail>` operator (local digdag only — **not needed on TD platform**) | Your SMTP provider |
-| `langfuse.public`, `langfuse.secret`, `langfuse.host` | Langfuse keys | `py>` with Langfuse | Langfuse dashboard → Settings |
 
 ### How to set secrets
 
@@ -194,10 +193,8 @@ tdx wf secrets set <project-name> "td.apikey=YOUR_MASTER_API_KEY"
 # Optional: Slack webhook for error notifications
 tdx wf secrets set <project-name> "slack.webhook=YOUR_SLACK_WEBHOOK_URL"
 
-# Optional: Langfuse tracing
-tdx wf secrets set <project-name> "langfuse.public=YOUR_PUBLIC_KEY"
-tdx wf secrets set <project-name> "langfuse.secret=YOUR_SECRET_KEY"
-tdx wf secrets set <project-name> "langfuse.host=YOUR_LANGFUSE_HOST"
+# Optional: Slack Bot API token
+tdx wf secrets set <project-name> "slack.bot_user_oauth_token=YOUR_BOT_TOKEN"
 ```
 
 ### About `td.apikey`
@@ -209,32 +206,29 @@ tdx wf secrets set <project-name> "langfuse.host=YOUR_LANGFUSE_HOST"
 
 ### Referencing secrets in .dig
 
+Secrets are available anywhere via `${secret:KEY}` — in headers, URLs, and `_env` blocks.
+
 ```yaml
 # In _env for py> tasks
 _env:
   TD_API_KEY: ${secret:td.apikey}
-  SLACK_WEBHOOK: ${secret:slack.webhook}
 
-# In http> headers (e.g., LLM Proxy)
-+call_llm:
-  http>: https://llm-proxy.us01.treasuredata.com/v1/messages
+# In http> headers
++call_api:
+  http>: https://api.example.com/data
   method: POST
   headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 1024
-    messages:
-      - role: user
-        content: "Hello"
-  content_format: json
+    - Authorization: "Bearer ${secret:my_api_token}"
 
 # Directly in http> URL
 +notify:
   http>: ${secret:slack.webhook}
   method: POST
+  content:
+    text: "Pipeline completed for ${session_date}"
 ```
+
+For LLM Proxy and Slack Bot API secret usage patterns, see the **llm-workflow** skill.
 
 ### Verifying secrets
 

--- a/workflow-skills/llm-workflow/SKILL.md
+++ b/workflow-skills/llm-workflow/SKILL.md
@@ -36,7 +36,7 @@ _export:
 # 1. Setup
 +setup:
   td_ddl>:
-  create_databases: ["${output_db}"]
+    create_databases: ["${output_db}"]
 
 # 2. Build tables
 +build_tables:

--- a/workflow-skills/llm-workflow/SKILL.md
+++ b/workflow-skills/llm-workflow/SKILL.md
@@ -246,6 +246,7 @@ TD's built-in SMTP relay handles delivery — no SMTP secrets needed on TD platf
 | `td.apikey` | LLM Proxy calls | `tdx wf secrets set <project> "td.apikey=YOUR_KEY"` |
 | `slack.webhook` | Slack Webhook | `tdx wf secrets set <project> "slack.webhook=YOUR_URL"` |
 | `slack.bot_user_oauth_token` | Slack Bot API | `tdx wf secrets set <project> "slack.bot_user_oauth_token=YOUR_TOKEN"` |
+| `agent.webhook_url` | TD Agent calls | `tdx wf secrets set <project> "agent.webhook_url=YOUR_WEBHOOK_URL"` |
 
 ## References
 

--- a/workflow-skills/llm-workflow/SKILL.md
+++ b/workflow-skills/llm-workflow/SKILL.md
@@ -59,6 +59,7 @@ _export:
 +llm_summarize:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01
@@ -106,6 +107,7 @@ _error:
 - **`store_content: true`** on `http>` stores the raw response in `${http.last_content}`
 - **`${JSON.parse(http.last_content).content[0].text}`** extracts the LLM response text inline — no `py>` needed
 - **`_export` block** centralizes Slack and LLM config for reuse across steps and `_error`
+- **`timeout: 300`** on LLM calls — `http>` defaults to 30s which is insufficient for LLM responses. Always set 300+ for LLM Proxy, 3600 for TD Agent
 
 ## Passing Query Results to LLM
 
@@ -136,6 +138,7 @@ For detailed patterns (conditional branching, multi-step reasoning): [llm-patter
 +ask_llm:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01

--- a/workflow-skills/llm-workflow/SKILL.md
+++ b/workflow-skills/llm-workflow/SKILL.md
@@ -149,16 +149,26 @@ Available models: `claude-haiku-4-5-20251001`, `claude-sonnet-4-6`, `claude-opus
 
 ### TD Agent (webhook)
 
+Call a pre-built TD Agent via its webhook action URL. The user must provide:
+1. **Agent created** in TD Console (with tools, knowledge bases, system prompt configured)
+2. **Action ID** obtained from the agent's webhook settings
+
 ```yaml
+_export:
+  agent:
+    endpoint: "https://llm-connect.treasuredata.com/api/actions"
+    action_id: "YOUR_ACTION_ID"
+
 +call_agent:
-  http>: ${secret:agent.webhook_url}
+  http>: ${agent.endpoint}/${agent.action_id}/text
   method: POST
   headers:
-    - content-type: application/json
+    - Authorization: "Basic ${secret:td.webhook_key}"
+    - Content-Type: "application/json"
   content:
-    message: "Analyze sales activity for ${session_date}"
-  content_format: json
+    question: "Analyze sales activity for ${session_date}"
   store_content: true
+  timeout: 3600
 ```
 
 ### Response parsing
@@ -246,7 +256,7 @@ TD's built-in SMTP relay handles delivery — no SMTP secrets needed on TD platf
 | `td.apikey` | LLM Proxy calls | `tdx wf secrets set <project> "td.apikey=YOUR_KEY"` |
 | `slack.webhook` | Slack Webhook | `tdx wf secrets set <project> "slack.webhook=YOUR_URL"` |
 | `slack.bot_user_oauth_token` | Slack Bot API | `tdx wf secrets set <project> "slack.bot_user_oauth_token=YOUR_TOKEN"` |
-| `agent.webhook_url` | TD Agent calls | `tdx wf secrets set <project> "agent.webhook_url=YOUR_WEBHOOK_URL"` |
+| `td.webhook_key` | TD Agent calls | `tdx wf secrets set <project> "td.webhook_key=YOUR_WEBHOOK_KEY"` |
 
 ## References
 

--- a/workflow-skills/llm-workflow/SKILL.md
+++ b/workflow-skills/llm-workflow/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: llm-workflow
+description: Use when building TD workflows that include LLM processing steps — data pipeline with LLM summarization, Slack/email notification, or any end-to-end automation. Covers patterns for query data, LLM analysis via TD LLM Proxy or TD Agent, and notification via Slack (Webhook/Bot API) or email. Also trigger on: LLM in workflow, workflow with Slack notification, automated report workflow, KPI summary pipeline, data-to-insight workflow.
+---
+
+# LLM Workflow
+
+Build TD workflows that chain data queries, LLM processing, and notifications into end-to-end automation.
+
+```
+[td> / py> pipeline] → [LLM summarize] → [Slack / Mail notify]
+```
+
+For digdag syntax and operator reference, see the **digdag** skill.
+
+## End-to-End Template
+
+A complete workflow: scheduled pipeline builds tables, extracts KPIs, asks LLM to summarize, and posts to Slack.
+
+```yaml
+timezone: Asia/Tokyo
+
+schedule:
+  daily>: "07:00:00"
+
+_export:
+  td:
+    database: my_database
+    engine: presto
+  output_db: my_analytics
+  slack:
+    post_url: "https://slack.com/api/chat.postMessage"
+    channel: "C0XXXXXXXXX"
+  llm_endpoint: "https://llm-proxy.us01.treasuredata.com/v1/messages"
+
+# 1. Setup
++setup:
+  td_ddl>:
+  create_databases: ["${output_db}"]
+
+# 2. Build tables
++build_tables:
+  _parallel: true
+  +summary_a:
+    td>: queries/summary_a.sql
+    database: ${output_db}
+    create_table: summary_a
+  +summary_b:
+    td>: queries/summary_b.sql
+    database: ${output_db}
+    create_table: summary_b
+
+# 3. Extract KPIs (single row for LLM context)
++extract_kpis:
+  td>: queries/kpi_snapshot.sql
+  store_last_results: true
+
+# 4. LLM summarize
++llm_summarize:
+  http>: ${llm_endpoint}
+  method: POST
+  headers:
+    - x-api-key: ${secret:td.apikey}
+    - anthropic-version: 2023-06-01
+  content:
+    model: claude-haiku-4-5-20251001
+    max_tokens: 1024
+    messages:
+      - role: user
+        content: |
+          Summarize this daily KPI snapshot. Be concise (under 300 chars).
+          Date: ${session_date}
+          Metric A: ${td.last_results.metric_a}
+          Metric B: ${td.last_results.metric_b}
+  content_format: json
+  store_content: true
+
+# 5. Post to Slack
++post_to_slack:
+  http>: ${slack.post_url}
+  method: POST
+  headers:
+    - content-type: "application/json"
+    - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+  content:
+    channel: ${slack.channel}
+    text: ${JSON.parse(http.last_content).content[0].text}
+  store_content: true
+
+# Error notification
+_error:
+  +notify_failure:
+    http>: ${slack.post_url}
+    method: POST
+    headers:
+      - content-type: "application/json"
+      - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+    content:
+      channel: ${slack.channel}
+      text: "Workflow failed for ${session_date}"
+```
+
+### Key patterns in this template
+
+- **`store_last_results: true`** on the KPI query exposes `${td.last_results.*}` — design the query to return exactly one row
+- **`store_content: true`** on `http>` stores the raw response in `${http.last_content}`
+- **`${JSON.parse(http.last_content).content[0].text}`** extracts the LLM response text inline — no `py>` needed
+- **`_export` block** centralizes Slack and LLM config for reuse across steps and `_error`
+
+## LLM Summarize
+
+Two options for calling LLM from workflows — **always ask the user which to use**:
+
+| Option | Prerequisites | Best for |
+|---|---|---|
+| **Raw LLM** (TD LLM Proxy) | None — works with `td.apikey` | Summarization, classification, formatting |
+| **TD Agent** (webhook) | Agent pre-created in TD Console | Complex tasks with tools, knowledge bases |
+
+For detailed patterns (conditional branching, multi-step reasoning): [llm-patterns.md](references/llm-patterns.md)
+
+### Raw LLM (TD LLM Proxy)
+
+```yaml
++ask_llm:
+  http>: ${llm_endpoint}
+  method: POST
+  headers:
+    - x-api-key: ${secret:td.apikey}
+    - anthropic-version: 2023-06-01
+  content:
+    model: claude-haiku-4-5-20251001
+    max_tokens: 1024
+    messages:
+      - role: user
+        content: "Summarize: revenue=${td.last_results.revenue}"
+  content_format: json
+  store_content: true
+```
+
+Available models: `claude-haiku-4-5-20251001`, `claude-sonnet-4-6`, `claude-opus-4-6`
+
+| Region | Endpoint |
+|---|---|
+| US | `https://llm-proxy.us01.treasuredata.com/v1/messages` |
+| JP | `https://llm-proxy.treasuredata.co.jp/v1/messages` |
+| EU | `https://llm-proxy.eu01.treasuredata.com/v1/messages` |
+| AP02 | `https://llm-proxy.ap02.treasuredata.com/v1/messages` |
+| AP03 | `https://llm-proxy.ap03.treasuredata.com/v1/messages` |
+
+### TD Agent (webhook)
+
+```yaml
++call_agent:
+  http>: ${secret:agent.webhook_url}
+  method: POST
+  headers:
+    - content-type: application/json
+  content:
+    message: "Analyze sales activity for ${session_date}"
+  content_format: json
+  store_content: true
+```
+
+### Response parsing
+
+**Inline (no py> needed)** — use JavaScript expressions in digdag templates:
+
+```yaml
+# Extract text from Anthropic Messages API response
+text: ${JSON.parse(http.last_content).content[0].text}
+```
+
+**Via py> (for complex parsing)** — when you need conditional logic or multi-field extraction:
+
+```yaml
++parse:
+  py>: tasks.ResponseParser.extract
+  docker:
+    image: "treasuredata/customscript-python:3.12.11-td1"
+```
+
+```python
+import digdag
+import json
+
+class ResponseParser:
+    def extract(self):
+        response = digdag.env.params.get("http", {}).get("last_content", "{}")
+        body = json.loads(response) if isinstance(response, str) else response
+        text = body.get("content", [{}])[0].get("text", "")
+        digdag.env.store({"llm_summary": text})
+```
+
+## Notification
+
+For detailed patterns (Block Kit, threads, HTML email): [notification-patterns.md](references/notification-patterns.md)
+
+### Slack: two methods
+
+| Method | Auth | Use case |
+|---|---|---|
+| **Incoming Webhook** | URL contains token | Simple post to a fixed channel |
+| **Bot API** (`chat.postMessage`) | Bearer token | Dynamic channel, threads, richer control |
+
+**Webhook** (simplest):
+
+```yaml
++notify:
+  http>: ${secret:slack.webhook}
+  method: POST
+  content:
+    text: "Pipeline completed for ${session_date}"
+```
+
+**Bot API** (flexible):
+
+```yaml
++notify:
+  http>: https://slack.com/api/chat.postMessage
+  method: POST
+  headers:
+    - content-type: "application/json"
+    - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+  content:
+    channel: "C0XXXXXXXXX"
+    text: "Pipeline completed for ${session_date}"
+  store_content: true
+```
+
+### Email
+
+TD's built-in SMTP relay handles delivery — no SMTP secrets needed on TD platform.
+
+```yaml
++send_report:
+  mail>: templates/report.html
+  subject: "Daily Report ${session_date}"
+  to: [team@example.com]
+  html: true
+```
+
+## Secrets
+
+| Secret | Required for | How to set |
+|---|---|---|
+| `td.apikey` | LLM Proxy calls | `tdx wf secrets set <project> "td.apikey=YOUR_KEY"` |
+| `slack.webhook` | Slack Webhook | `tdx wf secrets set <project> "slack.webhook=YOUR_URL"` |
+| `slack.bot_user_oauth_token` | Slack Bot API | `tdx wf secrets set <project> "slack.bot_user_oauth_token=YOUR_TOKEN"` |
+
+## References
+
+For digdag syntax, operators, and project setup — see the **digdag** skill and its references:
+
+- Operator parameter reference: [operators.md](../digdag/references/operators.md)
+- py> operator: [py-operator.md](../digdag/references/py-operator.md)
+- ETL pipeline patterns: [patterns-etl.md](../digdag/references/patterns-etl.md)
+- Control flow patterns: [patterns-control.md](../digdag/references/patterns-control.md)
+- Project structure and deployment: [scaffold.md](../digdag/references/scaffold.md)

--- a/workflow-skills/llm-workflow/SKILL.md
+++ b/workflow-skills/llm-workflow/SKILL.md
@@ -15,7 +15,9 @@ For digdag syntax and operator reference, see the **digdag** skill.
 
 ## End-to-End Template
 
-A complete workflow: scheduled pipeline builds tables, extracts KPIs, asks LLM to summarize, and posts to Slack.
+Steps 1-4 are shared. Step 5 depends on notification channel — **Slack** (requires Bot App) or **Mail** (no setup needed on TD).
+
+### Steps 1-4: Pipeline + LLM (shared)
 
 ```yaml
 timezone: Asia/Tokyo
@@ -28,9 +30,6 @@ _export:
     database: my_database
     engine: presto
   output_db: my_analytics
-  slack:
-    post_url: "https://slack.com/api/chat.postMessage"
-    channel: "C0XXXXXXXXX"
   llm_endpoint: "https://llm-proxy.us01.treasuredata.com/v1/messages"
 
 # 1. Setup
@@ -75,8 +74,19 @@ _export:
           Metric B: ${td.last_results.metric_b}
   content_format: json
   store_content: true
+```
 
-# 5. Post to Slack
+### Step 5a: Notify via Slack (Bot API)
+
+Requires Slack Bot App with `chat:write` scope. Add after step 4:
+
+```yaml
+_export:
+  slack:
+    post_url: "https://slack.com/api/chat.postMessage"
+    channel: "C0XXXXXXXXX"
+
+# 5. Post to Slack — JSON.parse extracts LLM text inline (no py> needed)
 +post_to_slack:
   http>: ${slack.post_url}
   method: POST
@@ -88,7 +98,6 @@ _export:
     text: ${JSON.parse(http.last_content).content[0].text}
   store_content: true
 
-# Error notification
 _error:
   +notify_failure:
     http>: ${slack.post_url}
@@ -101,13 +110,57 @@ _error:
       text: "Workflow failed for ${session_date}"
 ```
 
-### Key patterns in this template
+### Step 5b: Notify via Email (no setup needed)
 
-- **`store_last_results: true`** on the KPI query exposes `${td.last_results.*}` — design the query to return exactly one row
+TD's built-in SMTP relay handles delivery — no secrets required. LLM response must be extracted via `py>` into a template variable:
+
+```yaml
+# 5. Extract LLM response and send email
++extract_summary:
+  py>: tasks.ResponseExtractor.run
+  docker:
+    image: "treasuredata/customscript-python:3.12.11-td1"
+
++send_report:
+  mail>: templates/report.html
+  subject: "Daily Report ${session_date}"
+  to: [team@example.com]
+  html: true
+
+_error:
+  +notify_failure:
+    mail>:
+      data: "Workflow failed for ${session_date}"
+    subject: "ALERT: workflow failure ${session_date}"
+    to: [team@example.com]
+```
+
+`tasks/__init__.py`:
+```python
+import digdag
+import json
+
+class ResponseExtractor:
+    def run(self):
+        response = digdag.env.params.get("http", {}).get("last_content", "{}")
+        body = json.loads(response) if isinstance(response, str) else response
+        text = body.get("content", [{}])[0].get("text", "")
+        digdag.env.store({"llm_summary": text})
+```
+
+`templates/report.html` — use inline CSS only (email clients strip `<link>` tags):
+```html
+<h2>Daily Report: ${session_date}</h2>
+<div>${llm_summary}</div>
+```
+
+### Key patterns
+
+- **`timeout: 300`** on LLM calls — `http>` defaults to 30s which is insufficient. Always set 300+ for LLM Proxy, 3600 for TD Agent
+- **`store_last_results: true`** exposes `${td.last_results.*}` — design the query to return exactly one row
 - **`store_content: true`** on `http>` stores the raw response in `${http.last_content}`
-- **`${JSON.parse(http.last_content).content[0].text}`** extracts the LLM response text inline — no `py>` needed
-- **`_export` block** centralizes Slack and LLM config for reuse across steps and `_error`
-- **`timeout: 300`** on LLM calls — `http>` defaults to 30s which is insufficient for LLM responses. Always set 300+ for LLM Proxy, 3600 for TD Agent
+- **`${JSON.parse(http.last_content).content[0].text}`** extracts LLM text inline (Slack path, no py> needed)
+- **`py>` extraction** needed for Mail path because `mail>` templates cannot use `JSON.parse()`
 
 ## Passing Query Results to LLM
 
@@ -123,7 +176,7 @@ For detailed examples of each pattern: [llm-patterns.md](references/llm-patterns
 
 ## LLM Summarize
 
-Two options for calling LLM from workflows — **always ask the user which to use**:
+Two options — **always ask the user which to use**:
 
 | Option | Prerequisites | Best for |
 |---|---|---|
@@ -188,28 +241,16 @@ _export:
 
 ### Response parsing
 
-**Inline (no py> needed)** — use JavaScript expressions in digdag templates:
+**Inline (Slack path)** — `${JSON.parse(http.last_content).content[0].text}`
 
-```yaml
-# Extract text from Anthropic Messages API response
-text: ${JSON.parse(http.last_content).content[0].text}
-```
-
-**Via py> (for complex parsing)** — when you need conditional logic or multi-field extraction:
-
-```yaml
-+parse:
-  py>: tasks.ResponseParser.extract
-  docker:
-    image: "treasuredata/customscript-python:3.12.11-td1"
-```
+**Via py> (Mail path or complex parsing):**
 
 ```python
 import digdag
 import json
 
-class ResponseParser:
-    def extract(self):
+class ResponseExtractor:
+    def run(self):
         response = digdag.env.params.get("http", {}).get("last_content", "{}")
         body = json.loads(response) if isinstance(response, str) else response
         text = body.get("content", [{}])[0].get("text", "")
@@ -218,16 +259,25 @@ class ResponseParser:
 
 ## Notification
 
-For detailed patterns (Block Kit, threads, HTML email): [notification-patterns.md](references/notification-patterns.md)
-
-### Slack: two methods
-
-| Method | Auth | Use case |
+| Channel | Setup required | Best for |
 |---|---|---|
-| **Incoming Webhook** | URL contains token | Simple post to a fixed channel |
-| **Bot API** (`chat.postMessage`) | Bearer token | Dynamic channel, threads, richer control |
+| **Email** (`mail>`) | None on TD platform | Reports, alerts — simplest path |
+| **Slack Webhook** | Webhook URL | Simple fixed-channel posts |
+| **Slack Bot API** | Bot App with `chat:write` | Dynamic channels, threads |
 
-**Webhook** (simplest):
+For detailed patterns: [notification-patterns.md](references/notification-patterns.md)
+
+### Email
+
+```yaml
++send_report:
+  mail>: templates/report.html
+  subject: "Daily Report ${session_date}"
+  to: [team@example.com]
+  html: true
+```
+
+### Slack Webhook
 
 ```yaml
 +notify:
@@ -237,7 +287,7 @@ For detailed patterns (Block Kit, threads, HTML email): [notification-patterns.m
     text: "Pipeline completed for ${session_date}"
 ```
 
-**Bot API** (flexible):
+### Slack Bot API
 
 ```yaml
 +notify:
@@ -252,26 +302,16 @@ For detailed patterns (Block Kit, threads, HTML email): [notification-patterns.m
   store_content: true
 ```
 
-### Email
-
-TD's built-in SMTP relay handles delivery — no SMTP secrets needed on TD platform.
-
-```yaml
-+send_report:
-  mail>: templates/report.html
-  subject: "Daily Report ${session_date}"
-  to: [team@example.com]
-  html: true
-```
-
 ## Secrets
 
 | Secret | Required for | How to set |
 |---|---|---|
 | `td.apikey` | LLM Proxy calls | `tdx wf secrets set <project> "td.apikey=YOUR_KEY"` |
+| `td.webhook_key` | TD Agent calls | `tdx wf secrets set <project> "td.webhook_key=YOUR_WEBHOOK_KEY"` |
 | `slack.webhook` | Slack Webhook | `tdx wf secrets set <project> "slack.webhook=YOUR_URL"` |
 | `slack.bot_user_oauth_token` | Slack Bot API | `tdx wf secrets set <project> "slack.bot_user_oauth_token=YOUR_TOKEN"` |
-| `td.webhook_key` | TD Agent calls | `tdx wf secrets set <project> "td.webhook_key=YOUR_WEBHOOK_KEY"` |
+
+Email (`mail>`) requires no secrets on TD platform.
 
 ## References
 

--- a/workflow-skills/llm-workflow/SKILL.md
+++ b/workflow-skills/llm-workflow/SKILL.md
@@ -107,6 +107,18 @@ _error:
 - **`${JSON.parse(http.last_content).content[0].text}`** extracts the LLM response text inline — no `py>` needed
 - **`_export` block** centralizes Slack and LLM config for reuse across steps and `_error`
 
+## Passing Query Results to LLM
+
+`store_last_results: true` stores only the first row. For multi-row data, choose the right pattern:
+
+| Pattern | When to use |
+|---|---|
+| **Single row** | KPI snapshot, aggregated metrics |
+| **SQL aggregation** | Multi-row → one text column via `array_join`/`listagg` (no py> needed) |
+| **py> formatting** | Large tables, complex formatting (markdown table, CSV) |
+
+For detailed examples of each pattern: [llm-patterns.md](references/llm-patterns.md)
+
 ## LLM Summarize
 
 Two options for calling LLM from workflows — **always ask the user which to use**:

--- a/workflow-skills/llm-workflow/references/llm-patterns.md
+++ b/workflow-skills/llm-workflow/references/llm-patterns.md
@@ -26,6 +26,7 @@ Design the query to return one row of scalar values.
 +analyze:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01
@@ -51,6 +52,7 @@ Compress multiple rows into a single text column using string aggregation, then 
 +analyze:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01
@@ -129,6 +131,7 @@ Write query results to a table, then read with `py>` using pytd. Best for large 
 +analyze:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01
@@ -192,6 +195,7 @@ Ask a yes/no question and branch on the answer. Use `py>` to parse into a boolea
 +ask_llm:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01
@@ -256,6 +260,7 @@ Query results feed the LLM, and the LLM analysis is embedded into HTML via `py>`
 +analyze:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01

--- a/workflow-skills/llm-workflow/references/llm-patterns.md
+++ b/workflow-skills/llm-workflow/references/llm-patterns.md
@@ -1,35 +1,6 @@
-# LLM Agent Patterns
+# LLM Patterns
 
-Call the TD LLM Proxy (Anthropic Messages API-compatible) from digdag workflows via `http>`. No Python/Docker required (~2s vs ~60s for `py>`).
-
-`${secret:...}` works in `http>` headers. Response stored in `${http.last_content}` as JSON string when `store_content: true`.
-
----
-
-## Basic LLM Call
-
-```yaml
-_export:
-  llm_endpoint: https://llm-proxy.us01.treasuredata.com/v1/messages
-
-+ask_agent:
-  http>: ${llm_endpoint}
-  method: POST
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 1024
-    messages:
-      - role: user
-        content: "Summarize the key trends from today's sales data"
-  content_format: json
-  store_content: true
-
-+log:
-  echo>: "Agent response: ${http.last_content}"
-```
+Advanced patterns for LLM calls in TD workflows via `http>`.
 
 ---
 
@@ -43,7 +14,7 @@ Feed SQL results into an LLM for analysis.
   store_last_results: true
   database: analytics
 
-+analyze_with_agent:
++analyze:
   http>: https://llm-proxy.us01.treasuredata.com/v1/messages
   method: POST
   headers:
@@ -63,7 +34,7 @@ Feed SQL results into an LLM for analysis.
 
 ## LLM Conditional Action
 
-Ask the agent a yes/no question and branch on its answer. Use `py>` to parse the response into a boolean.
+Ask a yes/no question and branch on the answer. Use `py>` to parse into a boolean.
 
 ```yaml
 +gather_metrics:
@@ -71,7 +42,7 @@ Ask the agent a yes/no question and branch on its answer. Use `py>` to parse the
   store_last_results: true
   database: analytics
 
-+ask_agent:
++ask_llm:
   http>: https://llm-proxy.us01.treasuredata.com/v1/messages
   method: POST
   headers:
@@ -99,10 +70,14 @@ Ask the agent a yes/no question and branch on its answer. Use `py>` to parse the
       insert_into: public_table
   _else_do:
     +alert:
-      http>: ${secret:slack.webhook}
+      http>: https://slack.com/api/chat.postMessage
       method: POST
+      headers:
+        - content-type: "application/json"
+        - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
       content:
-        text: ":warning: Agent flagged data quality issue for ${session_date}"
+        channel: "C0XXXXXXXXX"
+        text: "Data quality issue flagged for ${session_date}"
 ```
 
 `tasks/__init__.py`:
@@ -122,63 +97,9 @@ class ResponseParser:
 
 ---
 
-## LLM → Slack Notification
+## LLM Analysis to HTML Email Report
 
-Have the agent draft a summary, then post to Slack.
-
-```yaml
-+gather:
-  td>: queries/weekly_stats.sql
-  store_last_results: true
-  database: analytics
-
-+draft_summary:
-  http>: https://llm-proxy.us01.treasuredata.com/v1/messages
-  method: POST
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 1024
-    messages:
-      - role: user
-        content: "Write a concise Slack message (use markdown, under 500 chars) summarizing: revenue=${td.last_results.revenue}, WoW_change=${td.last_results.wow_pct}%, top_product=${td.last_results.top_product}, active_users=${td.last_results.active_users}."
-  content_format: json
-  store_content: true
-
-+extract_text:
-  py>: tasks.SlackFormatter.extract
-  docker:
-    image: "treasuredata/customscript-python:3.12.11-td1"
-
-+post_to_slack:
-  http>: ${secret:slack.webhook}
-  method: POST
-  content:
-    text: ${agent_message}
-  content_format: json
-```
-
-`tasks/__init__.py`:
-```python
-import digdag
-import json
-
-
-class SlackFormatter:
-    def extract(self):
-        response = digdag.env.params.get("http", {}).get("last_content", "{}")
-        body = json.loads(response) if isinstance(response, str) else response
-        text = body.get("content", [{}])[0].get("text", "")
-        digdag.env.store({"agent_message": text})
-```
-
----
-
-## LLM Analysis → HTML Email Report
-
-For LLM-augmented workflows (data quality summaries, KPI interpretation, anomaly reports), `mail>` with an HTML template is the standard output channel. Query results feed the LLM, and the LLM's analysis is embedded into the HTML body via `py>` + `digdag.env.store()`.
+Query results feed the LLM, and the LLM analysis is embedded into HTML via `py>` + `digdag.env.store()`.
 
 ```yaml
 +gather:

--- a/workflow-skills/llm-workflow/references/llm-patterns.md
+++ b/workflow-skills/llm-workflow/references/llm-patterns.md
@@ -133,4 +133,18 @@ Query results feed the LLM, and the LLM analysis is embedded into HTML via `py>`
   html: true
 ```
 
+`tasks/__init__.py`:
+```python
+import digdag
+import json
+
+
+class ResponseExtractor:
+    def run(self):
+        response = digdag.env.params.get("http", {}).get("last_content", "{}")
+        body = json.loads(response) if isinstance(response, str) else response
+        text = body.get("content", [{}])[0].get("text", "")
+        digdag.env.store({"analysis_content": text})
+```
+
 The HTML template references `${analysis_content}` (stored by `py>`) and `${td.last_results.*}` for raw KPIs. Use inline CSS only — email clients strip `<link>` tags.

--- a/workflow-skills/llm-workflow/references/llm-patterns.md
+++ b/workflow-skills/llm-workflow/references/llm-patterns.md
@@ -6,16 +6,25 @@ Advanced patterns for LLM calls in TD workflows via `http>`.
 
 ## Query Results as LLM Context
 
-Feed SQL results into an LLM for analysis.
+`store_last_results: true` stores **only the first row**. Choose the pattern based on result shape:
+
+| Pattern | When to use |
+|---|---|
+| **Single row** | KPI snapshot, aggregated metrics — query returns exactly one row |
+| **SQL aggregation** | Multi-row data compressed into one row via `array_join`/`listagg` |
+| **py> formatting** | Large or complex tables — full control over formatting |
+
+### Pattern 1: Single row (simplest)
+
+Design the query to return one row of scalar values.
 
 ```yaml
 +gather_data:
   td>: queries/daily_summary.sql
   store_last_results: true
-  database: analytics
 
 +analyze:
-  http>: https://llm-proxy.us01.treasuredata.com/v1/messages
+  http>: ${llm_endpoint}
   method: POST
   headers:
     - x-api-key: ${secret:td.apikey}
@@ -25,9 +34,147 @@ Feed SQL results into an LLM for analysis.
     max_tokens: 2048
     messages:
       - role: user
-        content: "Analyze these metrics and flag anomalies: revenue=${td.last_results.revenue}, orders=${td.last_results.orders}, avg_order_value=${td.last_results.avg_order_value}. Compare to yesterday: prev_revenue=${td.last_results.prev_revenue}."
+        content: "Analyze: revenue=${td.last_results.revenue}, orders=${td.last_results.orders}, avg_order_value=${td.last_results.avg_order_value}"
   content_format: json
   store_content: true
+```
+
+### Pattern 2: SQL aggregation (no py> needed)
+
+Compress multiple rows into a single text column using string aggregation, then pass via `store_last_results`.
+
+```yaml
++gather_data:
+  td>: queries/aggregate_for_llm.sql
+  store_last_results: true
+
++analyze:
+  http>: ${llm_endpoint}
+  method: POST
+  headers:
+    - x-api-key: ${secret:td.apikey}
+    - anthropic-version: 2023-06-01
+  content:
+    model: claude-haiku-4-5-20251001
+    max_tokens: 2048
+    messages:
+      - role: user
+        content: |
+          Analyze the following sales data by region and identify trends:
+          ${td.last_results.report_text}
+  content_format: json
+  store_content: true
+```
+
+`queries/aggregate_for_llm.sql` (Trino):
+```sql
+select array_join(
+  array_agg(
+    region || ': revenue=' || cast(revenue as varchar)
+    || ', orders=' || cast(orders as varchar)
+    || ', avg_order=' || cast(avg_order_value as varchar)
+  ),
+  chr(10)
+) as report_text
+from (
+  select
+    region,
+    sum(revenue) as revenue,
+    count(*) as orders,
+    round(avg(order_value), 2) as avg_order_value
+  from sales
+  where td_interval(time, '-7d')
+  group by region
+  order by revenue desc
+)
+```
+
+This produces a single row like:
+```
+US: revenue=125000, orders=340, avg_order=367.65
+EU: revenue=89000, orders=210, avg_order=423.81
+AP: revenue=56000, orders=180, avg_order=311.11
+```
+
+**Tip:** For markdown table output, format with `|` separators:
+```sql
+select
+  '| Region | Revenue | Orders |' || chr(10)
+  || '|---|---|---|' || chr(10)
+  || array_join(
+    array_agg('| ' || region || ' | ' || cast(revenue as varchar) || ' | ' || cast(orders as varchar) || ' |'),
+    chr(10)
+  ) as report_text
+from ...
+```
+
+### Pattern 3: py> formatting (full control)
+
+Write query results to a table, then read with `py>` using pytd. Best for large result sets or complex formatting.
+
+```yaml
++build_report_data:
+  td>: queries/weekly_breakdown.sql
+  create_table: tmp_llm_input
+
++format_for_llm:
+  py>: tasks.LLMFormatter.run
+  docker:
+    image: "treasuredata/customscript-python:3.12.11-td1"
+  _env:
+    TD_API_KEY: ${secret:td.apikey}
+  database: analytics
+  table: tmp_llm_input
+
++analyze:
+  http>: ${llm_endpoint}
+  method: POST
+  headers:
+    - x-api-key: ${secret:td.apikey}
+    - anthropic-version: 2023-06-01
+  content:
+    model: claude-haiku-4-5-20251001
+    max_tokens: 2048
+    messages:
+      - role: user
+        content: |
+          Analyze this weekly performance data:
+          ${llm_input_text}
+  content_format: json
+  store_content: true
+```
+
+`tasks/__init__.py`:
+```python
+import digdag
+import os
+import pytd
+
+
+class LLMFormatter:
+    def run(self):
+        database = digdag.env.params["database"]
+        table = digdag.env.params["table"]
+
+        client = pytd.Client(
+            apikey=os.environ["TD_API_KEY"],
+            database=database,
+        )
+        result = client.query(f"select * from {table} order by date")
+
+        # Format as markdown table
+        headers = result["columns"]
+        lines = ["| " + " | ".join(headers) + " |"]
+        lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
+        for row in result["data"]:
+            lines.append("| " + " | ".join(str(v) for v in row) + " |")
+
+        digdag.env.store({"llm_input_text": "\n".join(lines)})
+```
+
+`tasks/requirements.txt`:
+```
+pytd
 ```
 
 ---

--- a/workflow-skills/llm-workflow/references/llm-patterns.md
+++ b/workflow-skills/llm-workflow/references/llm-patterns.md
@@ -2,70 +2,58 @@
 
 Advanced patterns for LLM calls in TD workflows via `http>`.
 
+## Base LLM Call
+
+All patterns below use this structure. Only `messages.content` and surrounding steps vary.
+
+```yaml
++ask_llm:
+  http>: ${llm_endpoint}
+  method: POST
+  timeout: 300
+  headers:
+    - x-api-key: ${secret:td.apikey}
+    - anthropic-version: 2023-06-01
+  content:
+    model: claude-haiku-4-5-20251001
+    max_tokens: 1024
+    messages:
+      - role: user
+        content: "YOUR PROMPT HERE"
+  content_format: json
+  store_content: true
+```
+
+Response stored in `${http.last_content}` (JSON string). Extract text with `${JSON.parse(http.last_content).content[0].text}` or via `py>`.
+
 ---
 
-## Query Results as LLM Context
+## Passing Query Results to LLM
 
-`store_last_results: true` stores **only the first row**. Choose the pattern based on result shape:
-
-| Pattern | When to use |
-|---|---|
-| **Single row** | KPI snapshot, aggregated metrics — query returns exactly one row |
-| **SQL aggregation** | Multi-row data compressed into one row via `array_join`/`listagg` |
-| **py> formatting** | Large or complex tables — full control over formatting |
+`store_last_results: true` stores **only the first row**. Choose based on result shape:
 
 ### Pattern 1: Single row (simplest)
-
-Design the query to return one row of scalar values.
 
 ```yaml
 +gather_data:
   td>: queries/daily_summary.sql
   store_last_results: true
 
-+analyze:
-  http>: ${llm_endpoint}
-  method: POST
-  timeout: 300
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 2048
-    messages:
-      - role: user
-        content: "Analyze: revenue=${td.last_results.revenue}, orders=${td.last_results.orders}, avg_order_value=${td.last_results.avg_order_value}"
-  content_format: json
-  store_content: true
+# Base LLM call with prompt:
+#   "Analyze: revenue=${td.last_results.revenue}, orders=${td.last_results.orders}"
 ```
 
 ### Pattern 2: SQL aggregation (no py> needed)
 
-Compress multiple rows into a single text column using string aggregation, then pass via `store_last_results`.
+Compress multiple rows into a single text column, then pass via `store_last_results`.
 
 ```yaml
 +gather_data:
   td>: queries/aggregate_for_llm.sql
   store_last_results: true
 
-+analyze:
-  http>: ${llm_endpoint}
-  method: POST
-  timeout: 300
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 2048
-    messages:
-      - role: user
-        content: |
-          Analyze the following sales data by region and identify trends:
-          ${td.last_results.report_text}
-  content_format: json
-  store_content: true
+# Base LLM call with prompt:
+#   "Analyze the following data:\n${td.last_results.report_text}"
 ```
 
 `queries/aggregate_for_llm.sql` (Trino):
@@ -74,16 +62,11 @@ select array_join(
   array_agg(
     region || ': revenue=' || cast(revenue as varchar)
     || ', orders=' || cast(orders as varchar)
-    || ', avg_order=' || cast(avg_order_value as varchar)
   ),
   chr(10)
 ) as report_text
 from (
-  select
-    region,
-    sum(revenue) as revenue,
-    count(*) as orders,
-    round(avg(order_value), 2) as avg_order_value
+  select region, sum(revenue) as revenue, count(*) as orders
   from sales
   where td_interval(time, '-7d')
   group by region
@@ -91,28 +74,17 @@ from (
 )
 ```
 
-This produces a single row like:
+Produces:
 ```
-US: revenue=125000, orders=340, avg_order=367.65
-EU: revenue=89000, orders=210, avg_order=423.81
-AP: revenue=56000, orders=180, avg_order=311.11
+US: revenue=125000, orders=340
+EU: revenue=89000, orders=210
 ```
 
-**Tip:** For markdown table output, format with `|` separators:
-```sql
-select
-  '| Region | Revenue | Orders |' || chr(10)
-  || '|---|---|---|' || chr(10)
-  || array_join(
-    array_agg('| ' || region || ' | ' || cast(revenue as varchar) || ' | ' || cast(orders as varchar) || ' |'),
-    chr(10)
-  ) as report_text
-from ...
-```
+For markdown table output, format with `|` separators in the SQL.
 
 ### Pattern 3: py> formatting (full control)
 
-Write query results to a table, then read with `py>` using pytd. Best for large result sets or complex formatting.
+Write query results to a table, then read with `py>` using pytd.
 
 ```yaml
 +build_report_data:
@@ -128,23 +100,8 @@ Write query results to a table, then read with `py>` using pytd. Best for large 
   database: analytics
   table: tmp_llm_input
 
-+analyze:
-  http>: ${llm_endpoint}
-  method: POST
-  timeout: 300
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 2048
-    messages:
-      - role: user
-        content: |
-          Analyze this weekly performance data:
-          ${llm_input_text}
-  content_format: json
-  store_content: true
+# Base LLM call with prompt:
+#   "Analyze this data:\n${llm_input_text}"
 ```
 
 `tasks/__init__.py`:
@@ -153,60 +110,35 @@ import digdag
 import os
 import pytd
 
-
 class LLMFormatter:
     def run(self):
         database = digdag.env.params["database"]
         table = digdag.env.params["table"]
-
-        client = pytd.Client(
-            apikey=os.environ["TD_API_KEY"],
-            database=database,
-        )
+        client = pytd.Client(apikey=os.environ["TD_API_KEY"], database=database)
         result = client.query(f"select * from {table} order by date")
 
-        # Format as markdown table
         headers = result["columns"]
         lines = ["| " + " | ".join(headers) + " |"]
         lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
         for row in result["data"]:
             lines.append("| " + " | ".join(str(v) for v in row) + " |")
-
         digdag.env.store({"llm_input_text": "\n".join(lines)})
-```
-
-`tasks/requirements.txt`:
-```
-pytd
 ```
 
 ---
 
 ## LLM Conditional Action
 
-Ask a yes/no question and branch on the answer. Use `py>` to parse into a boolean.
+Ask a yes/no question and branch on the answer.
 
 ```yaml
 +gather_metrics:
   td>: queries/data_quality_metrics.sql
   store_last_results: true
-  database: analytics
 
-+ask_llm:
-  http>: ${llm_endpoint}
-  method: POST
-  timeout: 300
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 256
-    messages:
-      - role: user
-        content: "Given null_rate=${td.last_results.null_rate}, duplicate_rate=${td.last_results.dup_rate}, row_count=${td.last_results.row_count}: is this data quality acceptable? Reply ONLY with 'yes' or 'no'."
-  content_format: json
-  store_content: true
+# Base LLM call (max_tokens: 256) with prompt:
+#   "Given null_rate=${td.last_results.null_rate}, duplicate_rate=${td.last_results.dup_rate}:
+#    is this data quality acceptable? Reply ONLY 'yes' or 'no'."
 
 +parse_response:
   py>: tasks.ResponseParser.parse_yes_no
@@ -221,82 +153,21 @@ Ask a yes/no question and branch on the answer. Use `py>` to parse into a boolea
       insert_into: public_table
   _else_do:
     +alert:
-      http>: https://slack.com/api/chat.postMessage
-      method: POST
-      headers:
-        - content-type: "application/json"
-        - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
-      content:
-        channel: "C0XXXXXXXXX"
-        text: "Data quality issue flagged for ${session_date}"
+      mail>:
+        data: "Data quality issue flagged for ${session_date}"
+      subject: "ALERT: data quality ${session_date}"
+      to: [team@example.com]
 ```
 
 `tasks/__init__.py`:
 ```python
 import digdag
 import json
-
 
 class ResponseParser:
     def parse_yes_no(self):
         response = digdag.env.params.get("http", {}).get("last_content", "{}")
         body = json.loads(response) if isinstance(response, str) else response
         text = body.get("content", [{}])[0].get("text", "").strip().lower()
-        approved = text.startswith("yes")
-        digdag.env.store({"agent_approved": approved})
+        digdag.env.store({"agent_approved": text.startswith("yes")})
 ```
-
----
-
-## LLM Analysis to HTML Email Report
-
-Query results feed the LLM, and the LLM analysis is embedded into HTML via `py>` + `digdag.env.store()`.
-
-```yaml
-+gather:
-  td>: queries/daily_kpis.sql
-  store_last_results: true
-
-+analyze:
-  http>: ${llm_endpoint}
-  method: POST
-  timeout: 300
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 2048
-    messages:
-      - role: user
-        content: "Analyze these KPIs and write an HTML <div> with key findings: revenue=${td.last_results.revenue}, churn=${td.last_results.churn_rate}%"
-  content_format: json
-  store_content: true
-
-+extract:
-  py>: tasks.ResponseExtractor.run
-  docker:
-    image: "treasuredata/customscript-python:3.12.11-td1"
-
-+send_report:
-  mail>: templates/report.html
-  subject: "Daily Report ${session_date}"
-  to: [team@example.com]
-  html: true
-```
-
-`tasks/__init__.py`:
-```python
-import digdag
-import json
-
-
-class ResponseExtractor:
-    def run(self):
-        response = digdag.env.params.get("http", {}).get("last_content", "{}")
-        body = json.loads(response) if isinstance(response, str) else response
-        text = body.get("content", [{}])[0].get("text", "")
-        digdag.env.store({"analysis_content": text})
-```
-
-The HTML template references `${analysis_content}` (stored by `py>`) and `${td.last_results.*}` for raw KPIs. Use inline CSS only — email clients strip `<link>` tags.

--- a/workflow-skills/llm-workflow/references/llm-patterns.md
+++ b/workflow-skills/llm-workflow/references/llm-patterns.md
@@ -190,7 +190,7 @@ Ask a yes/no question and branch on the answer. Use `py>` to parse into a boolea
   database: analytics
 
 +ask_llm:
-  http>: https://llm-proxy.us01.treasuredata.com/v1/messages
+  http>: ${llm_endpoint}
   method: POST
   headers:
     - x-api-key: ${secret:td.apikey}
@@ -254,7 +254,7 @@ Query results feed the LLM, and the LLM analysis is embedded into HTML via `py>`
   store_last_results: true
 
 +analyze:
-  http>: https://llm-proxy.us01.treasuredata.com/v1/messages
+  http>: ${llm_endpoint}
   method: POST
   headers:
     - x-api-key: ${secret:td.apikey}

--- a/workflow-skills/llm-workflow/references/notification-patterns.md
+++ b/workflow-skills/llm-workflow/references/notification-patterns.md
@@ -1,0 +1,203 @@
+# Notification Patterns
+
+Slack and email notification patterns for TD workflows.
+
+---
+
+## Slack Webhook
+
+Simplest method. The webhook URL contains the auth token — just POST a JSON payload.
+
+```yaml
+_export:
+  # Store webhook URL as a secret, not inline
+  # tdx wf secrets set <project> "slack.webhook=https://hooks.slack.com/services/..."
+
++notify_success:
+  http>: ${secret:slack.webhook}
+  method: POST
+  content:
+    text: "Pipeline completed for ${session_date}"
+```
+
+### Error notification with webhook
+
+```yaml
+_error:
+  http>: ${secret:slack.webhook}
+  method: POST
+  content:
+    text: "Workflow failed for ${session_date}"
+```
+
+---
+
+## Slack Bot API
+
+Use `chat.postMessage` for dynamic channels, thread replies, or richer message control. Requires a Slack Bot with `chat:write` scope.
+
+```yaml
+_export:
+  slack:
+    post_url: "https://slack.com/api/chat.postMessage"
+    channel: "C0XXXXXXXXX"
+
++notify:
+  http>: ${slack.post_url}
+  method: POST
+  headers:
+    - content-type: "application/json"
+    - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+  content:
+    channel: ${slack.channel}
+    text: "Pipeline completed for ${session_date}"
+  store_content: true
+```
+
+### LLM response to Slack (no py> needed)
+
+Chain `http>` calls: LLM response stored via `store_content: true`, then parsed inline with `JSON.parse()`.
+
+```yaml
++llm_summarize:
+  http>: ${llm_endpoint}
+  method: POST
+  headers:
+    - x-api-key: ${secret:td.apikey}
+    - anthropic-version: 2023-06-01
+  content:
+    model: claude-haiku-4-5-20251001
+    max_tokens: 1024
+    messages:
+      - role: user
+        content: "Summarize: metric_a=${td.last_results.metric_a}"
+  content_format: json
+  store_content: true
+
++post_to_slack:
+  http>: ${slack.post_url}
+  method: POST
+  headers:
+    - content-type: "application/json"
+    - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+  content:
+    channel: ${slack.channel}
+    text: ${JSON.parse(http.last_content).content[0].text}
+  store_content: true
+```
+
+### Error notification with Bot API
+
+```yaml
+_error:
+  +notify_failure:
+    http>: https://slack.com/api/chat.postMessage
+    method: POST
+    headers:
+      - content-type: "application/json"
+      - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+    content:
+      channel: "C0XXXXXXXXX"
+      text: "Workflow failed for ${session_date}"
+```
+
+### Success + failure notification pattern
+
+Centralize Slack config in `_export` so both success and error handlers share the same settings.
+
+```yaml
+_export:
+  slack:
+    post_url: "https://slack.com/api/chat.postMessage"
+    channel: "C0XXXXXXXXX"
+
+_error:
+  +notify_failure:
+    http>: ${slack.post_url}
+    method: POST
+    headers:
+      - content-type: "application/json"
+      - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+    content:
+      channel: ${slack.channel}
+      text: "Workflow failed for ${session_date}"
+
+# ... pipeline steps ...
+
++notify_success:
+  http>: ${slack.post_url}
+  method: POST
+  headers:
+    - content-type: "application/json"
+    - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
+  content:
+    channel: ${slack.channel}
+    text: "Pipeline completed for ${session_date}"
+  store_content: true
+```
+
+---
+
+## Email via mail>
+
+TD's built-in SMTP relay handles delivery. Do not configure `mail.host`, `mail.port`, `mail.username`, or `mail.password` secrets — they are not needed on TD platform.
+
+### Plain text
+
+```yaml
++send_report:
+  mail>: templates/report.txt
+  subject: "Daily Report ${session_date}"
+  to: [team@example.com]
+```
+
+### HTML with LLM content
+
+Use `py>` to store the LLM analysis into a variable, then reference it in the HTML template.
+
+```yaml
++analyze:
+  http>: ${llm_endpoint}
+  method: POST
+  headers:
+    - x-api-key: ${secret:td.apikey}
+    - anthropic-version: 2023-06-01
+  content:
+    model: claude-haiku-4-5-20251001
+    max_tokens: 2048
+    messages:
+      - role: user
+        content: "Write an HTML summary of: revenue=${td.last_results.revenue}"
+  content_format: json
+  store_content: true
+
++extract:
+  py>: tasks.ResponseExtractor.run
+  docker:
+    image: "treasuredata/customscript-python:3.12.11-td1"
+
++send_report:
+  mail>: templates/report.html
+  subject: "Daily Report ${session_date}"
+  to: [team@example.com]
+  html: true
+```
+
+`templates/report.html`:
+```html
+<h2>Daily Report: ${session_date}</h2>
+<div>${analysis_content}</div>
+```
+
+Use inline CSS only — email clients strip `<link>` tags.
+
+---
+
+## Secrets Reference
+
+| Secret | Method | How to set |
+|---|---|---|
+| `slack.webhook` | Slack Webhook | `tdx wf secrets set <project> "slack.webhook=YOUR_URL"` |
+| `slack.bot_user_oauth_token` | Slack Bot API | `tdx wf secrets set <project> "slack.bot_user_oauth_token=YOUR_TOKEN"` |
+
+Slack Bot setup: Create a Slack App, add `chat:write` scope, install to workspace, copy Bot User OAuth Token.

--- a/workflow-skills/llm-workflow/references/notification-patterns.md
+++ b/workflow-skills/llm-workflow/references/notification-patterns.md
@@ -9,9 +9,8 @@ Slack and email notification patterns for TD workflows.
 Simplest method. The webhook URL contains the auth token — just POST a JSON payload.
 
 ```yaml
-_export:
-  # Store webhook URL as a secret, not inline
-  # tdx wf secrets set <project> "slack.webhook=https://hooks.slack.com/services/..."
+# Store webhook URL as a secret, not inline
+# tdx wf secrets set <project> "slack.webhook=https://hooks.slack.com/services/..."
 
 +notify_success:
   http>: ${secret:slack.webhook}

--- a/workflow-skills/llm-workflow/references/notification-patterns.md
+++ b/workflow-skills/llm-workflow/references/notification-patterns.md
@@ -183,6 +183,20 @@ Use `py>` to store the LLM analysis into a variable, then reference it in the HT
   html: true
 ```
 
+`tasks/__init__.py`:
+```python
+import digdag
+import json
+
+
+class ResponseExtractor:
+    def run(self):
+        response = digdag.env.params.get("http", {}).get("last_content", "{}")
+        body = json.loads(response) if isinstance(response, str) else response
+        text = body.get("content", [{}])[0].get("text", "")
+        digdag.env.store({"analysis_content": text})
+```
+
 `templates/report.html`:
 ```html
 <h2>Daily Report: ${session_date}</h2>

--- a/workflow-skills/llm-workflow/references/notification-patterns.md
+++ b/workflow-skills/llm-workflow/references/notification-patterns.md
@@ -61,6 +61,7 @@ Chain `http>` calls: LLM response stored via `store_content: true`, then parsed 
 +llm_summarize:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01
@@ -158,6 +159,7 @@ Use `py>` to store the LLM analysis into a variable, then reference it in the HT
 +analyze:
   http>: ${llm_endpoint}
   method: POST
+  timeout: 300
   headers:
     - x-api-key: ${secret:td.apikey}
     - anthropic-version: 2023-06-01

--- a/workflow-skills/llm-workflow/references/notification-patterns.md
+++ b/workflow-skills/llm-workflow/references/notification-patterns.md
@@ -1,25 +1,74 @@
 # Notification Patterns
 
-Slack and email notification patterns for TD workflows.
+Email and Slack notification patterns for TD workflows.
+
+---
+
+## Email via mail>
+
+TD's built-in SMTP relay handles delivery — no secrets needed on TD platform. Simplest notification path.
+
+### Plain text alert
+
+```yaml
++send_alert:
+  mail>:
+    data: "Pipeline completed for ${session_date}"
+  subject: "Daily Pipeline ${session_date}"
+  to: [team@example.com]
+```
+
+### HTML report with LLM content
+
+Extract LLM response via `py>`, then reference the variable in the HTML template.
+
+```yaml
+# Assumes LLM call already ran with store_content: true
+
++extract:
+  py>: tasks.ResponseExtractor.run
+  docker:
+    image: "treasuredata/customscript-python:3.12.11-td1"
+
++send_report:
+  mail>: templates/report.html
+  subject: "Daily Report ${session_date}"
+  to: [team@example.com]
+  html: true
+```
+
+`templates/report.html` — use inline CSS only (email clients strip `<link>` tags):
+```html
+<h2>Daily Report: ${session_date}</h2>
+<div>${llm_summary}</div>
+```
+
+### Error notification
+
+```yaml
+_error:
+  +notify_failure:
+    mail>:
+      data: "Workflow failed for ${session_date}"
+    subject: "ALERT: workflow failure ${session_date}"
+    to: [team@example.com]
+```
 
 ---
 
 ## Slack Webhook
 
-Simplest method. The webhook URL contains the auth token — just POST a JSON payload.
+Webhook URL contains the auth token — just POST a JSON payload.
 
 ```yaml
-# Store webhook URL as a secret, not inline
-# tdx wf secrets set <project> "slack.webhook=https://hooks.slack.com/services/..."
-
-+notify_success:
++notify:
   http>: ${secret:slack.webhook}
   method: POST
   content:
     text: "Pipeline completed for ${session_date}"
 ```
 
-### Error notification with webhook
+Error notification:
 
 ```yaml
 _error:
@@ -35,12 +84,18 @@ _error:
 
 Use `chat.postMessage` for dynamic channels, thread replies, or richer message control. Requires a Slack Bot with `chat:write` scope.
 
+Centralize config in `_export` so both success and error handlers share the same settings:
+
 ```yaml
 _export:
   slack:
     post_url: "https://slack.com/api/chat.postMessage"
     channel: "C0XXXXXXXXX"
+```
 
+### Basic notification
+
+```yaml
 +notify:
   http>: ${slack.post_url}
   method: POST
@@ -55,24 +110,10 @@ _export:
 
 ### LLM response to Slack (no py> needed)
 
-Chain `http>` calls: LLM response stored via `store_content: true`, then parsed inline with `JSON.parse()`.
+`JSON.parse()` extracts the LLM response text inline:
 
 ```yaml
-+llm_summarize:
-  http>: ${llm_endpoint}
-  method: POST
-  timeout: 300
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 1024
-    messages:
-      - role: user
-        content: "Summarize: metric_a=${td.last_results.metric_a}"
-  content_format: json
-  store_content: true
+# Assumes LLM call already ran with store_content: true
 
 +post_to_slack:
   http>: ${slack.post_url}
@@ -86,31 +127,9 @@ Chain `http>` calls: LLM response stored via `store_content: true`, then parsed 
   store_content: true
 ```
 
-### Error notification with Bot API
+### Error notification
 
 ```yaml
-_error:
-  +notify_failure:
-    http>: https://slack.com/api/chat.postMessage
-    method: POST
-    headers:
-      - content-type: "application/json"
-      - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
-    content:
-      channel: "C0XXXXXXXXX"
-      text: "Workflow failed for ${session_date}"
-```
-
-### Success + failure notification pattern
-
-Centralize Slack config in `_export` so both success and error handlers share the same settings.
-
-```yaml
-_export:
-  slack:
-    post_url: "https://slack.com/api/chat.postMessage"
-    channel: "C0XXXXXXXXX"
-
 _error:
   +notify_failure:
     http>: ${slack.post_url}
@@ -121,98 +140,22 @@ _error:
     content:
       channel: ${slack.channel}
       text: "Workflow failed for ${session_date}"
-
-# ... pipeline steps ...
-
-+notify_success:
-  http>: ${slack.post_url}
-  method: POST
-  headers:
-    - content-type: "application/json"
-    - Authorization: "Bearer ${secret:slack.bot_user_oauth_token}"
-  content:
-    channel: ${slack.channel}
-    text: "Pipeline completed for ${session_date}"
-  store_content: true
 ```
 
 ---
 
-## Email via mail>
+## Shared py> Helper
 
-TD's built-in SMTP relay handles delivery. Do not configure `mail.host`, `mail.port`, `mail.username`, or `mail.password` secrets — they are not needed on TD platform.
+Used by both email and Slack patterns when `py>` extraction is needed:
 
-### Plain text
-
-```yaml
-+send_report:
-  mail>: templates/report.txt
-  subject: "Daily Report ${session_date}"
-  to: [team@example.com]
-```
-
-### HTML with LLM content
-
-Use `py>` to store the LLM analysis into a variable, then reference it in the HTML template.
-
-```yaml
-+analyze:
-  http>: ${llm_endpoint}
-  method: POST
-  timeout: 300
-  headers:
-    - x-api-key: ${secret:td.apikey}
-    - anthropic-version: 2023-06-01
-  content:
-    model: claude-haiku-4-5-20251001
-    max_tokens: 2048
-    messages:
-      - role: user
-        content: "Write an HTML summary of: revenue=${td.last_results.revenue}"
-  content_format: json
-  store_content: true
-
-+extract:
-  py>: tasks.ResponseExtractor.run
-  docker:
-    image: "treasuredata/customscript-python:3.12.11-td1"
-
-+send_report:
-  mail>: templates/report.html
-  subject: "Daily Report ${session_date}"
-  to: [team@example.com]
-  html: true
-```
-
-`tasks/__init__.py`:
 ```python
 import digdag
 import json
-
 
 class ResponseExtractor:
     def run(self):
         response = digdag.env.params.get("http", {}).get("last_content", "{}")
         body = json.loads(response) if isinstance(response, str) else response
         text = body.get("content", [{}])[0].get("text", "")
-        digdag.env.store({"analysis_content": text})
+        digdag.env.store({"llm_summary": text})
 ```
-
-`templates/report.html`:
-```html
-<h2>Daily Report: ${session_date}</h2>
-<div>${analysis_content}</div>
-```
-
-Use inline CSS only — email clients strip `<link>` tags.
-
----
-
-## Secrets Reference
-
-| Secret | Method | How to set |
-|---|---|---|
-| `slack.webhook` | Slack Webhook | `tdx wf secrets set <project> "slack.webhook=YOUR_URL"` |
-| `slack.bot_user_oauth_token` | Slack Bot API | `tdx wf secrets set <project> "slack.bot_user_oauth_token=YOUR_TOKEN"` |
-
-Slack Bot setup: Create a Slack App, add `chat:write` scope, install to workspace, copy Bot User OAuth Token.

--- a/workflow-skills/workflow-management/SKILL.md
+++ b/workflow-skills/workflow-management/SKILL.md
@@ -97,27 +97,34 @@ Use `td_partial_delete>` before insert, or `create_table` to overwrite.
 # Option 1: Partial delete + insert
 +delete_existing:
   td_partial_delete>: target_table
+  database: analytics
   from: ${session_date}
   to: ${next_session_date}
 
 +insert_fresh:
   td>: queries/transform.sql
+  database: analytics
   insert_into: target_table
 
 # Option 2: Overwrite with create_table
 +overwrite:
   td>: queries/transform.sql
+  database: analytics
   create_table: target_table
 ```
 
 ## Backfill Pattern
+
+Use `loop>` with date math to iterate over past days:
 
 ```yaml
 +backfill:
   loop>: 7
   _do:
     +process:
-      call>: main_workflow.dig
+      td>: queries/process.sql
+      _export:
+        target_date: ${moment(session_time).subtract(i, 'days').format("YYYY-MM-DD")}
 ```
 
 Or use `for_each>` with explicit dates:
@@ -129,6 +136,8 @@ Or use `for_each>` with explicit dates:
   _do:
     +process:
       td>: queries/process.sql
+      _export:
+        dt: ${target_date}
 ```
 
 ## Secrets

--- a/workflow-skills/workflow-management/SKILL.md
+++ b/workflow-skills/workflow-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-management
-description: TD workflow debugging and operations. Covers tdx wf commands for monitoring (sessions, attempt, logs), retry/backfill patterns, alerting (_error with Slack/email), and data quality checks.
+description: TD workflow debugging and operations. Covers tdx wf commands for monitoring (sessions, attempt, logs), retry/backfill patterns, alerting (_error with Slack/email), and data quality checks. Use when debugging failed workflows, checking session logs, retrying tasks, or setting up workflow alerts.
 ---
 
 # TD Workflow Management
@@ -28,16 +28,15 @@ tdx wf push                          # Push changes with diff preview
 
 ## Alerting
 
-```yaml
-+critical_task:
-  td>: queries/important.sql
+Use `http>` with Slack webhook or Bot API. For detailed Slack patterns, see the **llm-workflow** skill.
 
-  _error:
-    +slack_alert:
-      sh>: |
-        curl -X POST ${secret:slack.webhook_url} \
-        -H 'Content-Type: application/json' \
-        -d '{"text": "Workflow failed: ${session_id}"}'
+```yaml
+_error:
+  +slack_alert:
+    http>: ${secret:slack.webhook}
+    method: POST
+    content:
+      text: "Workflow failed: ${session_date}"
 ```
 
 ## Data Quality Checks
@@ -50,52 +49,86 @@ tdx wf push                          # Push changes with diff preview
 +validate:
   td>:
     query: |
-      SELECT COUNT(*) as cnt,
-             SUM(CASE WHEN id IS NULL THEN 1 ELSE 0 END) as nulls
-      FROM results
+      select count(*) as cnt,
+             sum(case when id is null then 1 else 0 end) as nulls
+      from results
   store_last_results: true
 
 +check:
   if>: ${td.last_results.cnt == 0}
   _do:
     +fail:
-      sh>: exit 1
+      fail>: "No rows produced — data quality check failed"
 ```
 
 ## Wait for Data
 
+Use `td_wait_table>` to wait for data availability before processing.
+
 ```yaml
 +wait_for_data:
-  sh>: |
-    for i in {1..30}; do
-      COUNT=$(tdx query -d analytics "SELECT COUNT(*) FROM src WHERE date='${session_date}'" --format csv | tail -1)
-      if [ "$COUNT" -gt 0 ]; then exit 0; fi
-      sleep 60
-    done
-    exit 1
+  td_wait_table>: source_table
+  database: analytics
+  rows: 1
+  interval: 120
+```
+
+For custom conditions, use `td_wait>` with a SQL query:
+
+```yaml
++wait_for_condition:
+  td_wait>: queries/check_ready.sql
+  database: analytics
+  interval: 120
+```
+
+`queries/check_ready.sql`:
+```sql
+select count(*) > 0
+from source_table
+where td_interval(time, '-1d')
 ```
 
 ## Idempotent Operations
 
+Use `td_partial_delete>` before insert, or `create_table` to overwrite.
+
 ```yaml
-+safe_insert:
-  td>:
-    query: |
-      DELETE FROM target WHERE date = '${session_date}';
-      INSERT INTO target SELECT * FROM source WHERE date = '${session_date}'
+# Option 1: Partial delete + insert
++delete_existing:
+  td_partial_delete>: target_table
+  from: ${session_date}
+  to: ${next_session_date}
+
++insert_fresh:
+  td>: queries/transform.sql
+  insert_into: target_table
+
+# Option 2: Overwrite with create_table
++overwrite:
+  td>: queries/transform.sql
+  create_table: target_table
 ```
 
 ## Backfill Pattern
 
 ```yaml
 +backfill:
-  loop>:
-    dates: ["2024-01-01", "2024-01-02", "2024-01-03"]
+  loop>: 7
   _do:
     +process:
       call>: main_workflow.dig
-      params:
-        session_date: ${dates}
+```
+
+Or use `for_each>` with explicit dates:
+
+```yaml
++backfill:
+  for_each>:
+    target_date: ["2026-01-01", "2026-01-02", "2026-01-03"]
+  _do:
+    +process:
+      td>: queries/process.sql
 ```
 
 ## Secrets
@@ -103,8 +136,12 @@ tdx wf push                          # Push changes with diff preview
 See **tdx-skills/workflow** for `tdx wf secrets` commands. Usage in .dig files:
 
 ```yaml
-+task:
-  sh>: curl -H "Authorization: ${secret:API_KEY}" https://api.example.com
++call_api:
+  http>: https://api.example.com/data
+  method: GET
+  headers:
+    - Authorization: "Bearer ${secret:api_token}"
+  store_content: true
 ```
 
 ## Common Issues
@@ -114,4 +151,4 @@ See **tdx-skills/workflow** for `tdx wf secrets` commands. Usage in .dig files:
 | Timeout | Add `timeout: 3600s`, `_retry: 2` |
 | Intermittent failures | Add `_retry: 5` with exponential backoff |
 | Out of memory | Reduce data volume, use approx functions |
-| Duplicate runs | Use idempotent DELETE+INSERT pattern |
+| Duplicate runs | Use idempotent DELETE+INSERT or `create_table` pattern |


### PR DESCRIPTION
## Summary

- **New skill: `llm-workflow`** — end-to-end LLM pipeline patterns (data pipeline → LLM summarize → Slack/Mail notify) with E2E template as the main entry point
- **Reorganized `digdag` skill** — slimmed down to pure syntax reference (HOW to write .dig), moved LLM/notification patterns to llm-workflow
- **Fixed `workflow-management` skill** — replaced all `sh>` examples with TD-available operators (`http>`, `td_wait_table>`, `td_partial_delete>`, `fail>`)
- **Expanded `operators.md`** — added docs for 7 previously undocumented operators (`td_partial_delete>`, `td_table_export>`, `td_result_export>`, `for_range>`, `wait>`, `require>`, `http_call>`)
- **Cleaned up `scaffold.md`** — removed unused Langfuse secrets, replaced LLM-specific example with generic secret reference syntax

### Role separation

| Skill | Role | Content |
|---|---|---|
| `digdag` | Syntax reference (HOW to write) | .dig syntax, operators, session variables, scheduling |
| `llm-workflow` | LLM pipeline patterns (WHAT to build) | E2E template, LLM Proxy/Agent, Slack (Webhook/Bot API), Mail |
| `workflow-management` | Operations (HOW to operate) | Debugging, retry, backfill, monitoring |

### Key patterns introduced

- **Slack Bot API** (`chat.postMessage`) with Bearer token auth — more flexible than webhook
- **`JSON.parse()` inline parsing** — extract LLM response text without `py>` overhead
- **TD Agent webhook** — correct pattern with `Basic` auth, `action_id`, and `question` field
- **Centralized `_export`** — Slack/LLM config shared across steps and `_error` handler

## Test plan

- [ ] Verify `llm-workflow` registered in marketplace.json
- [ ] Verify trigger test routes "Build a workflow that summarizes KPIs with LLM and posts to Slack" to `llm-workflow`
- [ ] Verify no `sh>` remains in workflow-management examples
- [ ] Verify all cross-references between skills resolve (no broken links)
- [ ] Run `./tests/run-tests.sh` to validate trigger tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)