### PR TITLE
chore: add .playwright to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/worktrees
+.playwright


### PR DESCRIPTION
## Summary
- Add `.playwright` to `.gitignore` to prevent local Playwright cache from being committed

## Test plan
- [x] No functional changes — gitignore only

🤖 Generated with [Claude Code](https://claude.com/claude-code)