### PR TITLE
feat(graflow): update HITL docs and template for Studio Phase 2

### DIFF
--- a/workflow-skills/graflow/SKILL.md
+++ b/workflow-skills/graflow/SKILL.md
@@ -15,11 +15,9 @@ Build Python workflow pipelines combining **deterministic flow control** (branch
 | Add Studio Agent to a task | See [Studio Agent Integration](#studio-agent-integration) |
 | Use CLI tools without agent overhead | See [Subprocess Tasks](#subprocess-tasks) |
 | Add branching or loops | See [Dynamic Control Flow](#dynamic-control-flow) |
-| Add human approval gates (see Studio note below) | See [HITL Patterns](references/advanced-patterns.md#human-in-the-loop-hitl) |
+| Add human approval gates | See [HITL Patterns](references/advanced-patterns.md#human-in-the-loop-hitl) |
 | Configure triggers and tool permissions | See [manifest.yml Reference](references/manifest-yml.md) |
 | Browse templates | See [templates/](templates/) |
-
-> **HITL + Studio**: `ctx.request_feedback()` works as a Graflow primitive, but the Studio agentic-workflow runtime does **not** yet provide an approval UI. A Studio-launched workflow that calls `request_feedback()` will block on a filesystem poll until the timeout expires (by default, failing the run). For Studio-targeted workflows, either skip the HITL task or keep humans in the loop out-of-band (e.g. post the draft to a Slack review channel for manual follow-up). When Studio Phase 2 lands, the task will surface in the UI without code changes.
 
 ## When to Use Graflow
 
@@ -372,7 +370,7 @@ Write `workflow.py` + `manifest.yml` + `requirements.txt` based on the approved 
 | [cs-health-check.py](templates/cs-health-check.py) | `scan >> evaluate >> alert` | CS account monitoring |
 | [sdr-sequence.py](templates/sdr-sequence.py) | `qualify >> (enrich_co \| enrich_ct) >> personalize >> schedule` | SDR outreach automation |
 | [parallel-enrichment.py](templates/parallel-enrichment.py) | `fetch >> (crm \| usage \| support) >> merge >> report` | Multi-source data enrichment |
-| [hitl-approval.py](templates/hitl-approval.py) (Studio UI pending) | `draft >> approve >> send/revise` | Human-gated content delivery (not runnable in Studio until Phase 2) |
+| [hitl-approval.py](templates/hitl-approval.py) | `draft >> approve >> send/revise` | Human-gated content delivery with Studio approval UI |
 
 ## References
 

--- a/workflow-skills/graflow/references/advanced-patterns.md
+++ b/workflow-skills/graflow/references/advanced-patterns.md
@@ -102,63 +102,108 @@ def root(ctx: TaskExecutionContext):
 
 ## Human-in-the-Loop (HITL)
 
-> ⚠️ **Studio compatibility**: The Studio agentic-workflow runtime does **not** yet surface an approval UI for HITL requests. `ctx.request_feedback()` blocks on a filesystem poll for `feedback_data/responses/{feedback_id}.json` — if nothing writes that file before the `timeout`, the task raises `FeedbackTimeoutError` and the workflow run fails. For Studio-targeted workflows, prefer out-of-band review (post the draft to a Slack review channel and act on it separately) until Phase 2 adds the UI. The patterns below are still correct Graflow API, and will work unchanged once the UI lands.
+Studio provides a built-in HITL mechanism via `request_feedback()` from the `studio_agent` package. When a workflow calls `request_feedback()`, Studio displays an approval card in the Agentic Workflows panel (plus an OS notification), and the call blocks until the user responds or the timeout expires.
+
+Use `request_feedback()` instead of Graflow's native `ctx.request_feedback()` for workflows running under Studio. The Studio function uses HTTP long-polling to the Local API Server rather than filesystem polling, and surfaces a rich approval UI with options, context display, and free-form comments.
 
 ### Basic Approval
 ```python
-@task(inject_context=True)
-def approval_task(ctx: TaskExecutionContext):
-    response = ctx.request_feedback(
-        feedback_type="approval",
-        prompt="Approve deployment to production?",
-        timeout=300.0,
-    )
+from studio_agent import request_feedback
 
-    if response.approved:
-        ctx.next_task(deploy())
-    else:
-        ctx.cancel_workflow(error=f"Rejected: {response.reason}")
+@task
+def approval_gate(draft: str) -> dict:
+    decision = request_feedback(
+        prompt=f"Approve this draft?\n\n{draft}",
+        timeout=3600,
+    )
+    if decision["status"] != "approved":
+        raise RuntimeError(f"Rejected: {decision.get('comment', 'no reason')}")
+    return decision
 ```
 
-### Text Input
+### Selection with Options
 ```python
 @task(inject_context=True)
-def text_input_task(ctx: TaskExecutionContext):
-    response = ctx.request_feedback(
-        feedback_type="text",
-        prompt="Enter the target Slack channel:",
-        timeout=60.0,
-    )
-    channel_name = response.text
-```
-
-### Selection
-```python
-@task(inject_context=True)
-def selection_task(ctx: TaskExecutionContext):
-    response = ctx.request_feedback(
-        feedback_type="selection",
+def select_action(ctx: TaskExecutionContext):
+    decision = request_feedback(
         prompt="Select action for at-risk account:",
-        options=["schedule_call", "send_email", "escalate_to_manager", "skip"],
-        timeout=120.0,
+        options=["Schedule call", "Send email", "Escalate to manager", "Skip"],
+        timeout=300,
     )
-    selected_action = response.selected
+    ctx.get_channel().set("action", decision["choice"])
 ```
 
-### Channel Integration
+### Rich Context Display
 ```python
 @task(inject_context=True)
-def feedback_to_channel(ctx: TaskExecutionContext):
-    response = ctx.request_feedback(
-        feedback_type="selection",
-        prompt="Select processing mode:",
-        options=["conservative", "balanced", "aggressive"],
-        channel_key="processing_mode",  # Auto-write to channel
-        write_to_channel=True,
-        timeout=60.0,
+def review_outreach(ctx: TaskExecutionContext):
+    email_body = ctx.get_channel().get("email_body")
+    account = ctx.get_channel().get("account")
+    decision = request_feedback(
+        prompt="Send this outreach email?",
+        options=["Send now", "Queue for tomorrow", "Discard"],
+        context={
+            "account": account["name"],
+            "ARR": f"${account['arr']:,.0f}",
+            "email_preview": email_body[:500],
+        },
+        timeout=3600,
     )
-    # response.selected is also written to channel["processing_mode"]
+    ctx.get_channel().set("send_decision", decision)
 ```
+
+### Handling All Response Statuses
+```python
+decision = request_feedback(prompt="Deploy to production?", timeout=1800)
+
+if decision["status"] == "approved":
+    # User clicked Approve
+    print(f"Approved. Choice: {decision['choice']}, Comment: {decision['comment']}")
+elif decision["status"] == "rejected":
+    # User clicked Reject
+    print(f"Rejected. Reason: {decision['comment']}")
+elif decision["status"] == "timeout":
+    # No response within timeout
+    print("No response — aborting.")
+elif decision["status"] == "cancelled":
+    # Studio closed or workflow run cancelled
+    print("Cancelled — exiting cleanly.")
+```
+
+### `request_feedback()` API
+
+```python
+from studio_agent import request_feedback
+
+decision = request_feedback(
+    prompt="Question for the user (1–2000 chars)",
+    options=["Option A", "Option B"],   # Up to 4 labeled options (optional)
+    context={"key": "value"},           # Key/value pairs shown beside the prompt (optional)
+    timeout=3600,                       # Max seconds to wait (clamped to [60, 86400])
+)
+```
+
+**Returns** a dict:
+
+| Key | Type | Description |
+|---|---|---|
+| `status` | `str` | `"approved"` \| `"rejected"` \| `"timeout"` \| `"cancelled"` |
+| `choice` | `str \| None` | Selected option label, or `None` |
+| `comment` | `str \| None` | Free-form text the user entered, or `None` |
+
+**Raises** `StudioAgentError` if Studio is unreachable.
+
+### Timeout Strategy for HITL Workflows
+
+When a workflow includes `request_feedback()`, the `execution.timeout` in `manifest.yml` must account for human response time. Budget the `request_feedback` timeout **plus** agent task time:
+
+| Workflow Shape | Recommended `execution.timeout` |
+|---|---|
+| 1 agent task + 1 HITL (1h) | 3900 (3600 + 300 margin) |
+| 2 agent tasks + 1 HITL (1h) | 4200 |
+| Agent + HITL + agent (chain) | 4500+ |
+
+Set `execution.timeout` >= the sum of all `request_feedback` timeouts plus agent execution time.
 
 ---
 

--- a/workflow-skills/graflow/references/advanced-patterns.md
+++ b/workflow-skills/graflow/references/advanced-patterns.md
@@ -117,7 +117,7 @@ def approval_gate(draft: str) -> dict:
         timeout=3600,
     )
     if decision["status"] != "approved":
-        raise RuntimeError(f"Rejected: {decision.get('comment', 'no reason')}")
+        raise RuntimeError(f"Rejected: {decision.get('comment') or 'no reason'}")
     return decision
 ```
 

--- a/workflow-skills/graflow/references/manifest-yml.md
+++ b/workflow-skills/graflow/references/manifest-yml.md
@@ -38,12 +38,6 @@ execution:
   timeout: 300                        # Max execution time in seconds (default: 300)
   max_retries: 2                      # Retry on failure (default: 0)
 
-# HITL settings (Phase 2 — not yet wired into Studio runtime; see warning below)
-hitl:
-  enabled: false
-  approval_channel: slack             # slack | studio
-  timeout: 3600                       # Wait time for human response (seconds)
-
 # Results retention
 results:
   max_retained: 30                    # Number of run results to keep (default: 30)

--- a/workflow-skills/graflow/references/studio-agent-bridge.md
+++ b/workflow-skills/graflow/references/studio-agent-bridge.md
@@ -213,6 +213,63 @@ with StudioAgent() as agent:
     result = agent.run("...")
 ```
 
+## Human-in-the-Loop: `request_feedback()`
+
+The `studio_agent` package provides a standalone `request_feedback()` function that pauses the workflow until a human responds via Studio's approval UI.
+
+```python
+from studio_agent import request_feedback
+
+decision = request_feedback(
+    prompt="Send the renewal pitch to Acme Corp?",
+    options=["Send now", "Queue for tomorrow"],
+    context={
+        "summary": "3 sessions this week, ARR $120k",
+        "draft": "Hi Pat — just checking in on Q2 goals...",
+    },
+    timeout=3600,
+)
+
+if decision["status"] == "approved":
+    selected = decision["choice"]    # "Send now" or "Queue for tomorrow"
+    comment = decision["comment"]    # Optional free-form text from user
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `prompt` | `str` | (required) | Question shown to the user (1–2000 chars) |
+| `options` | `list[str] \| None` | `None` | Up to 4 labeled options. `None` = free-form only |
+| `context` | `dict \| None` | `None` | Key/value pairs rendered beside the prompt |
+| `timeout` | `int` | `3600` | Max seconds to wait. Server clamps to [60, 86400] |
+| `base_url` | `str \| None` | env-resolved | Override Studio API base URL |
+| `auth_token` | `str \| None` | env-resolved | Override per-run auth token |
+
+### Return Value
+
+Returns a dict with three keys:
+
+| Key | Type | Description |
+|---|---|---|
+| `status` | `str` | `"approved"` \| `"rejected"` \| `"timeout"` \| `"cancelled"` |
+| `choice` | `str \| None` | Selected option label, or `None` if no options provided |
+| `comment` | `str \| None` | Free-form text the user entered, or `None` |
+
+### How It Works
+
+1. `request_feedback()` POSTs to Studio's `/feedback/create` endpoint
+2. Studio displays an approval card in the Agentic Workflows panel + sends an OS notification
+3. The function blocks on HTTP long-polling (`/feedback/{id}/wait`) until the user responds
+4. When the user clicks Approve/Reject, the resolution is returned to the caller
+
+### Notes
+
+- `request_feedback()` is independent of `StudioAgent` — it doesn't require an active agent session. Call it anywhere in your workflow code.
+- `auth_token` and `base_url` are auto-resolved from environment variables (`STUDIO_AUTH_TOKEN`, `STUDIO_API_PORT`) set by Studio when launching the workflow subprocess.
+- If Studio is closed while a feedback request is pending, `status` becomes `"cancelled"`.
+- Set `execution.timeout` in `manifest.yml` high enough to cover human response time (e.g. 3900s for a 1-hour HITL + 300s agent margin).
+
 ## Error Handling
 
 ```python

--- a/workflow-skills/graflow/templates/hitl-approval.py
+++ b/workflow-skills/graflow/templates/hitl-approval.py
@@ -1,31 +1,20 @@
 """HITL Approval Workflow
 
-Drafts content using Studio Agent, pauses for human approval,
-then sends or revises based on feedback.
+Drafts content using Studio Agent, pauses for human approval via
+Studio's approval UI, then sends or revises based on feedback.
 
 Graph: draft_content >> request_approval >> route_action
 
 Each agent-backed task opens its own ephemeral Studio Agent session.
-The ``request_approval`` task stores decision state on the channel so
-that ``route_action`` (which also opens a fresh session) can branch
-deterministically without relying on shared agent memory.
-
-.. warning::
-
-    The Studio agentic-workflow runtime does NOT yet surface an
-    approval UI. Running this template under Studio causes
-    ``request_approval`` to block on a filesystem poll for
-    ``feedback_data/responses/{feedback_id}.json`` until the
-    ``timeout`` elapses and the task raises ``FeedbackTimeoutError``.
-    Either skip HITL in Studio-targeted workflows, or run this
-    template outside Studio and drop the response JSON manually to
-    unblock it. Once Studio Phase 2 lands, this template will work
-    unchanged.
+The ``request_approval`` task uses ``request_feedback()`` from the
+``studio_agent`` package to display an approval card in Studio and
+block until the user responds. Decision state is stored on the channel
+so ``route_action`` can branch deterministically.
 """
 
 from graflow import task, workflow
 from graflow.core.context import TaskExecutionContext
-from studio_agent import StudioAgent
+from studio_agent import StudioAgent, request_feedback
 
 
 @task
@@ -43,26 +32,31 @@ def draft_content() -> str:
 
 @task(inject_context=True)
 def request_approval(ctx: TaskExecutionContext, draft: str) -> bool:
-    """Pause workflow and wait for human review."""
-    response = ctx.request_feedback(
-        feedback_type="approval",
-        prompt=(
-            f"Review this executive update draft:\n\n{draft}\n\n"
-            "Approve to send, or reject with revision notes."
-        ),
-        timeout=3600.0,
+    """Pause workflow and wait for human review via Studio approval UI."""
+    decision = request_feedback(
+        prompt="Review this executive update draft. Approve to send, or reject with revision notes.",
+        options=["Send as-is", "Send with edits"],
+        context={
+            "draft": draft[:1000],
+            "type": "Weekly CS Update",
+        },
+        timeout=3600,
     )
 
     channel = ctx.get_channel()
-    if response.approved:
+    if decision["status"] == "approved":
         channel.set("action", "send")
         channel.set("final_content", draft)
-    else:
+        if decision["comment"]:
+            channel.set("send_note", decision["comment"])
+    elif decision["status"] == "rejected":
         channel.set("action", "revise")
-        channel.set("revision_notes", response.reason)
+        channel.set("revision_notes", decision.get("comment") or "No specific notes provided")
         channel.set("original_draft", draft)
+    else:
+        channel.set("action", "abort")
 
-    return response.approved
+    return decision["status"] == "approved"
 
 
 @task(inject_context=True)
@@ -75,12 +69,16 @@ def route_action(ctx: TaskExecutionContext, approved: bool) -> str:
     channel = ctx.get_channel()
     action = channel.get("action")
 
+    if action == "abort":
+        return "Workflow aborted — no human response or run cancelled."
+
     if action == "send":
         content = channel.get("final_content")
         with StudioAgent() as agent:
             result = agent.run(
                 f"Send this executive update via email to the CS leadership "
-                f"distribution list and post to #cs-leadership on Slack:\n\n{content}"
+                f"distribution list and post to #cs-leadership on Slack. "
+                f"Use slack_post_message tool.\n\n{content}"
             )
         return result["output"]
 

--- a/workflow-skills/graflow/templates/hitl-approval.py
+++ b/workflow-skills/graflow/templates/hitl-approval.py
@@ -44,19 +44,17 @@ def request_approval(ctx: TaskExecutionContext, draft: str) -> bool:
     )
 
     channel = ctx.get_channel()
-    if decision["status"] == "approved":
+    if decision["status"] == "approved" and decision.get("choice") != "Send with edits":
         channel.set("action", "send")
         channel.set("final_content", draft)
-        if decision["comment"]:
-            channel.set("send_note", decision["comment"])
-    elif decision["status"] == "rejected":
+    elif decision["status"] in ("approved", "rejected"):
         channel.set("action", "revise")
         channel.set("revision_notes", decision.get("comment") or "No specific notes provided")
         channel.set("original_draft", draft)
     else:
         channel.set("action", "abort")
 
-    return decision["status"] == "approved"
+    return channel.get("action") == "send"
 
 
 @task(inject_context=True)


### PR DESCRIPTION
## Summary

- Remove "Phase 2 not yet landed" warnings and "Studio UI pending" labels across all graflow skill docs
- Replace `ctx.request_feedback()` (Graflow filesystem-poll primitive) with `studio_agent.request_feedback()` (Studio HTTP long-poll API) in all references and templates
- Add full `request_feedback()` API reference to studio-agent-bridge.md (parameters, return value, behavior, notes)
- Remove stale `hitl` manifest config section — HITL is now a regular function call in task code, no manifest config needed
- Rewrite hitl-approval.py template with options, context display, and all four status branches

## Context

Studio Phase 2 shipped `request_feedback()` in the `studio_agent` package. It displays an approval card in the Agentic Workflows panel with OS notifications, and blocks via HTTP long-polling until the user responds. This makes the old filesystem-poll approach and manifest-level `hitl` config obsolete for Studio-targeted workflows.

## Test plan

- [ ] Verify `hitl-approval.py` template runs correctly in Studio with a scaffolded workflow
- [ ] Confirm `request_feedback()` API docs in studio-agent-bridge.md match the actual Python function signature
- [ ] Check no remaining references to "Phase 2 not landed" or `ctx.request_feedback()` in graflow skill files

🤖 Generated with [Claude Code](https://claude.com/claude-code)