### PR TITLE
Add Treasure AI Slides Skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,11 +127,12 @@
     },
     {
       "name": "document-skills",
-      "description": "Document creation skills including PowerPoint presentation generation using HTML-to-PPTX conversion pipeline with agent-browser for rendering and PptxGenJS for assembly",
+      "description": "Document creation skills including PowerPoint presentation generation using HTML-to-PPTX conversion pipeline (generic) and Treasure AI branded template generation (python-pptx/pptxgenjs)",
       "source": "./",
       "strict": false,
       "skills": [
-        "./document-skills/pptx"
+        "./document-skills/pptx",
+        "./document-skills/treasure-ai-slides"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -110,6 +110,7 @@
         "./tdx-skills/agent-prompt",
         "./tdx-skills/workflow",
         "./tdx-skills/parent-segment-analysis",
+        "./tdx-skills/predictive-scoring",
         "./tdx-skills/engage"
       ]
     },

--- a/document-skills/treasure-ai-slides/IMPROVEMENT_PLAN.md
+++ b/document-skills/treasure-ai-slides/IMPROVEMENT_PLAN.md
@@ -1,0 +1,202 @@
+# Treasure AI Slides スキル改善プラン
+
+## 現状の問題点
+
+### 技術的問題
+1. ✅ **pptxgenjs v4非互換** - グラデーション背景、ShapeType enumでクラッシュ
+2. ✅ **ロゴ画像が空** - ASCIIテキストで実画像なし
+3. ✅ **サンプルコードが動かない** - background, line指定が間違い
+
+### 設計上の問題
+4. ⚠️ **レイアウトが限定的** - 5種類しかない（Title, Section, Content, Bento, End）
+5. ⚠️ **実用性が低い** - pptxgenjsで一から作るのは非効率
+6. ⚠️ **テンプレート未活用** - 公式テンプレート（48レイアウト）を使っていない
+
+## 改善方針
+
+### Phase 1: 即時修正（pptxgenjs v4対応）
+
+#### 1.1 動作確認済みサンプルコードに差し替え
+- ✅ `working-example-v4.js` 作成済み
+- グラデーション → 単色 + 装飾シェイプ
+- ShapeType enum → 文字列リテラル
+- background, line 指定を修正
+
+#### 1.2 ロゴ画像問題の対応
+- ✅ `LOGO_SETUP.md` 作成済み
+- フォールバック処理を追加
+- テキストロゴ代替オプション提供
+
+### Phase 2: td-branded-slides アプローチ統合
+
+#### 2.1 テンプレートベースのアプローチを追加
+
+**アーキテクチャ**:
+```
+アプローチ1: pptxgenjs（クイックスタート）
+├── 基本的なスライド生成
+├── カスタマイズ性高い
+└── 適用範囲: 簡単なプレゼン（5-10スライド）
+
+アプローチ2: Python + テンプレート（プロダクション品質）
+├── 公式テンプレート（tai-template.pptx）使用
+├── 48レイアウトから選択
+├── スクリプト駆動（rearrange.py, replace.py）
+└── 適用範囲: 本格的なプレゼン（10-50スライド）
+```
+
+#### 2.2 必要なスクリプト
+
+**rearrange.py**: テンプレートから必要なスライドを抽出・並び替え
+```python
+# 使用例
+python rearrange.py tai-template.pptx output.pptx 1,3,18,23,34
+# → スライド1,3,18,23,34だけを含む新しいPPTXを生成
+```
+
+**inventory.py**: スライド構造を解析してJSONに出力
+```python
+# 使用例
+python inventory.py output.pptx inventory.json
+# → 各スライドのシェイプ、テキストボックスの位置情報をJSON化
+```
+
+**replace.py**: replacement.jsonに従ってテキストを置換
+```python
+# 使用例
+python replace.py output.pptx replacement.json final.pptx
+# → 各シェイプのテキストを置換した最終PPTXを生成
+```
+
+**upload_gdrive.py**: Google Driveにアップロード（オプション）
+```python
+# 使用例
+python upload_gdrive.py final.pptx --title "提案資料"
+```
+
+#### 2.3 レイアウトカタログ整備
+
+`references/layouts.md` を作成：
+- 48レイアウトの完全カタログ
+- 各レイアウトのスクリーンショット
+- 使用シーン（「3つの並列要素 → Slide 23」）
+- クイック選択ガイド（デシジョンツリー）
+
+#### 2.4 ワークフロー統合
+
+SKILL.mdに両方のアプローチを記載：
+
+```markdown
+## Quick Start（pptxgenjs）
+
+簡単なプレゼンを素早く作成する場合：
+
+```bash
+node working-example-v4.js
+```
+
+## Production Quality（Python + Template）
+
+公式レイアウトを使った本格的なプレゼン：
+
+```bash
+# 1. レイアウト選択
+# layouts.md を参照して使用するスライド番号を決定
+
+# 2. テンプレートから抽出
+python scripts/rearrange.py \
+  assets/tai-template.pptx working.pptx \
+  1,3,18,23,31,34
+
+# 3. テキスト置換
+python scripts/replace.py \
+  working.pptx replacement.json output.pptx
+
+# 4. Google Driveアップロード（オプション）
+python scripts/upload_gdrive.py output.pptx
+```
+```
+
+### Phase 3: 品質向上
+
+#### 3.1 レイアウトバリエーション推奨ルール
+
+td-branded-slides.mdの良い点を取り入れ：
+- **同じレイアウトを3回以上連続使用しない**
+- **箇条書きだけのContentスライドを連続させない**
+- **セクション間にDividerを挟む**
+
+#### 3.2 デシジョンツリー統合
+
+```
+コンテンツの性質は？
+├─ 3つの並列要素（比較/フェーズ/柱）
+│   └→ 3-Column (23) or Boxed 3-Column (25)
+├─ 4つの並列要素
+│   └→ 4-Column (27) or Text+4 Boxes (29)
+├─ デモ画面/スクリーンショット
+│   └→ Console (38) or Laptop+Text (31)
+└─ ステップ/手順
+    └→ Steps (58) or Timeline (59)
+```
+
+#### 3.3 サンプルプレゼンテーション
+
+実際の使用例を追加：
+- `examples/corporate-presentation/` - 社内報告用（14スライド）
+- `examples/client-proposal/` - クライアント提案用（10スライド）
+- `examples/seminar-materials/` - セミナー資料用（8スライド）
+
+### Phase 4: アセット整備
+
+#### 4.1 必要なアセット
+- [ ] `assets/tai-template.pptx` - 公式テンプレート（48レイアウト）
+- [ ] `references/logos/treasure-ai-logo.png` - 実際のロゴPNG
+- [ ] `references/logos/treasure-ai-icon.png` - アイコンPNG
+- [ ] `references/layouts.md` - レイアウトカタログ
+- [ ] `references/layout-screenshots/` - 各レイアウトのプレビュー画像
+
+#### 4.2 スクリプト
+- [ ] `scripts/rearrange.py`
+- [ ] `scripts/inventory.py`
+- [ ] `scripts/replace.py`
+- [ ] `scripts/upload_gdrive.py`
+- [ ] `scripts/thumbnail.py` - プレビュー生成
+
+## 実装優先順位
+
+### P0（即時）
+1. ✅ pptxgenjs v4対応コード作成 → `working-example-v4.js`
+2. ✅ ロゴ対応ガイド作成 → `LOGO_SETUP.md`
+3. ⬜ SKILL.md修正（v4対応、フォールバック記載）
+
+### P1（1週間以内）
+4. ⬜ Pythonスクリプト作成（rearrange, inventory, replace）
+5. ⬜ `tai-template.pptx` 入手または作成
+6. ⬜ `references/layouts.md` 作成
+
+### P2（2週間以内）
+7. ⬜ 実際のロゴPNG配置
+8. ⬜ レイアウトスクリーンショット生成
+9. ⬜ サンプルプレゼンテーション3種作成
+
+### P3（1ヶ月以内）
+10. ⬜ Google Drive連携スクリプト
+11. ⬜ テンプレートカスタマイズガイド
+12. ⬜ 日本語禁則処理の自動化
+
+## 成功指標
+
+- ✅ pptxgenjs v4でエラーなく動作
+- ✅ ロゴなしでも動作する
+- ⬜ 5分以内に10スライドのプレゼンを生成可能
+- ⬜ 48レイアウトすべてが使用可能
+- ⬜ Google Slidesで編集可能なPPTXを出力
+- ⬜ 日本語テキストで禁則処理が適用される
+
+## 次のアクション
+
+1. **ユーザーにロゴPNGファイルを提供してもらう**
+2. **tai-template.pptx の入手方法を確認**
+3. **Pythonスクリプトの実装開始**
+4. **修正版SKILL.mdのレビュー**

--- a/document-skills/treasure-ai-slides/LOGO_SETUP.md
+++ b/document-skills/treasure-ai-slides/LOGO_SETUP.md
@@ -1,0 +1,106 @@
+# ロゴ画像のセットアップ
+
+## 問題
+
+現在、`references/logos/` 内のPNGファイルが空（ASCIIテキスト）で、実際の画像データが含まれていません。
+
+## 対応方法
+
+### オプション 1: 実際のロゴPNGを配置（推奨）
+
+1. Treasure AIの公式ロゴPNGファイルを取得
+2. 以下の場所に配置：
+
+```bash
+# グローバルスキル
+~/.claude/skills/treasure-ai-slides/references/logos/treasure-ai-logo.png
+~/.claude/skills/treasure-ai-slides/references/logos/treasure-ai-icon.png
+
+# リポジトリ
+td-skills/creative-skills/treasure-ai-slides/references/logos/treasure-ai-logo.png
+td-skills/creative-skills/treasure-ai-slides/references/logos/treasure-ai-icon.png
+```
+
+### オプション 2: 公式テンプレートから抽出
+
+もし `tai-template.pptx` や `2026_Treasure_AI_Official_Template.pptx` がある場合：
+
+```bash
+# PPTXを解凍
+unzip tai-template.pptx -d temp_extract
+
+# メディアフォルダ内の画像を確認
+ls -la temp_extract/ppt/media/
+
+# ロゴらしきPNGをコピー
+cp temp_extract/ppt/media/image1.png references/logos/treasure-ai-logo.png
+cp temp_extract/ppt/media/image2.png references/logos/treasure-ai-icon.png
+
+# クリーンアップ
+rm -rf temp_extract
+```
+
+### オプション 3: ロゴなしで動作（フォールバック）
+
+`working-example-v4.js` のようにロゴ追加部分をコメントアウト、または：
+
+```javascript
+function addLogoIfExists(slide) {
+  const logoPath = '../references/logos/treasure-ai-logo.png';
+  const fs = require('fs');
+  
+  try {
+    // ファイルが存在し、かつ100バイト以上（実画像）の場合のみ追加
+    const stats = fs.statSync(logoPath);
+    if (stats.size > 100) {
+      slide.addImage({
+        path: logoPath,
+        x: 0.2, y: 0.15, w: 1.5, h: 0.35,
+      });
+    } else {
+      console.warn('⚠️  ロゴファイルが空です。スキップします。');
+    }
+  } catch (err) {
+    console.warn('⚠️  ロゴファイルが見つかりません:', logoPath);
+  }
+}
+```
+
+### オプション 4: テキストロゴで代替
+
+```javascript
+// 画像の代わりにテキストでロゴを表現
+function addTextLogo(slide) {
+  slide.addText('◆ Treasure AI', {
+    x: 0.2, y: 0.15, w: 2, h: 0.35,
+    fontFace: 'Arial',
+    fontSize: 14,
+    bold: true,
+    color: '2D40AA', // Navy Blue
+  });
+}
+```
+
+## 推奨サイズ
+
+- **メインロゴ（横型）**: 200px × 50px 程度（アスペクト比 4:1）
+- **アイコンのみ**: 80px × 80px（正方形）
+- ファイル形式: PNG（透過背景推奨）
+
+## 確認方法
+
+```bash
+# ファイルサイズ確認（100バイト以上なら実画像の可能性が高い）
+ls -lh references/logos/*.png
+
+# ファイル形式確認
+file references/logos/*.png
+# 正常: "PNG image data, 200 x 50, 8-bit/color RGBA, non-interlaced"
+# 異常: "ASCII text, with no line terminators"
+```
+
+## 次のステップ
+
+1. 実際のロゴPNGを入手・配置
+2. `working-example-v4.js` を実行してテスト
+3. ロゴが正しく表示されることを確認

--- a/document-skills/treasure-ai-slides/README.md
+++ b/document-skills/treasure-ai-slides/README.md
@@ -1,0 +1,343 @@
+# Treasure AI Slides
+
+Claude Code skill for generating professional PowerPoint presentations that follow Treasure AI's official brand guidelines.
+
+## Overview
+
+This skill teaches Claude Code to create branded slide decks with:
+- Treasure AI color palette (Navy Blue `#2D40AA`, Purple, Pink, Sky Blue)
+- Proper typography (Manrope/Arial, Noto Sans JP/MS Pゴシック)
+- Brand-compliant layouts (Title, Section Divider, Content, Multi-column)
+- Japanese kinsoku shori (禁則処理) support
+- Layout variation principles (avoid repetitive patterns)
+
+## Quick Start
+
+### In Claude Code
+
+```
+"Create a Treasure AI presentation about [topic]"
+```
+
+Claude automatically:
+1. Analyzes content and selects appropriate layouts
+2. Applies brand colors and gradients
+3. Uses correct fonts (Arial/Manrope for English, Noto Sans JP for Japanese)
+4. Follows layout variation principles
+5. Applies Japanese kinsoku shori when needed
+
+### Example Prompts
+
+**Basic:**
+```
+"Create a Treasure AI slide deck about our product features"
+```
+
+**Structured:**
+```
+Create a Treasure AI presentation:
+Title: Platform Overview
+Slides:
+1. Title slide
+2. Section divider: What is Treasure AI?
+3. Content: Platform introduction (2-column layout)
+4. 3-column grid: Key Features
+5. Device mockup: Demo screen
+6. Content: Use cases
+7. Thank You
+```
+
+## Files
+
+- **[SKILL.md](SKILL.md)** — Main skill definition for Claude Code
+- **[references/design.md](references/design.md)** — Complete Treasure AI design system specification
+- **[references/brand-guidelines.md](references/brand-guidelines.md)** — Quick reference for brand colors, fonts, rules
+- **[references/layouts.md](references/layouts.md)** — Layout catalog with decision tree
+- **[references/logos/](references/logos/)** — Logo assets (PNG format)
+  - `treasure-ai-logo.png` — Main horizontal logo
+  - `treasure-ai-icon.png` — Icon only
+- **[examples/](examples/)** — Sample code and templates
+  - `working-example-v4.js` — pptxgenjs v4 implementation (fallback)
+  - `simple-python-example.py` — python-pptx implementation (recommended)
+
+## Design System Highlights
+
+### Brand Colors
+
+| Name | HEX | RGB | Usage |
+|------|-----|-----|-------|
+| Navy Blue | `#2D40AA` | `(45, 64, 170)` | Primary (titles, headings) |
+| Purple | `#847BF2` | `(132, 123, 242)` | Accents, highlights |
+| Pink | `#C466D4` | `(196, 102, 212)` | Secondary accents |
+| Sky Blue | `#80B3FA` | `(128, 179, 250)` | Supporting elements |
+| White | `#FFFFFF` | `(255, 255, 255)` | Content backgrounds |
+
+### Typography
+
+- **English**: Manrope (primary), Arial (fallback)
+- **Japanese**: Noto Sans JP (primary), MS Pゴシック (fallback)
+- **Slide Titles**: 36-44pt Bold
+- **Body Text**: 13-16pt Regular
+- **Subtitles**: 16-18pt Regular, Navy or Pink
+
+### Gradient Themes
+
+Choose based on presentation purpose:
+- **Default (Navy)**: Formal / Executive
+- **Sunset (Warm)**: Customer-facing / Friendly
+- **Rainbow (Multi-color)**: Product portfolio / Diversity
+- **Dusk (Tech)**: Technology / Data
+- **Lavender (Soft)**: Partner / Trust-building
+
+### Layout Types
+
+1. **Title Slide** — Gradient background, large title
+2. **Section Divider** — Gradient background, section name
+3. **Content Slide** — White background, text + visual
+4. **2-Column** — Text + Visual side-by-side
+5. **3-Column Grid** — Three parallel elements
+6. **4-Column Grid** — Four parallel elements
+7. **Device Mockup** — Large screen image + text
+8. **Bento Grid** — Asymmetric dashboard-style
+9. **End Slide** — Gradient background, "Thank You"
+
+## Layout Variation Principles
+
+### ✓ Do
+- Vary layouts based on content type
+- Use 3-Column for three parallel elements
+- Use Device Mockup for demo screens
+- Place Section Divider between major sections
+
+### ✗ Don't
+- Use same layout 3+ times in a row
+- Use only Content slides with bullet points
+- Skip Section Dividers between major sections
+
+### Good Example (14-slide deck)
+```
+1.  Title Slide
+2.  Section Divider
+3.  Content (with chart area)
+4.  Section Divider
+5.  Device Mockup
+6.  3-Column Grid
+7.  Content (detailed text)
+8.  Content (visual-heavy)
+9.  Section Divider
+10. Content
+11. Device Mockup
+12. End Slide
+```
+
+## Japanese Typography
+
+When creating slides with Japanese text, apply kinsoku shori (禁則処理):
+- **No punctuation (、。) at line start**
+- **No opening brackets (（「) at line end**
+- **Keep multi-char symbols together (…… ——)**
+
+python-pptx automatically applies these rules when Japanese fonts are set:
+```python
+para.font.name = 'Noto Sans JP'  # or 'MS Pゴシック'
+text_frame.word_wrap = True
+```
+
+See `references/design.md` for complete kinsoku rules.
+
+## Implementation
+
+### Recommended: python-pptx
+
+```python
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+
+# Colors
+NAVY = RGBColor(45, 64, 170)
+WHITE = RGBColor(255, 255, 255)
+
+# Create presentation
+prs = Presentation()
+prs.slide_width = Inches(13.33)  # 16:9
+prs.slide_height = Inches(7.5)
+
+# Title slide
+slide = prs.slides.add_slide(prs.slide_layouts[6])  # Blank
+slide.background.fill.solid()
+slide.background.fill.fore_color.rgb = NAVY
+
+# Add title
+title_box = slide.shapes.add_textbox(
+    Inches(0.94), Inches(2.37), Inches(9.94), Inches(1.64)
+)
+title_frame = title_box.text_frame
+title_frame.text = 'Presentation Title'
+# ... set font, size, color
+
+prs.save('TreasureAI_Presentation.pptx')
+```
+
+See `examples/simple-python-example.py` for complete implementation.
+
+### Fallback: pptxgenjs
+
+For quick Node.js-based generation (limitations apply):
+- Gradient backgrounds not supported in v4
+- Use solid colors + decorative shapes instead
+
+See `examples/working-example-v4.js` for pptxgenjs implementation.
+
+## Logo Usage
+
+### Standard Placement
+- **Position**: Top-left corner
+- **Coordinates**: x: 0.2in, y: 0.15in
+- **Size**: w: 1.5in, h: 0.35in
+
+### python-pptx Implementation
+```python
+slide.shapes.add_picture(
+    'references/logos/treasure-ai-logo.png',
+    Inches(0.2), Inches(0.15),
+    height=Inches(0.35)
+)
+```
+
+### Fallback (if logo image unavailable)
+```python
+# Text logo
+logo_box = slide.shapes.add_textbox(
+    Inches(0.2), Inches(0.15), Inches(2), Inches(0.35)
+)
+logo_frame = logo_box.text_frame
+logo_frame.text = '◆ Treasure AI'
+logo_para = logo_frame.paragraphs[0]
+logo_para.font.name = 'Arial'
+logo_para.font.size = Pt(14)
+logo_para.font.bold = True
+logo_para.font.color.rgb = NAVY
+```
+
+## Quality Checklist
+
+Before delivering slides, verify:
+
+- [ ] Logo on all slides (top-left standard position)
+- [ ] Title/section slides have gradient backgrounds (or Navy solid)
+- [ ] Content slides have white backgrounds (not cream/beige)
+- [ ] Font is Manrope/Arial (English) or Noto Sans JP (Japanese)
+- [ ] No text overflowing boxes
+- [ ] No decorative lines under titles
+- [ ] All slides have visual elements (images/icons/shapes)
+- [ ] Rounded corners on images
+- [ ] Accent colors (purple/pink) used sparingly
+- [ ] No same layout 3+ times in a row
+- [ ] Japanese text applies kinsoku shori
+
+## Development
+
+### Running Examples
+
+**Python (recommended)**:
+```bash
+cd examples/
+pip install python-pptx
+python simple-python-example.py
+# Output: TreasureAI_Presentation.pptx
+```
+
+**Node.js (fallback)**:
+```bash
+cd examples/
+npm install pptxgenjs
+node working-example-v4.js
+# Output: TreasureAI_Presentation_v4.pptx
+```
+
+## Reference
+
+Full design specification: [references/design.md](references/design.md)
+
+Includes:
+- Complete color palette with hex codes
+- Gradient definitions (5 themes)
+- Font sizing guidelines
+- Layout specifications (margins, spacing)
+- Japanese kinsoku shori rules
+- Implementation code (python-pptx, pptxgenjs, XML)
+- QA checklist
+
+## Related Skills
+
+- **brand-compliance** — Validate slides against brand guidelines
+- **brand-onboarding** — Create custom brand guidelines
+
+## Troubleshooting
+
+### Logo not displaying
+**Issue**: Logo image files not included in repository
+
+**Reason**: Logo files must be placed manually by users with access to Treasure AI brand assets.
+
+**Solutions**:
+
+1. **Place actual logo PNG files** (recommended):
+   ```bash
+   # Add logo files to:
+   references/logos/treasure-ai-logo.png  # Main horizontal logo
+   references/logos/treasure-ai-icon.png  # Icon only
+   
+   # Verify files are actual images
+   file references/logos/*.png
+   # Should show: "PNG image data, ..."
+   ```
+
+2. **Use text logo fallback**: The Python example already includes text logo fallback (see [examples/simple-python-example.py](examples/simple-python-example.py))
+
+3. **Extract from official template**: If you have `tai-template.pptx`:
+   ```bash
+   unzip tai-template.pptx -d temp
+   cp temp/ppt/media/image1.png references/logos/treasure-ai-logo.png
+   rm -rf temp
+   ```
+
+See [LOGO_SETUP.md](LOGO_SETUP.md) for detailed instructions.
+
+### Gradients not rendering
+**Issue**: python-pptx doesn't support gradient backgrounds
+
+**Solutions**:
+1. Use solid Navy (`#2D40AA`) background
+2. Add decorative shapes with transparency for gradient-like effect
+3. Manually set gradients in PowerPoint after generation
+
+### Japanese fonts not applied
+```python
+# Explicitly set font
+para.font.name = 'Noto Sans JP'  # or 'MS Pゴシック'
+
+# Check font is installed
+# Mac: Font Book
+# Windows: Settings > Fonts
+```
+
+### Kinsoku not working
+```python
+# Enable word wrap
+text_frame.word_wrap = True
+
+# Set appropriate textbox width
+# Kinsoku is automatically applied with Japanese fonts
+```
+
+## License
+
+Internal Treasure Data use only.
+
+---
+
+**Version**: 2.0  
+**Last Updated**: 2026-04-22  
+**Based on**: Treasure AI 2026 Official Design System

--- a/document-skills/treasure-ai-slides/SKILL.md
+++ b/document-skills/treasure-ai-slides/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: treasure-ai-slides
+description: Create PowerPoint presentations (.pptx) following Treasure AI (formerly Treasure Data) brand guidelines. Used for internal presentations, client proposals, and seminar materials using official design system (Navy Blue #2D40AA, Manrope font, 5 gradient themes). Triggers on requests like "create TD slides", "make Treasure AI presentation", "build branded deck", or "generate presentation".
+---
+
+# Treasure AI Branded Slide Generator
+
+Create presentations (.pptx) following the official Treasure AI design system.
+Applies brand colors, typography, and layout patterns based on `design.md` specifications.
+
+## Initial Setup
+
+On first use, read these documents:
+- [`references/design.md`](references/design.md): Complete design system specification
+- [`references/brand-guidelines.md`](references/brand-guidelines.md): Brand guidelines summary
+- [`references/layouts.md`](references/layouts.md): Layout catalog
+
+## Core Principles
+
+### 1. Layout Variation (Critical)
+
+**Avoid repeating the same layout. Select layouts based on content type.**
+
+❌ **Avoid**:
+- Same layout used 3+ times in a row
+- Only bullet-point Content slides
+- Missing Section Dividers between major sections
+
+✅ **Recommended**:
+- 3 parallel elements → 3-Column layout
+- 4 parallel elements → 4-Column layout
+- Demo screens/screenshots → Console or Laptop+Text layout
+- Steps/procedures → Steps or Timeline layout
+
+### 2. Theme Selection Decision Tree
+
+Choose gradient theme based on presentation purpose:
+
+```
+Presentation Purpose?
+├─ Formal / Executive        → Default (dark): Navy gradient
+├─ Customer-facing / Friendly → Sunset: Warm gradient
+├─ Product portfolio / Diversity → Rainbow: Multi-color gradient
+├─ Technology / Data          → Dusk: Tech gradient
+└─ Partner / Trust-building   → Lavender: Soft gradient
+```
+
+### 3. Essential Design Rules
+
+Extracted from `design.md`:
+
+**Colors**:
+- Primary: Navy Blue `#2D40AA`
+- Accents: Purple `#847BF2`, Pink `#C466D4`, Sky Blue `#80B3FA`
+- Background: White `#FFFFFF` or Off-White `#F9FEFF` (content slides)
+
+**Typography**:
+- English: Manrope (or Arial fallback)
+- Japanese: Noto Sans JP (or MS Pゴシック fallback)
+- Slide Titles: 36-44pt Bold
+- Body Text: 13-16pt Regular
+
+**Japanese Kinsoku Shori (禁則処理)**:
+
+When slides contain Japanese text, apply line-breaking rules to prevent prohibited characters at line start/end:
+
+- **Line-start prohibition** (行頭禁則): Do not start lines with closing punctuation
+  - Prohibited: ）、」、。、！、？、・、：、etc.
+  - Example: ❌ `\n）する` → ✅ `なる）\nする`
+
+- **Line-end prohibition** (行末禁則): Do not end lines with opening punctuation
+  - Prohibited: （、「、etc.
+  - Example: ❌ `データ（\nCDP` → ✅ `データ\n（CDP`
+
+- **No-break** (分離禁止): Keep together
+  - English words, numbers (`1,000`), URLs
+
+- **Hanging punctuation** (ぶら下がり処理): Allow punctuation at line end
+  - Sentence-ending punctuation (。、、etc.) can exceed right margin
+
+python-pptx automatically applies kinsoku shori when Japanese fonts are set and word wrapping is enabled.
+
+**Layout**:
+- Gradient backgrounds: Title, Section Divider, and End slides only
+- Content slides: White background
+- All slides must have visual elements (images, icons, or shapes)
+
+## Generation Workflow
+
+### Step 1: Requirements Analysis
+
+Determine from user requirements:
+1. Presentation purpose (internal/client/seminar)
+2. Theme selection (use decision tree above)
+3. Slide structure (title, sections, content count)
+4. Content and layout for each slide
+
+### Step 2: Layout Mapping
+
+Select optimal layout from `references/design.md` "Available Layout Types":
+
+**Basic Structure Example**:
+```
+1. Title Slide (A)        - Cover
+2. Section Divider (B)    - Section break (gradient background)
+3. Content Slide (C)      - Standard content (white background)
+4. 2-Column Layout        - Text + Visual side-by-side
+5. 3-Column Grid          - Three parallel elements
+6. Content Slide (C)      - Detailed explanation
+7. Section Divider (B)    - Next section
+8. Content Slide (C)      - Summary
+9. End Slide (D)          - Thank You
+```
+
+**Layout Pattern Variation**:
+```python
+# Good example (14-slide deck)
+layouts = [
+    "Title",
+    "Section Divider",
+    "Content (with chart)",
+    "Section Divider",
+    "Device Mockup",
+    "3-Column Grid",
+    "Content (text-heavy)",
+    "Content (visual-heavy)",
+    "Section Divider",
+    "Content",
+    "Device Mockup",
+    "End"
+]
+# → 6 different layout types, no 3+ consecutive repeats
+```
+
+### Step 3: Code Generation
+
+Use **python-pptx** (recommended) or pptxgenjs (fallback):
+
+**python-pptx example** (see `examples/simple-python-example.py`):
+```python
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+
+NAVY = RGBColor(45, 64, 170)
+prs = Presentation()
+prs.slide_width = Inches(13.33)  # 16:9
+prs.slide_height = Inches(7.5)
+
+# Title slide
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+slide.background.fill.solid()
+slide.background.fill.fore_color.rgb = NAVY
+
+# Add title
+title_box = slide.shapes.add_textbox(
+    Inches(0.94), Inches(2.37), Inches(11.45), Inches(1.64)
+)
+title_frame = title_box.text_frame
+title_frame.text = 'Presentation Title'
+title_para = title_frame.paragraphs[0]
+title_para.font.name = 'Arial'
+title_para.font.size = Pt(44)
+title_para.font.bold = True
+title_para.font.color.rgb = RGBColor(255, 255, 255)
+
+prs.save('TreasureAI_Deck.pptx')
+```
+
+**Logo placement** (reserved space - no text overlay):
+```python
+# Logo area: x=0.2in, y=0.15in, w=2.0in, h=0.35in
+# To add actual logo image:
+# slide.shapes.add_picture(
+#     'path/to/treasure-ai-logo.png',
+#     Inches(0.2), Inches(0.15),
+#     height=Inches(0.35)
+# )
+```
+
+**Page numbers** (optional, bottom-right):
+```python
+def add_page_number(slide, page_num, total_pages=None):
+    page_text = f"{page_num}/{total_pages}" if total_pages else str(page_num)
+    page_box = slide.shapes.add_textbox(
+        Inches(11.5), Inches(6.95), Inches(1.5), Inches(0.4)
+    )
+    page_frame = page_box.text_frame
+    page_frame.text = page_text
+    page_para = page_frame.paragraphs[0]
+    page_para.font.name = 'Arial'
+    page_para.font.size = Pt(12)
+    page_para.font.color.rgb = RGBColor(102, 102, 102)
+    page_para.alignment = PP_ALIGN.RIGHT
+```
+
+### Step 4: Quality Check
+
+Before delivering, verify:
+- [ ] Logo space reserved (top-left, no text overlay)
+- [ ] Title/section slides have gradient backgrounds (or Navy solid)
+- [ ] Content slides have white backgrounds
+- [ ] Font is Manrope/Arial (English) or Noto Sans JP (Japanese)
+- [ ] No text overflowing boxes
+- [ ] All slides have visual elements (images/icons/shapes)
+- [ ] Rounded corners on images
+- [ ] Accent colors (purple/pink) used sparingly
+- [ ] No same layout 3+ times in a row
+- [ ] Japanese text applies kinsoku shori (if applicable)
+- [ ] Page numbers added if user requested
+
+## Available Layout Types
+
+See `references/layouts.md` for complete catalog. Key layouts:
+
+### A. Title Slide
+- Navy gradient background
+- Large title (44pt)
+- Optional subtitle (18pt)
+- Logo reserved space (top-left)
+
+### B. Section Divider
+- Purple gradient background
+- Section title (40pt)
+- Logo reserved space
+
+### C. Content Slide
+- White background
+- Slide title (36pt Navy)
+- Bullet points or paragraphs (16pt)
+- Logo reserved space
+
+### D. 2-Column Layout
+- White background
+- Left: Text (50% width)
+- Right: Visual (50% width)
+
+### E. 3-Column Grid
+- White background
+- Three equal-width columns
+- Parallel content presentation
+
+### F. 4-Column Grid
+- White background
+- Four equal-width columns
+- Features, stats, or comparison
+
+### G. Device Mockup
+- Large screen image (laptop/console)
+- Descriptive text beside or below
+
+### H. End Slide
+- Navy gradient background
+- "Thank You" text (44pt)
+- Logo reserved space
+
+## Implementation Patterns
+
+### Gradient Backgrounds
+
+**Limitation**: python-pptx doesn't support gradient backgrounds.
+
+**Solutions**:
+1. Use solid Navy (`#2D40AA`) background (acceptable)
+2. Add decorative shapes with transparency for gradient-like effect
+3. Manually set gradients in PowerPoint after generation
+
+**Example (solid color fallback)**:
+```python
+slide.background.fill.solid()
+slide.background.fill.fore_color.rgb = RGBColor(45, 64, 170)  # Navy
+```
+
+### Visual Placeholders
+
+When visual elements are unavailable, add placeholder text:
+
+```python
+# Example: Chart placeholder
+chart_box = slide.shapes.add_textbox(
+    Inches(6.92), Inches(1.88), Inches(5.47), Inches(4.69)
+)
+chart_frame = chart_box.text_frame
+chart_frame.text = "[Visual: Bar chart showing quarterly growth]"
+chart_para = chart_frame.paragraphs[0]
+chart_para.font.name = 'Arial'
+chart_para.font.size = Pt(14)
+chart_para.font.color.rgb = RGBColor(102, 102, 102)
+chart_para.font.italic = True
+```
+
+### Japanese Font Handling
+
+```python
+# For Japanese text
+para.font.name = 'Noto Sans JP'  # or 'MS Pゴシック'
+text_frame.word_wrap = True
+
+# Kinsoku shori is automatically applied when:
+# 1. Japanese font is set
+# 2. Word wrapping is enabled
+# 3. Textbox width is appropriate
+```
+
+## Color Palette Reference
+
+Quick reference (see `references/brand-guidelines.md` for complete palette):
+
+| Name | HEX | RGB | Usage |
+|------|-----|-----|-------|
+| Navy Blue | `#2D40AA` | `(45, 64, 170)` | Primary color, titles |
+| Purple | `#847BF2` | `(132, 123, 242)` | Accents, highlights |
+| Pink | `#C466D4` | `(196, 102, 212)` | Secondary accents |
+| Sky Blue | `#80B3FA` | `(128, 179, 250)` | Supporting elements |
+| White | `#FFFFFF` | `(255, 255, 255)` | Content backgrounds |
+| Black | `#000000` | `(0, 0, 0)` | Body text |
+| Gray | `#666666` | `(102, 102, 102)` | Captions, footnotes |
+
+## Reference Files
+
+- [`references/design.md`](references/design.md) - Complete design system specification
+- [`references/brand-guidelines.md`](references/brand-guidelines.md) - Brand guidelines summary
+- [`references/layouts.md`](references/layouts.md) - Layout catalog
+- [`examples/working-example-v4.js`](examples/working-example-v4.js) - pptxgenjs sample
+- [`examples/simple-python-example.py`](examples/simple-python-example.py) - python-pptx sample (recommended)
+- [`LOGO_SETUP.md`](LOGO_SETUP.md) - Logo file placement instructions (optional)
+
+## Related Skills
+
+- **brand-compliance**: Validate slides against brand guidelines
+- **brand-onboarding**: Create custom brand guidelines
+
+## Troubleshooting
+
+**Logo not displaying**:
+- Logo files must be placed separately (see `LOGO_SETUP.md`)
+- Default: Logo space reserved (no text overlay)
+- To add actual logo PNG: Place in `references/logos/treasure-ai-logo.png`
+
+**Gradients not rendering**:
+- python-pptx doesn't support gradient backgrounds
+- Use solid Navy (`#2D40AA`) background (acceptable)
+- Or manually set gradients in PowerPoint after generation
+
+**Japanese fonts not applied**:
+```python
+# Explicitly set font
+para.font.name = 'Noto Sans JP'  # or 'MS Pゴシック'
+
+# Check font is installed (Mac: Font Book, Windows: Settings > Fonts)
+```
+
+**Kinsoku not working**:
+```python
+# Enable word wrap
+text_frame.word_wrap = True
+
+# Set appropriate textbox width
+# Kinsoku is automatically applied with Japanese fonts
+```
+
+**Page numbers not showing**:
+- Uncomment page number code in `simple-python-example.py` (lines 307-312)
+- Or call `add_page_number(slide, page_num, total_pages)` manually
+
+## Notes
+
+- This skill focuses on Treasure AI brand compliance
+- For generic PowerPoint generation, use the `pptx` skill instead
+- Logo area is reserved but not populated (users must add logo files separately)
+- Page numbering is optional (disabled by default)

--- a/document-skills/treasure-ai-slides/examples/simple-python-example.py
+++ b/document-skills/treasure-ai-slides/examples/simple-python-example.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Treasure AI Slide Generator - Simple Python Example
+
+This example creates a basic Treasure AI branded presentation using python-pptx.
+
+Requirements:
+    pip install python-pptx
+
+Usage:
+    python simple-python-example.py
+
+Output:
+    TreasureAI_Presentation.pptx
+"""
+
+from pptx import Presentation
+from pptx.util import Inches, Pt
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+
+# Treasure AI Brand Colors
+NAVY = RGBColor(45, 64, 170)
+PURPLE = RGBColor(132, 123, 242)
+PINK = RGBColor(196, 102, 212)
+SKY_BLUE = RGBColor(128, 179, 250)
+WHITE = RGBColor(255, 255, 255)
+BLACK = RGBColor(0, 0, 0)
+GRAY = RGBColor(102, 102, 102)
+
+# Create presentation
+prs = Presentation()
+prs.slide_width = Inches(13.33)  # 16:9 aspect ratio
+prs.slide_height = Inches(7.5)
+
+
+def add_logo(slide):
+    """
+    Reserve space for Treasure AI logo (top-left corner).
+    Logo area: x=0.2in, y=0.15in, w=2.0in, h=0.35in
+
+    To add actual logo image:
+    slide.shapes.add_picture(
+        'path/to/treasure-ai-logo.png',
+        Inches(0.2), Inches(0.15),
+        height=Inches(0.35)
+    )
+    """
+    # Logo space reserved - no text overlay
+    # Users can manually add logo image file later
+    pass
+
+
+def add_page_number(slide, page_num, total_pages=None, color=GRAY):
+    """
+    Add page number to bottom-right corner.
+
+    Args:
+        slide: Slide object
+        page_num: Current page number
+        total_pages: Total page count (optional, shows "3/10" format)
+        color: Text color (default: GRAY)
+    """
+    if total_pages:
+        page_text = f"{page_num}/{total_pages}"
+    else:
+        page_text = str(page_num)
+
+    page_box = slide.shapes.add_textbox(
+        Inches(11.5), Inches(6.95), Inches(1.5), Inches(0.4)
+    )
+    page_frame = page_box.text_frame
+    page_frame.text = page_text
+    page_para = page_frame.paragraphs[0]
+    page_para.font.name = 'Arial'
+    page_para.font.size = Pt(12)
+    page_para.font.color.rgb = color
+    page_para.alignment = PP_ALIGN.RIGHT
+
+
+def create_title_slide(prs, title, subtitle=""):
+    """Create title slide with Navy background"""
+    slide = prs.slides.add_slide(prs.slide_layouts[6])  # Blank layout
+
+    # Navy background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = NAVY
+
+    # Reserve logo space (top-left)
+    add_logo(slide)
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.94), Inches(2.37), Inches(11.45), Inches(1.64)
+    )
+    title_frame = title_box.text_frame
+    title_frame.text = title
+    title_para = title_frame.paragraphs[0]
+    title_para.font.name = 'Arial'
+    title_para.font.size = Pt(44)
+    title_para.font.bold = True
+    title_para.font.color.rgb = WHITE
+
+    # Subtitle (optional)
+    if subtitle:
+        subtitle_box = slide.shapes.add_textbox(
+            Inches(0.94), Inches(4.24), Inches(11.45), Inches(0.75)
+        )
+        subtitle_frame = subtitle_box.text_frame
+        subtitle_frame.text = subtitle
+        subtitle_para = subtitle_frame.paragraphs[0]
+        subtitle_para.font.name = 'Arial'
+        subtitle_para.font.size = Pt(18)
+        subtitle_para.font.color.rgb = WHITE
+
+
+def create_section_divider(prs, section_title):
+    """Create section divider slide with Purple background"""
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Purple background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = PURPLE
+
+    # Reserve logo space (top-left)
+    add_logo(slide)
+
+    # Section title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.94), Inches(2.81), Inches(11.45), Inches(1.64)
+    )
+    title_frame = title_box.text_frame
+    title_frame.text = section_title
+    title_para = title_frame.paragraphs[0]
+    title_para.font.name = 'Arial'
+    title_para.font.size = Pt(40)
+    title_para.font.bold = True
+    title_para.font.color.rgb = WHITE
+
+
+def create_content_slide(prs, title, bullet_points):
+    """Create content slide with white background"""
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # White background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = WHITE
+
+    # Logo
+    add_logo(slide)
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.94), Inches(0.75), Inches(11.45), Inches(0.75)
+    )
+    title_frame = title_box.text_frame
+    title_frame.text = title
+    title_para = title_frame.paragraphs[0]
+    title_para.font.name = 'Arial'
+    title_para.font.size = Pt(36)
+    title_para.font.bold = True
+    title_para.font.color.rgb = NAVY
+
+    # Content area with bullet points
+    content_box = slide.shapes.add_textbox(
+        Inches(0.94), Inches(1.88), Inches(11.45), Inches(4.69)
+    )
+    content_frame = content_box.text_frame
+    content_frame.word_wrap = True
+
+    for i, point in enumerate(bullet_points):
+        if i > 0:
+            content_frame.add_paragraph()
+        p = content_frame.paragraphs[i]
+        p.text = point
+        p.font.name = 'Arial'
+        p.font.size = Pt(16)
+        p.font.color.rgb = BLACK
+        p.level = 0
+
+
+def create_two_column_slide(prs, title, left_content, right_content):
+    """Create 2-column layout slide"""
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # White background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = WHITE
+
+    # Logo
+    add_logo(slide)
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.94), Inches(0.75), Inches(11.45), Inches(0.75)
+    )
+    title_frame = title_box.text_frame
+    title_frame.text = title
+    title_para = title_frame.paragraphs[0]
+    title_para.font.name = 'Arial'
+    title_para.font.size = Pt(36)
+    title_para.font.bold = True
+    title_para.font.color.rgb = NAVY
+
+    # Left column
+    left_box = slide.shapes.add_textbox(
+        Inches(0.94), Inches(1.88), Inches(5.47), Inches(4.69)
+    )
+    left_frame = left_box.text_frame
+    left_frame.word_wrap = True
+    left_frame.text = left_content
+    left_para = left_frame.paragraphs[0]
+    left_para.font.name = 'Arial'
+    left_para.font.size = Pt(16)
+    left_para.font.color.rgb = BLACK
+
+    # Right column (visual placeholder)
+    right_box = slide.shapes.add_textbox(
+        Inches(6.92), Inches(1.88), Inches(5.47), Inches(4.69)
+    )
+    right_frame = right_box.text_frame
+    right_frame.word_wrap = True
+    right_frame.text = right_content
+    right_para = right_frame.paragraphs[0]
+    right_para.font.name = 'Arial'
+    right_para.font.size = Pt(16)
+    right_para.font.color.rgb = BLACK
+
+
+def create_end_slide(prs):
+    """Create Thank You slide with Navy background"""
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Navy background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = NAVY
+
+    # Reserve logo space (top-left)
+    add_logo(slide)
+
+    # Thank You text
+    thank_you_box = slide.shapes.add_textbox(
+        Inches(0.94), Inches(2.81), Inches(11.45), Inches(1.64)
+    )
+    thank_you_frame = thank_you_box.text_frame
+    thank_you_frame.text = 'Thank You'
+    thank_you_para = thank_you_frame.paragraphs[0]
+    thank_you_para.font.name = 'Arial'
+    thank_you_para.font.size = Pt(44)
+    thank_you_para.font.bold = True
+    thank_you_para.font.color.rgb = WHITE
+    thank_you_para.alignment = PP_ALIGN.CENTER
+
+
+# Build presentation
+print("Creating Treasure AI presentation...")
+
+# Slide 1: Title
+create_title_slide(
+    prs,
+    title="Treasure AI Platform Overview",
+    subtitle="Empowering Data-Driven Marketing"
+)
+
+# Slide 2: Section Divider
+create_section_divider(prs, "What is Treasure AI?")
+
+# Slide 3: Content
+create_content_slide(
+    prs,
+    title="Customer Data Platform",
+    bullet_points=[
+        "Unified customer data across all touchpoints",
+        "Real-time personalization and segmentation",
+        "Privacy-first data management",
+        "Enterprise-grade security and compliance"
+    ]
+)
+
+# Slide 4: 2-Column Layout
+create_two_column_slide(
+    prs,
+    title="Key Benefits",
+    left_content="• Increase customer engagement\n• Improve conversion rates\n• Reduce operational costs\n• Accelerate time to market",
+    right_content="[Visual: Chart showing ROI growth over 12 months]"
+)
+
+# Slide 5: Section Divider
+create_section_divider(prs, "Platform Features")
+
+# Slide 6: Content
+create_content_slide(
+    prs,
+    title="Core Capabilities",
+    bullet_points=[
+        "Data Collection: Web, mobile, server-side tracking",
+        "Data Integration: 200+ pre-built connectors",
+        "Audience Builder: Drag-and-drop segmentation",
+        "Activation: Multi-channel campaign orchestration"
+    ]
+)
+
+# Slide 7: End
+create_end_slide(prs)
+
+# Optional: Add page numbers to all slides (except title and end slides)
+# Uncomment the following lines to enable page numbering:
+#
+# total_slides = len(prs.slides)
+# for idx, slide in enumerate(prs.slides):
+#     # Skip title slide (0) and end slide (last)
+#     if idx > 0 and idx < total_slides - 1:
+#         add_page_number(slide, idx, total_slides - 2, color=GRAY)
+
+# Save presentation
+output_file = 'TreasureAI_Presentation.pptx'
+prs.save(output_file)
+print(f"✓ Presentation created: {output_file}")
+print(f"  Total slides: {len(prs.slides)}")
+print(f"  Size: 16:9 (13.33\" x 7.5\")")
+print(f"\nTo add page numbers, uncomment lines 307-312 and re-run.")

--- a/document-skills/treasure-ai-slides/examples/working-example-v4.js
+++ b/document-skills/treasure-ai-slides/examples/working-example-v4.js
@@ -1,0 +1,275 @@
+// Treasure AI スライド生成（pptxgenjs v4 動作確認済み）
+const pptxgen = require('pptxgenjs');
+
+// カラー定数（design.mdから）
+const COLORS = {
+  navy: '2D40AA',
+  purple: '847BF2',
+  pink: 'C466D4',
+  skyBlue: '80B3FA',
+  lilac: 'F3CCF2',
+  white: 'FFFFFF',
+  black: '000000',
+};
+
+// プレゼンテーション作成
+const pres = new pptxgen();
+pres.layout = 'LAYOUT_WIDE'; // 16:9
+pres.author = 'Treasure AI';
+pres.company = 'Treasure Data';
+
+// =====================
+// タイトルスライド
+// =====================
+function createTitleSlide(title, subtitle) {
+  const slide = pres.addSlide();
+
+  // ✅ v4での正しい背景指定（ソリッドカラー）
+  slide.background = { color: COLORS.navy };
+
+  // タイトル
+  slide.addText(title, {
+    x: 0.94, y: 2.37, w: 9.94, h: 1.64,
+    fontFace: 'Arial',
+    fontSize: 40,
+    bold: true,
+    color: COLORS.white,
+    align: 'left',
+  });
+
+  // サブタイトル
+  slide.addText(subtitle, {
+    x: 0.94, y: 3.8, w: 6, h: 0.5,
+    fontFace: 'Arial',
+    fontSize: 20,
+    color: COLORS.pink,
+    align: 'left',
+  });
+
+  // 装飾シェイプ（グラデーション風）
+  // ✅ v4では文字列リテラルでシェイプタイプを指定
+  slide.addShape('ellipse', {
+    x: 10, y: 0.5, w: 3, h: 3,
+    fill: { color: COLORS.purple, transparency: 60 },
+    line: { width: 0 }, // ✅ 枠線を消す場合はwidth: 0
+  });
+
+  slide.addShape('ellipse', {
+    x: 11.5, y: 5.5, w: 2, h: 2,
+    fill: { color: COLORS.pink, transparency: 50 },
+    line: { width: 0 },
+  });
+}
+
+// =====================
+// コンテンツスライド
+// =====================
+function createContentSlide(title, subtitle, bullets) {
+  const slide = pres.addSlide();
+
+  // ✅ 白背景
+  slide.background = { color: COLORS.white };
+
+  // タイトル
+  slide.addText(title, {
+    x: 0.38, y: 0.3, w: 9, h: 0.7,
+    fontFace: 'Arial',
+    fontSize: 28,
+    bold: true,
+    color: COLORS.black,
+  });
+
+  // サブタイトル（オプション）
+  if (subtitle) {
+    slide.addText(subtitle, {
+      x: 0.38, y: 0.95, w: 7, h: 0.35,
+      fontFace: 'Arial',
+      fontSize: 16,
+      color: COLORS.navy,
+    });
+  }
+
+  // 本文（箇条書き）
+  slide.addText(bullets, {
+    x: 0.38, y: subtitle ? 1.4 : 1.1,
+    w: 5.5, h: 4.5,
+    fontFace: 'Arial',
+    fontSize: 14,
+    color: COLORS.black,
+    bullet: true,
+    valign: 'top',
+  });
+
+  // 装飾ボックス（右側）
+  slide.addShape('roundRect', {
+    x: 7, y: 1.5, w: 5.5, h: 4,
+    fill: { color: COLORS.lilac },
+    line: { color: COLORS.purple, width: 2 },
+  });
+
+  // ボックス内テキスト
+  slide.addText('ビジュアル要素\nここに画像やチャートを\n配置できます', {
+    x: 7.2, y: 2.8, w: 5.1, h: 1,
+    fontFace: 'Arial',
+    fontSize: 14,
+    color: COLORS.navy,
+    align: 'center',
+    valign: 'middle',
+  });
+}
+
+// =====================
+// 3カラムスライド
+// =====================
+function create3ColumnSlide(title, columns) {
+  const slide = pres.addSlide();
+  slide.background = { color: COLORS.white };
+
+  // タイトル
+  slide.addText(title, {
+    x: 0.38, y: 0.3, w: 12, h: 0.7,
+    fontFace: 'Arial',
+    fontSize: 28,
+    bold: true,
+    color: COLORS.black,
+  });
+
+  // 3カラム
+  const colWidth = 3.8;
+  const colHeight = 4.5;
+  const startY = 1.4;
+  const spacing = 0.3;
+
+  columns.forEach((col, idx) => {
+    const x = 0.38 + (colWidth + spacing) * idx;
+
+    // カラムボックス
+    slide.addShape('roundRect', {
+      x: x, y: startY, w: colWidth, h: colHeight,
+      fill: { color: COLORS.white },
+      line: { color: COLORS.purple, width: 2 },
+    });
+
+    // アイコン（円）
+    slide.addShape('ellipse', {
+      x: x + (colWidth / 2 - 0.4),
+      y: startY + 0.3,
+      w: 0.8, h: 0.8,
+      fill: { color: COLORS.purple },
+      line: { width: 0 },
+    });
+
+    // ヘッダー
+    slide.addText(col.header, {
+      x: x, y: startY + 1.3, w: colWidth, h: 0.5,
+      fontFace: 'Arial',
+      fontSize: 18,
+      bold: true,
+      color: COLORS.navy,
+      align: 'center',
+    });
+
+    // 本文
+    slide.addText(col.text, {
+      x: x + 0.2, y: startY + 1.9, w: colWidth - 0.4, h: 2.3,
+      fontFace: 'Arial',
+      fontSize: 13,
+      color: COLORS.black,
+      align: 'left',
+      valign: 'top',
+    });
+  });
+}
+
+// =====================
+// Thank Youスライド
+// =====================
+function createThankYouSlide() {
+  const slide = pres.addSlide();
+  slide.background = { color: COLORS.navy };
+
+  slide.addText('Thank You', {
+    x: 0, y: 2.5, w: 13.33, h: 1.5,
+    fontFace: 'Arial',
+    fontSize: 60,
+    bold: true,
+    color: COLORS.white,
+    align: 'center',
+  });
+
+  slide.addText("Let's build something amazing", {
+    x: 0, y: 4.3, w: 13.33, h: 0.5,
+    fontFace: 'Arial',
+    fontSize: 20,
+    color: COLORS.pink,
+    align: 'center',
+  });
+
+  // 装飾シェイプ
+  slide.addShape('ellipse', {
+    x: 1, y: 1, w: 2.5, h: 2.5,
+    fill: { color: COLORS.purple, transparency: 70 },
+    line: { width: 0 },
+  });
+
+  slide.addShape('ellipse', {
+    x: 10, y: 4.5, w: 2, h: 2,
+    fill: { color: COLORS.pink, transparency: 60 },
+    line: { width: 0 },
+  });
+}
+
+// =====================
+// サンプルスライド生成
+// =====================
+
+// 1. タイトルスライド
+createTitleSlide(
+  'Treasure AI Platform Overview',
+  'The Agentic Experience Platform'
+);
+
+// 2. コンテンツスライド
+createContentSlide(
+  'What is Treasure AI?',
+  'エンタープライズ向けAIエクスペリエンスプラットフォーム',
+  [
+    { text: 'リアルタイムパーソナライゼーション', options: { fontSize: 14 } },
+    { text: 'AIエージェントによる自動化', options: { fontSize: 14 } },
+    { text: 'データ活用の民主化', options: { fontSize: 14 } },
+  ]
+);
+
+// 3. 3カラムスライド
+create3ColumnSlide(
+  'Key Features',
+  [
+    {
+      header: 'Real-Time',
+      text: 'リアルタイムでの顧客理解とパーソナライゼーションを実現'
+    },
+    {
+      header: 'AI-Powered',
+      text: 'AIエージェントが業務を自動化し、生産性を向上'
+    },
+    {
+      header: 'Enterprise-Ready',
+      text: 'エンタープライズグレードのセキュリティとスケーラビリティ'
+    },
+  ]
+);
+
+// 4. Thank Youスライド
+createThankYouSlide();
+
+// =====================
+// 保存
+// =====================
+pres.writeFile({ fileName: 'TreasureAI_Presentation_v4.pptx' });
+console.log('✅ プレゼンテーション生成完了: TreasureAI_Presentation_v4.pptx');
+console.log('');
+console.log('📝 Notes:');
+console.log('  - pptxgenjs v4 対応版');
+console.log('  - グラデーション背景は非対応のため、単色 + 装飾シェイプで代替');
+console.log('  - ShapeType enum不使用（文字列リテラルで指定）');
+console.log('  - ロゴ画像は別途追加してください');

--- a/document-skills/treasure-ai-slides/references/brand-guidelines.md
+++ b/document-skills/treasure-ai-slides/references/brand-guidelines.md
@@ -1,0 +1,260 @@
+# Treasure AI Brand Guidelines - Quick Reference
+
+このドキュメントは design.md からの要約版です。スライド作成時のクイックリファレンスとして使用します。
+
+## Brand Colors
+
+### Primary Colors
+- **Navy Blue**: `#2D40AA` - メインブランドカラー（タイトル、見出し）
+- **Off-White**: `#F9FEFF` - ライト背景
+- **White**: `#FFFFFF` - コンテンツスライド背景
+- **Black**: `#000000` - 本文テキスト
+
+### Accent Colors
+- **Purple (Lavender)**: `#847BF2` - ハイライト、アイコン
+- **Pink (Mauve)**: `#C466D4` - セカンダリアクセント
+- **Sky Blue**: `#80B3FA` - サポート要素
+- **Lilac**: `#F3CCF2` - 淡い背景、装飾
+- **Peach**: `#FFE2BD` - ウォームアクセント
+- **Coral**: `#FDB893` - ウォームサポート
+- **Link Blue**: `#494FFF` - リンク、CTA
+
+### RGB Values (for python-pptx)
+```python
+from pptx.dml.color import RGBColor
+
+NAVY = RGBColor(45, 64, 170)      # #2D40AA
+PURPLE = RGBColor(132, 123, 242)  # #847BF2
+PINK = RGBColor(196, 102, 212)    # #C466D4
+SKY_BLUE = RGBColor(128, 179, 250) # #80B3FA
+LILAC = RGBColor(243, 204, 242)   # #F3CCF2
+WHITE = RGBColor(255, 255, 255)
+BLACK = RGBColor(0, 0, 0)
+```
+
+## Typography
+
+### Font Stack
+- **English**: Manrope (primary), Arial (fallback)
+- **Japanese**: Noto Sans JP (primary), MS Pゴシック (fallback)
+
+### Font Sizes
+| 要素 | サイズ | ウェイト | カラー |
+|------|--------|---------|--------|
+| スライドタイトル | 36-44pt | Bold | `#000000` or `#FFFFFF` |
+| セクションヘッダー | 20-24pt | Bold | `#000000` |
+| サブタイトル | 16-18pt | Regular | `#2D40AA` or `#C466D4` |
+| 本文テキスト | 13-16pt | Regular | `#000000` |
+| キャプション・注記 | 10-12pt | Regular | `#666666` |
+| 大きな数値（KPI） | 48-72pt | Bold | `#2D40AA` or `#847BF2` |
+
+### python-pptx Implementation
+```python
+from pptx.util import Pt
+
+# タイトル
+title_para.font.name = 'Arial'  # または 'Manrope'
+title_para.font.size = Pt(40)
+title_para.font.bold = True
+title_para.font.color.rgb = BLACK
+
+# 日本語本文
+body_para.font.name = 'Noto Sans JP'  # または 'MS Pゴシック'
+body_para.font.size = Pt(14)
+body_para.font.color.rgb = BLACK
+```
+
+## Logo Usage
+
+### Standard Placement
+- **位置**: 左上コーナー
+- **座標**: x: 0.2in, y: 0.15in
+- **サイズ**: w: 1.5in, h: 0.35in
+
+### python-pptx Implementation
+```python
+from pptx.util import Inches
+
+# ロゴ追加
+logo_path = 'references/logos/treasure-ai-logo.png'
+slide.shapes.add_picture(
+    logo_path,
+    Inches(0.2),   # x
+    Inches(0.15),  # y
+    height=Inches(0.35)  # 高さ（幅は自動調整）
+)
+```
+
+### Fallback (テキストロゴ)
+```python
+# 画像が使えない場合
+logo_box = slide.shapes.add_textbox(
+    Inches(0.2), Inches(0.15), Inches(2), Inches(0.35)
+)
+logo_frame = logo_box.text_frame
+logo_frame.text = '◆ Treasure AI'
+logo_para = logo_frame.paragraphs[0]
+logo_para.font.name = 'Arial'
+logo_para.font.size = Pt(14)
+logo_para.font.bold = True
+logo_para.font.color.rgb = NAVY
+```
+
+## Gradient Themes
+
+### 1. Default (Dark) - フォーマル/エグゼクティブ
+- Stop 1: `#FF86B4` (Pink)
+- Stop 2: `#9864FF` (Purple)
+- Stop 3: `#3D9CFF` (Blue)
+- Direction: 45° (top-left to bottom-right)
+
+### 2. Sunset - カスタマー向け/親しみ
+- Stop 1: `#FFF1DD` (Beige)
+- Stop 2: `#DD71DA` (Pink)
+- Stop 3: `#B4AEF7` (Lavender)
+
+### 3. Rainbow - 製品群紹介/多様性
+- Stop 1: `#FFE5C3` (Warm Orange)
+- Stop 2: `#DBA2E5` (Mauve)
+- Stop 3: `#B4AEF7` (Lavender)
+
+### 4. Dusk - テクノロジー/データ
+- Stop 1: `#8855FF` (Deep Purple)
+- Stop 2: `#4485FF` (Blue)
+- Stop 3: `#00B6FF` (Cyan)
+
+### 5. Lavender - パートナー/信頼性
+- Similar to Sunset, soft tones
+
+**Note**: python-pptxではグラデーション背景は非対応。単色背景（Navy `#2D40AA`）を推奨。
+
+## Design Rules
+
+### ✓ Must Do
+- すべてのスライドにビジュアル要素（画像、アイコン、シェイプ）
+- グラデーション背景: タイトル、セクション区切り、エンドスライドのみ
+- コンテンツスライド: 白背景のみ
+- ロゴ: 左上に配置
+- タイトルはBold、本文はRegular
+- 画像は角丸
+- ブランドシェイプ（有機的な円・楕円）を装飾に使用
+
+### ✗ Never Do
+- タイトル下に装飾ライン
+- コンテンツスライドにクリーム・ベージュ背景
+- テキストのみのスライド
+- すべて同じレイアウトを繰り返す
+- テキストをセンタリング（タイトル除く）
+- テキストをボックスからはみ出させる
+- アクセントカラー（パープル/ピンク）を多用
+
+### Color Usage Ratio
+- 白/ライトグレー（背景）: 60-70%
+- ブランドカラー（アクセント）: 20-30%
+- テキスト（黒/紺）: 残り
+
+## Slide Types
+
+### A. Title Slide (表紙)
+- Background: Gradient
+- Content: Large title (centered, white, bold) + subtitle
+- Logo: Bottom-right or top-left
+
+### B. Section Divider (区切り)
+- Background: Gradient (theme consistent)
+- Content: Left-aligned white text, large section name
+- Optional: Right-side image or abstract shapes
+
+### C. Content Slide (標準)
+- Background: Solid white (`#FFFFFF`) or off-white (`#F9FEFF`)
+- Header: Top-left title (black, bold)
+- Content: Text + visual elements
+- Logo: Top-left corner
+
+### D. End Slide (Thank You)
+- Background: Same gradient as title
+- Content: "Thank you" centered (white)
+- Optional CTA: Chat-style box
+
+## Layout Patterns
+
+### 1-Column (Text-Focused)
+- Title + subtitle + body text
+- Bullet points (max 3 levels)
+
+### 2-Column (Text + Visual)
+- Left: Title + text (55% width)
+- Right: Image, chart, icon (40% width)
+
+### 3-Column Grid
+- Equal width columns (~30% each)
+- Each column: Icon + header + text
+
+### 4-Column Grid
+- Four equal columns
+- Use for feature lists, comparisons
+
+### Bento Grid
+- Asymmetric grid: Large main area + multiple small areas
+- Mix images, numbers, text
+
+### Device Mockup
+- Left: Large product image (laptop, mobile)
+- Right: Text explanation
+
+## Japanese Typography Rules
+
+### 行頭禁則文字 (No Line-Start)
+- 閉じ括弧: `）` `］` `｝` `」` `』`
+- 句読点: `、` `。` `,` `.`
+- 中点・記号: `・` `：` `；` `:` `;`
+- ハイフン: `‐` `゠` `–` `ー`
+- 感嘆符: `!` `?` `！` `？`
+- 小書き仮名: `ぁ` `ぃ` `ぅ` `ぇ` `ぉ` `ゃ` `ゅ` `ょ` `っ` `ァ` `ィ` 等
+
+### 行末禁則文字 (No Line-End)
+- 開き括弧: `（` `［` `｛` `「` `『`
+
+### 分離禁止 (No Separation)
+- 連続記号: `……` (ellipsis, 2 sets), `——` (dashes)
+- 英単語: `PowerPoint` → `Power-Point` に分割しない
+- 数値: `1,000`, `2024年3月22日`, `10:30`
+- URL: `https://example.com`
+
+### python-pptx Implementation
+```python
+# 日本語フォント設定で自動適用
+text_frame.word_wrap = True
+para.font.name = 'Noto Sans JP'  # または 'MS Pゴシック'
+```
+
+## Quick Decision Tree
+
+```
+スライドの目的は？
+├─ 表紙・タイトル → Title Slide (Gradient背景)
+├─ セクション区切り → Section Divider (Gradient背景)
+├─ 標準的な説明 → Content Slide (白背景)
+├─ 3つの並列要素 → 3-Column Grid
+├─ 4つの並列要素 → 4-Column Grid
+├─ デモ画面表示 → Device Mockup or Bento Grid
+├─ ステップ/手順 → Numbered list in Content Slide
+├─ 終了 → End Slide (Gradient背景)
+└─ その他 → Content Slide with visual elements
+```
+
+## Tagline
+"The Agentic Experience Platform"
+
+## Common Mistakes
+
+1. **クリーム/ベージュ背景** → 白に変更
+2. **テキストのみ** → アイコンやシェイプを追加
+3. **ロゴなし** → 左上に配置
+4. **グラデーション乱用** → コンテンツは白背景
+5. **同じレイアウト連続** → バリエーションを持たせる
+6. **アクセントカラー多用** → 控えめに使用
+
+## References
+- Full specification: [`design.md`](design.md)
+- Logo files: [`logos/treasure-ai-logo.png`](logos/treasure-ai-logo.png)

--- a/document-skills/treasure-ai-slides/references/design.md
+++ b/document-skills/treasure-ai-slides/references/design.md
@@ -1,0 +1,394 @@
+# Treasure AI – Presentation Design System
+# Claude Code用スライド作成ガイド
+
+このファイルはClaude CodeがTreasure AIブランドに準拠したPowerPointスライドを作成する際の
+すべての設計仕様を定めます。スライド作成前に必ずこのファイルを参照してください。
+
+---
+
+## 1. ブランドカラーパレット
+
+### コアカラー（ベースカラー）
+
+| 用途 | 名前 | HEX | 使用場面 |
+|------|------|-----|---------|
+| Primary Dark | Navy Blue | `#2D40AA` | テキスト・アクセント |
+| Primary Light | Off-White | `#F9FEFF` | 背景・軽量エリア |
+| Accent Purple | Lavender | `#847BF2` | ハイライト・アイコン |
+| Accent Pink | Mauve | `#C466D4` | セカンダリアクセント |
+| Accent Blue | Sky | `#80B3FA` | サポート要素 |
+| Accent Lilac | Pale Pink | `#F3CCF2` | 淡い背景・装飾 |
+| Accent Peach | Warm | `#FFE2BD` | ウォームアクセント |
+| Accent Coral | Soft | `#FDB893` | ウォームサポート |
+| Black | Text | `#000000` | 本文テキスト |
+| White | Base | `#FFFFFF` | 背景・反転テキスト |
+| Link Blue | Hyperlink | `#494FFF` | リンク・CTA |
+
+### グラデーション定義
+
+スライドの背景グラデーションはTreasure AI独自のものを以下を正確に再現すること。
+
+**メインタイトルグラデーション（Title & Section slides）**
+- 左上 → 右下の斜めグラデーション
+- Stop 1: `#FF86B4` (ピンク)
+- Stop 2: `#9864FF` → `#8470FF` (パープル)
+- Stop 3: `#3D9CFF` → `#00C3FF` (ブルー)
+- 角度: 約45度（左上から右下）
+
+**Sunsetグラデーション（暖色系スライド）**
+- `#FFF1DD` → `#DD71DA` → `#B4AEF7`
+- 淡いベージュからラベンダー
+
+**Rainbowグラデーション**
+- `#FFE5C3` → `#DBA2E5` → `#B4AEF7`
+- ウォームオレンジからパープルへ
+
+**Dusk / Lavenderグラデーション**
+- `#8855FF` → `#4485FF` → `#00B6FF`
+- ディープパープルからブルーへ
+
+**コンテンツスライド背景**
+- 白 (`#FFFFFF`) またはごく薄いオフホワイト (`#F9FEFF`)
+- グラデーションは「タイトル」「セクション区切り」「エンドスライド」専用
+
+---
+
+## 2. タイポグラフィ
+
+### フォント
+
+| 要素 | フォント | 代替 |
+|------|---------|------|
+| 見出し (Heading) | Arial | Arial Black |
+| 本文 (Body) | Arial | Calibri |
+| 日本語 | ＭＳ Ｐゴシック | — |
+
+### フォントサイズ規定
+
+| 要素 | サイズ | ウェイト | カラー |
+|------|--------|---------|--------|
+| スライドタイトル | 36〜44pt | Bold | `#000000` または `#FFFFFF`（背景に依存）|
+| セクションヘッダー | 20〜24pt | Bold | `#000000` |
+| サブタイトル | 16〜18pt | Regular | `#2D40AA` または `#C466D4` |
+| 本文テキスト | 13〜16pt | Regular | `#000000` |
+| キャプション・注記 | 10〜12pt | Regular | `#666666` |
+| 大きな数値（KPI） | 48〜72pt | Bold | `#2D40AA` または `#847BF2` |
+
+---
+
+## 3. ロゴ & ブランド要素
+
+### Treasure AI ロゴファイル
+
+| ファイル | パス | 用途 | サイズ目安 |
+|---------|------|------|-----------|
+| メインロゴ（横） | `assets/logos/treasure-ai-logo.png` | スライド標準配置 | W: 150-200px |
+| アイコンのみ | `assets/logos/treasure-ai-icon.png` | 小サイズ・装飾 | W: 40-60px |
+
+**ロゴの特徴**:
+- ダイヤモンド型アイコン: グラデーション（紫 → ピンク → 青）
+- テキスト "Treasure AI": Navy Blue `#2D40AA`
+- 透過PNG形式
+
+### スライド内配置ルール
+
+**標準配置（ほとんどのスライド）**:
+- 位置: 左上コーナー
+- 座標: x: 0.2in (約0.5cm), y: 0.15in (約0.4cm)
+- サイズ: w: 1.5in, h: 0.35in
+
+**右下配置（オプション）**:
+- 座標: x: 11.5in, y: 6.3in
+- サイズ: w: 1.2in, h: 0.28in
+
+**ダーク背景スライド**:
+- 白抜きロゴまたはアイコンのみ使用を推奨
+- グラデーション背景では視認性を確保
+
+### pptxgenjsでの実装
+
+```javascript
+// メインロゴ追加（左上）
+slide.addImage({
+  path: 'assets/logos/treasure-ai-logo.png',
+  x: 0.2,    // 左端から0.2インチ
+  y: 0.15,   // 上端から0.15インチ
+  w: 1.5,    // 幅1.5インチ
+  h: 0.35,   // 高さ0.35インチ
+});
+
+// アイコンのみ（装飾用・右下）
+slide.addImage({
+  path: 'assets/logos/treasure-ai-icon.png',
+  x: 11.5,
+  y: 6.5,
+  w: 0.5,
+  h: 0.5,
+});
+```
+
+### タグライン
+- "Making you Super🤩 at all things Treasure✨" – エンドスライド・フッター右側に小さく表示
+- "The Agentic Experience Platform" – タイトルスライドのサブタイトル
+
+---
+
+## 4. レイアウトシステム
+
+### スライドサイズ
+- **16:9 ワイドスクリーン**: 33.87cm × 19.05cm（標準）
+- EMU換算: 12192000 × 6858000
+
+### マージン規定
+- 上下左右: 最低 0.5インチ（457,200 EMU）
+- コンテンツエリア: 左端から約0.7インチ以降
+
+### 利用可能なレイアウトタイプ
+
+#### A. タイトルスライド（表紙）
+- フルスクリーングラデーション背景（メインタイトルグラデーション）
+- 中央上寄せに大きなタイトル（白・Bold）
+- サブタイトルは `#C466D4` でイタリック風アクセント
+- 右下にロゴ
+
+#### B. セクション区切りスライド（Divider）
+- グラデーション背景（4種類から選択）
+- 左寄せに白テキスト
+- オプション: 右側に画像（角丸）または抽象シェイプ（ブランドカラーの円・楕円）
+
+#### C. コンテンツスライド（標準）
+- 白またはごく薄いグラデーション背景
+- 左上にタイトル（黒・Bold）
+- サブタイトルは `#2D40AA` または `#C466D4`
+- 本文エリアにテキスト + ビジュアル要素
+
+#### D. エンドスライド（Thank You）
+- タイトルスライドと同じグラデーション背景
+- 中央に "Thank you" テキスト（白）
+- AIチャット風のCTAボックス（"Let's build something amazing"）
+
+### 主要レイアウトパターン
+
+**1カラム（テキスト中心）**
+- タイトル + サブタイトル + 本文テキスト
+- 箇条書きは最大3レベル
+
+**2カラム（テキスト + ビジュアル）**
+- 左: タイトル + テキスト（幅55%）
+- 右: 画像・グラフ・アイコン（幅40%）
+
+**3カラム（グリッド）**
+- 等幅3分割（各約30%）
+- 各カラムにアイコン + ヘッダー + 本文
+
+**ボックス付3カラム**
+- 角丸ボックス（border: `#847BF2`, 薄紫）で囲む
+
+**Bentoグリッド**
+- 非対称グリッド: 大きなメインエリア + 複数の小エリア
+- 画像・数値・テキストを組み合わせ
+
+**ラップトップ/デバイスモックアップ**
+- 左: 大きな製品画像（デバイス）
+- 右: テキスト説明
+
+---
+
+## 5. デザインルール
+
+### 必須ルール ✓
+- **すべてのスライドにビジュアル要素を入れる** – 画像・アイコン・チャート・シェイプのいずれか
+- **グラデーション背景はタイトル・セクション・エンドスライドのみ**、コンテンツスライドは白
+- **ロゴを左上または右下に必ず配置**
+- **タイトルはBold、本文はRegular** – ウェイトの差でヒエラルキーを出す
+- **アクセントカラー（パープル系）は強調箇所のみ** – 多用しない
+- **画像は角丸（rounded corners）** でクリッピング
+- **ブランドシェイプ（有機的な円・楕円）** を装飾に活用
+
+### 禁止事項 ✗
+- タイトル下に装飾ラインを引かない（AI生成スライドの典型的悪例）
+- コンテンツスライドにクリーム・ベージュ系の背景を使わない
+- テキストのみのスライドを作らない
+- すべてのスライドで同じレイアウトを繰り返さない
+- テキストをセンタリングしない（タイトルを除く）
+- テキストをボックスからはみ出させない
+
+### カラー使用比率
+- 白/ライトグレー（背景）: 60〜70%
+- ブランドカラー（アクセント）: 20〜30%
+- テキスト（黒/紺）: 残り
+
+---
+
+## 6. 図形・シェイプライブラリ
+
+Treasure AIテンプレートで使用される有機的シェイプ（装飾用）:
+
+| シェイプ名 | 用途 | カラー |
+|-----------|------|--------|
+| 大きな円（ゼロ） | 右側装飾 | `#80B3FA`（薄ブルー）, `#C466D4`（ピンク） |
+| 楕円（小） | アクセント | `#847BF2`（パープル） |
+| 流動的ブロブ | セクション背景 | グラデーション |
+| 角丸四角 | カード・ボックス | 枠線 `#847BF2`、背景白 |
+
+---
+
+## 7. Claude Code向け実装ガイド
+
+### スライド作成フロー
+
+```bash
+# 1. テンプレートをコピーして作業開始
+cp /path/to/2026_Treasure_AI_Official_Template.pptx output.pptx
+
+# 2. アンパック
+python scripts/office/unpack.py output.pptx unpacked/
+
+# 3. スライドXMLを編集
+
+# 4. 再パック
+python scripts/office/pack.py unpacked/ output.pptx
+
+# 5. 画像変換してQA
+python scripts/office/soffice.py --headless --convert-to pdf output.pptx
+pdftoppm -jpeg -r 150 output.pdf slide
+```
+
+### pptxgenjsで一から作成する場合
+
+```javascript
+const pptxgen = require('pptxgenjs');
+
+// カラー定数
+const COLORS = {
+  navy: '2D40AA',
+  purple: '847BF2',
+  pink: 'C466D4',
+  skyBlue: '80B3FA',
+  lilac: 'F3CCF2',
+  peach: 'FFE2BD',
+  black: '000000',
+  white: 'FFFFFF',
+  offWhite: 'F9FEFF',
+  linkBlue: '494FFF',
+};
+
+// グラデーション背景（タイトルスライド用）
+const titleGradient = {
+  type: 'linear',
+  angle: 45,
+  stops: [
+    { position: 0,   color: 'FF86B4' },
+    { position: 0.3, color: '9864FF' },
+    { position: 0.6, color: '3D9CFF' },
+    { position: 1,   color: '00C3FF' },
+  ]
+};
+
+// フォント設定
+const FONTS = {
+  heading: { fontFace: 'Arial', bold: true },
+  body:    { fontFace: 'Arial', bold: false },
+};
+
+// プレゼンテーション作成
+const pres = new pptxgen();
+pres.layout = 'LAYOUT_WIDE'; // 33.87cm × 19.05cm
+
+// ロゴ追加ヘルパー
+function addLogo(slide) {
+  slide.addImage({
+    path: 'assets/logos/treasure-ai-logo.png',
+    x: 0.2,
+    y: 0.15,
+    w: 1.5,
+    h: 0.35,
+  });
+}
+```
+
+### スライドタイプ別テンプレートコード
+
+**タイトルスライド**
+```javascript
+function createTitleSlide(title, subtitle) {
+  const slide = pres.addSlide();
+  
+  // グラデーション背景（簡易版：実際はtitleGradient使用）
+  slide.background = { fill: { color: COLORS.navy } };
+  
+  // ロゴ
+  addLogo(slide);
+  
+  // タイトル
+  slide.addText(title, {
+    x: 0.94, y: 2.37, w: 9.94, h: 1.64,
+    fontFace: 'Arial', fontSize: 40, bold: true, color: COLORS.white,
+  });
+  
+  // サブタイトル
+  slide.addText(subtitle, {
+    x: 0.94, y: 3.8, w: 6, h: 0.5,
+    fontFace: 'Arial', fontSize: 20, color: COLORS.pink,
+  });
+}
+```
+
+**コンテンツスライド（白背景）**
+```javascript
+function createContentSlide(title, content) {
+  const slide = pres.addSlide();
+  slide.background = { fill: COLORS.white };
+  
+  // ロゴ
+  addLogo(slide);
+  
+  // タイトル
+  slide.addText(title, {
+    x: 0.38, y: 0.3, w: 9, h: 0.7,
+    fontFace: 'Arial', fontSize: 28, bold: true, color: COLORS.black,
+  });
+  
+  // サブタイトル（オプション）
+  slide.addText('サブタイトル', {
+    x: 0.38, y: 0.95, w: 7, h: 0.35,
+    fontFace: 'Arial', fontSize: 16, color: COLORS.navy,
+  });
+  
+  // 本文
+  slide.addText(content, {
+    x: 0.38, y: 1.4, w: 5.5, h: 4.5,
+    fontFace: 'Arial', fontSize: 14, color: COLORS.black,
+    valign: 'top', bullet: true,
+  });
+  
+  // ビジュアル要素（例：装飾ボックス）
+  slide.addShape('roundRect', {
+    x: 7, y: 1.5, w: 5.5, h: 4,
+    fill: { color: COLORS.lilac },
+    line: { color: COLORS.purple, width: 2 },
+  });
+}
+```
+
+---
+
+## 8. QAチェックリスト
+
+スライド完成後、以下を確認すること:
+
+- [ ] すべてのスライドにTreasure AIロゴが表示されている
+- [ ] タイトル・セクションスライドにグラデーション背景が適用されている
+- [ ] コンテンツスライドの背景は白（クリーム・ベージュではない）
+- [ ] フォントはArialを使用している
+- [ ] テキストがボックスからはみ出していない
+- [ ] タイトル下に装飾ラインがない
+- [ ] すべてのスライドにビジュアル要素（画像・アイコン・シェイプ）がある
+- [ ] 画像に角丸が適用されている
+- [ ] アクセントカラー（パープル/ピンク）を多用していない
+
+---
+
+*このdesign.mdはTreasure AIの2026年公式テンプレートから抽出した仕様に基づいています。*
+*テンプレートファイル: `2026_Treasure_AI_Official_Template.pptx`*
+*ロゴファイル: `assets/logos/treasure-ai-logo.png`, `assets/logos/treasure-ai-icon.png`*

--- a/document-skills/treasure-ai-slides/references/layouts.md
+++ b/document-skills/treasure-ai-slides/references/layouts.md
@@ -1,0 +1,513 @@
+# Treasure AI Slide Layouts - Quick Selection Guide
+
+スライドのコンテンツに応じて最適なレイアウトを選択するためのガイドです。
+
+## Layout Selection Decision Tree
+
+```
+コンテンツの性質は？
+├─ 表紙・タイトル
+│   └→ Title Slide (A)
+│
+├─ セクション区切り（大項目の開始）
+│   └→ Section Divider (B)
+│
+├─ 標準的な説明・箇条書き
+│   └→ Content Slide (C)
+│
+├─ 2つの対比・比較（左右）
+│   └→ 2-Column Layout
+│
+├─ 3つの並列要素（フェーズ/柱/比較）
+│   └→ 3-Column Grid
+│
+├─ 4つの並列要素
+│   └→ 4-Column Grid
+│
+├─ デモ画面/スクリーンショット（大きく見せたい）
+│   └→ Console Layout または Laptop+Text Layout
+│
+├─ ステップ/手順/タイムライン
+│   └→ Steps Layout または Content with numbered list
+│
+├─ 引用/顧客の声
+│   └→ Quote Layout (装飾付きテキスト)
+│
+├─ 複数メトリクス/ダッシュボード風
+│   └→ Bento Grid Layout
+│
+├─ 終了・Thank You
+│   └→ End Slide (D)
+│
+└─ その他
+    └→ Content Slide with visual elements
+```
+
+## Layout Catalog
+
+### Tier 1: Core Layouts（必須・頻出）
+
+#### A. Title Slide（タイトルスライド）
+**用途**: プレゼンテーション表紙
+
+**特徴**:
+- グラデーション背景（テーマに応じて選択）
+- 中央上寄せの大きなタイトル（白、Bold、36-44pt）
+- サブタイトル（アクセントカラー、16-20pt）
+- ロゴ配置（右下または左上）
+
+**python-pptx実装**:
+```python
+slide = prs.slides.add_slide(prs.slide_layouts[6])  # Blank
+slide.background.fill.solid()
+slide.background.fill.fore_color.rgb = NAVY  # または他のグラデーション色
+
+# タイトル
+title_box = slide.shapes.add_textbox(
+    Inches(0.94), Inches(2.37), Inches(9.94), Inches(1.64)
+)
+# ...
+```
+
+**いつ使う**: プレゼンの最初のスライドのみ
+
+---
+
+#### B. Section Divider（セクション区切り）
+**用途**: 大きなセクション間の区切り
+
+**特徴**:
+- グラデーション背景（タイトルと同じテーマ）
+- 左寄せの大きな白テキスト（セクション名）
+- オプション: 右側に画像または抽象シェイプ
+
+**python-pptx実装**:
+```python
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+slide.background.fill.solid()
+slide.background.fill.fore_color.rgb = NAVY
+
+# セクション名（左寄せ）
+section_box = slide.shapes.add_textbox(
+    Inches(0.94), Inches(2.5), Inches(6), Inches(1.5)
+)
+section_frame = section_box.text_frame
+section_frame.text = 'Section Title'
+section_para = section_frame.paragraphs[0]
+section_para.font.name = 'Arial'
+section_para.font.size = Pt(40)
+section_para.font.bold = True
+section_para.font.color.rgb = WHITE
+section_para.alignment = PP_ALIGN.LEFT
+
+# 装飾シェイプ（右側・オプション）
+from pptx.enum.shapes import MSO_SHAPE
+shape = slide.shapes.add_shape(
+    MSO_SHAPE.OVAL,
+    Inches(10), Inches(1), Inches(3), Inches(3)
+)
+shape.fill.solid()
+shape.fill.fore_color.rgb = PURPLE
+shape.fill.transparency = 0.4  # 40% 透明
+shape.line.fill.background()  # 枠線なし
+```
+
+**いつ使う**: 「課題提起」→「ソリューション」→「事例」のような大きなセクション間
+
+---
+
+#### C. Content Slide（コンテンツスライド）
+**用途**: 最も頻繁に使用する標準スライド
+
+**特徴**:
+- 白背景（`#FFFFFF` または `#F9FEFF`）
+- 左上にタイトル（黒、Bold、28pt）
+- オプション: サブタイトル（Navy または Pink、16pt）
+- 本文エリア: テキスト（箇条書き）+ ビジュアル要素
+
+**python-pptx実装**:
+```python
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+slide.background.fill.solid()
+slide.background.fill.fore_color.rgb = WHITE
+
+# タイトル
+title_box = slide.shapes.add_textbox(
+    Inches(0.38), Inches(0.3), Inches(9), Inches(0.7)
+)
+title_frame = title_box.text_frame
+title_frame.text = 'Slide Title'
+title_para = title_frame.paragraphs[0]
+title_para.font.name = 'Arial'
+title_para.font.size = Pt(28)
+title_para.font.bold = True
+title_para.font.color.rgb = BLACK
+
+# 本文（箇条書き）
+body_box = slide.shapes.add_textbox(
+    Inches(0.38), Inches(1.4), Inches(5.5), Inches(4.5)
+)
+body_frame = body_box.text_frame
+body_frame.word_wrap = True
+
+items = ['First point', 'Second point', 'Third point']
+for idx, item in enumerate(items):
+    if idx == 0:
+        p = body_frame.paragraphs[0]
+    else:
+        p = body_frame.add_paragraph()
+    p.text = item
+    p.font.name = 'Arial'
+    p.font.size = Pt(14)
+    p.font.color.rgb = BLACK
+    p.level = 0  # 箇条書きレベル
+
+# 装飾ボックス（右側）
+shape = slide.shapes.add_shape(
+    MSO_SHAPE.ROUNDED_RECTANGLE,
+    Inches(7), Inches(1.5), Inches(5.5), Inches(4)
+)
+shape.fill.solid()
+shape.fill.fore_color.rgb = LILAC
+shape.line.color.rgb = PURPLE
+shape.line.width = Pt(2)
+```
+
+**バリエーション**:
+- **Content + Gradient**: タイトル下にアクセント用グラデーション帯
+- **Content + Subtitle**: サブタイトル追加
+- **Content No Gradient**: シンプル版（テキスト量が多い場合）
+
+**いつ使う**: 説明、箇条書き、詳細情報、まとめ
+
+---
+
+#### D. End Slide（終了スライド）
+**用途**: プレゼンテーション終了
+
+**特徴**:
+- タイトルと同じグラデーション背景
+- 中央に "Thank You"（白、大きく）
+- オプション: CTA（"Let's build something amazing"）
+- オプション: 連絡先情報
+
+**python-pptx実装**:
+```python
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+slide.background.fill.solid()
+slide.background.fill.fore_color.rgb = NAVY
+
+# "Thank You"
+thank_box = slide.shapes.add_textbox(
+    Inches(0), Inches(2.5), Inches(13.33), Inches(1.5)
+)
+thank_frame = thank_box.text_frame
+thank_frame.text = 'Thank You'
+thank_para = thank_frame.paragraphs[0]
+thank_para.font.name = 'Arial'
+thank_para.font.size = Pt(60)
+thank_para.font.bold = True
+thank_para.font.color.rgb = WHITE
+thank_para.alignment = PP_ALIGN.CENTER
+
+# CTA（オプション）
+cta_box = slide.shapes.add_textbox(
+    Inches(0), Inches(4.3), Inches(13.33), Inches(0.5)
+)
+cta_frame = cta_box.text_frame
+cta_frame.text = "Let's build something amazing"
+cta_para = cta_frame.paragraphs[0]
+cta_para.font.name = 'Arial'
+cta_para.font.size = Pt(20)
+cta_para.font.color.rgb = PINK
+cta_para.alignment = PP_ALIGN.CENTER
+```
+
+**いつ使う**: プレゼンテーションの最後のスライドのみ
+
+---
+
+### Tier 2: Multi-Column Layouts（並列要素）
+
+#### 2-Column Layout（2カラム）
+**用途**: テキスト + ビジュアルの組み合わせ
+
+**構成**:
+- 左（55%）: タイトル + テキスト（箇条書きまたは段落）
+- 右（40%）: 画像、チャート、アイコン
+
+**いつ使う**:
+- デモ画面/スクリーンショットの説明
+- フロー/ハイライトの視覚化
+- Before/After比較
+
+**python-pptx実装**:
+```python
+# 左カラム（テキスト）
+left_box = slide.shapes.add_textbox(
+    Inches(0.38), Inches(1.4), Inches(6), Inches(4.5)
+)
+# ... テキスト追加
+
+# 右カラム（ビジュアル用プレースホルダー）
+right_box = slide.shapes.add_shape(
+    MSO_SHAPE.ROUNDED_RECTANGLE,
+    Inches(7), Inches(1.4), Inches(5.5), Inches(4.5)
+)
+right_box.fill.solid()
+right_box.fill.fore_color.rgb = LILAC
+right_box.text_frame.text = '[画像をここに配置]'
+```
+
+---
+
+#### 3-Column Grid（3カラムグリッド）
+**用途**: 3つの並列要素を並べて表示
+
+**構成**:
+- 等幅3分割（各約30%）
+- 各カラム: アイコン + ヘッダー + 説明文
+
+**いつ使う**:
+- 3つの柱/フェーズ/特徴
+- "What / Why / How"
+- "Past / Present / Future"
+- 製品の3つの強み
+
+**python-pptx実装**:
+```python
+col_width = 3.8
+col_height = 4.5
+start_y = 1.4
+spacing = 0.3
+
+columns = [
+    {'header': 'Column 1', 'text': 'Description 1'},
+    {'header': 'Column 2', 'text': 'Description 2'},
+    {'header': 'Column 3', 'text': 'Description 3'},
+]
+
+for idx, col in enumerate(columns):
+    x = 0.38 + (col_width + spacing) * idx
+    
+    # カラムボックス
+    box = slide.shapes.add_shape(
+        MSO_SHAPE.ROUNDED_RECTANGLE,
+        Inches(x), Inches(start_y), Inches(col_width), Inches(col_height)
+    )
+    box.fill.solid()
+    box.fill.fore_color.rgb = WHITE
+    box.line.color.rgb = PURPLE
+    box.line.width = Pt(2)
+    
+    # アイコン（円）
+    icon = slide.shapes.add_shape(
+        MSO_SHAPE.OVAL,
+        Inches(x + col_width/2 - 0.4), Inches(start_y + 0.3),
+        Inches(0.8), Inches(0.8)
+    )
+    icon.fill.solid()
+    icon.fill.fore_color.rgb = PURPLE
+    icon.line.fill.background()
+    
+    # ヘッダー
+    header_box = slide.shapes.add_textbox(
+        Inches(x), Inches(start_y + 1.3), Inches(col_width), Inches(0.5)
+    )
+    header_frame = header_box.text_frame
+    header_frame.text = col['header']
+    header_para = header_frame.paragraphs[0]
+    header_para.font.name = 'Arial'
+    header_para.font.size = Pt(18)
+    header_para.font.bold = True
+    header_para.font.color.rgb = NAVY
+    header_para.alignment = PP_ALIGN.CENTER
+    
+    # 説明文
+    text_box = slide.shapes.add_textbox(
+        Inches(x + 0.2), Inches(start_y + 1.9),
+        Inches(col_width - 0.4), Inches(2.3)
+    )
+    text_frame = text_box.text_frame
+    text_frame.text = col['text']
+    text_frame.word_wrap = True
+    text_para = text_frame.paragraphs[0]
+    text_para.font.name = 'Arial'
+    text_para.font.size = Pt(13)
+    text_para.font.color.rgb = BLACK
+```
+
+**バリエーション**:
+- **Boxed 3-Column**: 各カラムをボックスで囲む（上記実装）
+- **Simple 3-Column**: ボックスなし、テキストのみ
+
+---
+
+#### 4-Column Grid（4カラムグリッド）
+**用途**: 4つの並列要素
+
+**構成**:
+- 等幅4分割
+- 各カラム: アイコン + ヘッダー + 説明文
+
+**いつ使う**:
+- 4つの製品/サービス
+- 4ステップのプロセス
+- 4つの機能
+
+**python-pptx実装**: 3-Columnと同様（4列に調整）
+
+---
+
+### Tier 3: Specialized Layouts（特殊用途）
+
+#### Bento Grid Layout（ベントグリッド）
+**用途**: 複数のメトリクス/情報を非対称に配置
+
+**構成**:
+- 大きなメインエリア（KPI、重要情報）
+- 複数の小エリア（補足情報、サブメトリクス）
+
+**いつ使う**:
+- ダッシュボード風の表示
+- 複数KPIの同時表示
+- 複雑な情報の整理
+
+**例**:
+```
+┌─────────────┬───┬───┐
+│             │ 2 │ 3 │
+│      1      ├───┼───┤
+│   (Main)    │ 4 │ 5 │
+├─────┬───────┴───┴───┤
+│  6  │       7       │
+└─────┴───────────────┘
+```
+
+---
+
+#### Device Mockup Layout（デバイスモックアップ）
+**用途**: 製品画面/UIを大きく見せる
+
+**構成**:
+- 左（60%）: ノートPC/スマホ画面の大きな画像
+- 右（35%）: 説明テキスト
+
+**いつ使う**:
+- 製品デモ
+- UI/UX説明
+- 機能ハイライト
+
+**別名**: Console Layout, Laptop+Text Layout
+
+---
+
+#### Quote Layout（引用レイアウト）
+**用途**: 顧客の声、推薦文、重要な引用
+
+**構成**:
+- 大きな引用符装飾
+- センタリングされた引用文（大きめ）
+- 引用元（小さめ、下部）
+
+**いつ使う**:
+- 顧客の声（testimonial）
+- 業界の引用
+- インパクトのある一言
+
+---
+
+#### Steps/Timeline Layout（ステップ/タイムライン）
+**用途**: 手順、プロセス、時系列の表示
+
+**構成**:
+- 番号付きステップ
+- 矢印/線で接続
+- 各ステップの説明
+
+**いつ使う**:
+- 導入手順
+- プロジェクトフェーズ
+- 歴史・沿革
+
+---
+
+## Layout Variation Rules
+
+### レイアウト選択の原則
+
+1. **同じレイアウトを3回以上連続使用しない**
+   - ❌ Content → Content → Content → Content
+   - ✅ Content → 3-Column → Content → 2-Column
+
+2. **箇条書きだけのContentスライドを連続させない**
+   - ❌ Content(bullet) → Content(bullet) → Content(bullet)
+   - ✅ Content(bullet) → 3-Column → Content(bullet)
+
+3. **セクション間にDividerを挟む**
+   - ✅ Content → Divider → Content (新セクション)
+
+### 良い構成例（14スライド・社内All Hands）
+
+```
+1.  Title Slide              - 表紙
+2.  Section Divider          - セクション区切り
+3.  Content                  - データ分析（チャート領域）
+4.  Section Divider          - セクション区切り
+5.  Device Mockup            - ハイライト説明（図+テキスト）
+6.  3-Column Grid            - 3フェーズの構成（What/Status/Next）
+7.  Content                  - 詳細テキスト（箇条書き多）
+8.  Content + Visual         - アクション付きフロー
+9.  Section Divider          - セクション区切り
+10. Content                  - 手順ガイド
+11. Device Mockup            - クロージング（大きな図）
+12. End Slide                - Thank You
+```
+
+この構成の特徴:
+- レイアウトバリエーション豊富
+- Dividerで明確なセクション分け
+- ビジュアル要素とテキストのバランス
+- 単調さを避けた構成
+
+---
+
+## Quick Reference Table
+
+| コンテンツ | 推奨レイアウト | 避けるべきパターン |
+|-----------|--------------|------------------|
+| 3つの並列要素 | 3-Column Grid | Content + 箇条書きで3つ羅列 |
+| 4つの並列要素 | 4-Column Grid | Content + 箇条書きで4つ羅列 |
+| デモ画面 | Device Mockup or Console | Content + [画像placeholder] |
+| 大きな画像を貼りたい | Console/Mockup（タイトル上部+広い画像領域） | Content + 空白BODY |
+| フロー/ハイライト説明 | Laptop+Text（左に図、右にテキスト） | 全部箇条書き |
+| ステップ/手順 | Steps or Timeline | Content + 番号付きリスト |
+| 引用/顧客の声 | Quote Layout | Content + 引用符テキスト |
+| セクション間の区切り | Divider | 空のContentスライド |
+
+---
+
+## Implementation Checklist
+
+スライド生成時の確認項目:
+
+- [ ] 各スライドのコンテンツを分析した
+- [ ] 最適なレイアウトを選択した
+- [ ] 同じレイアウトが3回以上連続していない
+- [ ] セクション間にDividerを配置した
+- [ ] すべてのスライドにビジュアル要素がある
+- [ ] タイトル、本文のフォントサイズが適切
+- [ ] ブランドカラーを正しく使用した
+- [ ] 日本語テキストで禁則処理が適用される設定
+
+---
+
+## Next Steps
+
+このカタログを参考に、プレゼンテーションの構成を計画してください。
+
+1. 各スライドの内容を決定
+2. このガイドから最適なレイアウトを選択
+3. `brand-guidelines.md` でカラー・フォントを確認
+4. python-pptx で実装
+5. QAチェックリストで品質確認

--- a/tdx-skills/predictive-scoring/SKILL.md
+++ b/tdx-skills/predictive-scoring/SKILL.md
@@ -1,0 +1,465 @@
+---
+name: predictive-scoring
+description: >
+  Manages Audience Studio predictive scoring models (Predictive Segments) using tdx api and Audience/CDP APIs.
+  Covers listing models in a parent segment, creating new models from existing segments,
+  running (re)training jobs, inspecting feature importance and score distributions,
+  and guiding how to use predicted scores for segmentation.
+  Use when: creating/retraining/inspecting Predictive Scoring models, asking about "predictive scoring", "predictive segments", "propensity model", "lookalike model" in CDP context, or understanding which attributes/behaviors drive a predictive model.
+---
+
+# tdx Predictive Scoring — Audience Studio Predictive Segments
+
+## Prerequisites & Permissions
+
+- Predictive Scoring must be enabled for the account (feature flag / contract).
+- The parent segment (audience) must already exist and be enabled in Audience Studio.
+- The parent segment workflow must have run successfully at least once before predictive scores are available.
+- Column Visibility:
+  - Only columns with visibility **Clear** can be used as features and are visible in predictive scoring UIs.
+  - Columns marked as PII or Blocked will not appear as selectable features and are hidden in Predictive Scores / Model Performance views.
+- Folder-based permissions:
+  - Creating, editing, deleting, or running a predictive model requires View+ (View or Full Control) for:
+    - The folder that contains the predictive scoring model.
+    - All referenced segments:
+      - Training Population
+      - Scoring Target
+      - Positive Samples
+- Do **not** attempt predictive scoring operations if the user does not have appropriate Audience Studio permissions.
+
+## Key Concepts
+
+- **Parent Segment (Audience)** — The unified customer base (cdp_audience_{id}) that predictive scoring is attached to.
+- **Predictive Segment / Predictive Scoring Model** — A model that predicts the likelihood of a target behavior (churn, purchase, click, conversion, etc.) for profiles in a parent segment.
+- **Training Population** — Segment (or All Profiles) used as the base population for training.
+- **Scoring Target** — Segment representing the profiles that exhibited the target behavior (positive label).
+- **Positive Samples** — Segment representing examples of the behavior you want to predict (used by some UI workflows).
+- **Features (Categorical / Array / Quantitative)** — Attribute/behavior columns from the parent segment that the model uses as predictors.
+- **Grade Thresholds** — Score thresholds (e.g., [75, 50, 25]) that define A/B/C buckets.
+
+## API Overview
+
+Prefer JSON:API **entities** endpoints for model-level operations, and Audience endpoints for listing models per parent segment:
+
+- Audience API (per parent segment):
+  - `GET  /audiences/{audienceId}/predictive_segments`
+    - List predictive models for a given parent segment.
+  - `POST /audiences/{audienceId}/predictive_segments`
+    - Create a new predictive scoring model (legacy payload).
+- JSON:API entities (model-level):
+  - `POST   /entities/predictive_segments`                  # Create model (JSON:API envelope)
+  - `PATCH  /entities/predictive_segments/{id}`             # Update model
+  - `DELETE /entities/predictive_segments/{id}`             # Delete model
+  - `POST   /entities/predictive_segments/{id}/run`         # Run (train/score)
+  - `GET    /entities/predictive_segments/{id}`             # Get model details
+  - `GET    /entities/predictive_segments/{id}/executions`  # Execution history
+  - `GET    /entities/predictive_segments/{id}/model/features` # Feature importances
+  - `GET    /entities/predictive_segments/{id}/model/score`    # Score histogram
+- All calls use the CDP API endpoint (e.g. `https://api-cdp.treasuredata.com`).
+
+From tdx, call these via:
+
+- `tdx api -X GET  --type cdp <path>`
+- `tdx api -X POST --type cdp <path> [...]`
+- `tdx api -X PATCH --type cdp <path> [...]`
+- `tdx api -X DELETE --type cdp <path> [...]`
+
+## Workflow 1 — Inspect Existing Predictive Models
+
+**Visualization principle: Always format and present API results as tables or summaries immediately—never show raw JSON. Include business interpretation.**
+
+### 1. Identify the parent segment
+
+1. Ask the user to specify the parent segment:
+   - Name (recommended), or
+   - Numeric audience ID.
+2. If the user provides a name, list audiences and match by name:
+   - `tdx ps list --format json`
+   - Find `id` and `name` for the target parent segment.
+
+### 2. List predictive models in a parent segment
+
+- Use Audience API to list models for the audience:
+
+```bash
+tdx api -X GET --type cdp /audiences/{audienceId}/predictive_segments
+```
+
+- Extract and present for each model:
+  - `id`, `name`, `description`
+  - `baseSegmentId`, `segmentId`, `scoredSegmentId`
+  - `accuracy`, `areaUnderRocCurve`, `gradeThresholds`
+  - `createdAt`, `updatedAt`
+
+### 3. Show detailed model info
+
+- Fetch JSON:API representation for a specific model:
+
+```bash
+tdx api -X GET --type cdp /entities/predictive_segments/{id}
+```
+
+- Summarize:
+  - Audience / segment relationships
+  - Feature lists:
+    - `categoricalAsColumnNames`
+    - `categoricalArrayAsColumnNames`
+    - `quantitativeAsColumnNames`
+  - Accuracy & AUC (with a short explanation of AUC 0–1 range).
+  - Grade thresholds (e.g. 0–100 scores split by [75, 50, 25]).
+
+### 4. Inspect execution history
+
+- Retrieve executions:
+
+```bash
+tdx api -X GET --type cdp /entities/predictive_segments/{id}/executions
+```
+
+- For each execution, display:
+  - `workflowId`, `workflowSessionId`
+  - `createdAt`, `finishedAt`
+  - `status` (queued / running / success / error / canceled / blocked)
+- If needed, tell the user they can inspect the underlying workflow session via:
+  - `tdx wf sessions` / `tdx wf attempt` (use the workflowSessionId).
+
+### 5. Inspect feature importance
+
+- Retrieve model features:
+
+```bash
+tdx api -X GET --type cdp /entities/predictive_segments/{id}/model/features
+```
+
+- **Format results immediately as a table with interpretation:**
+
+```
+Top 10 Features by Importance
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Feature          | Importance | Impact
+─────────────────────────────────────────
+custserv_calls   |   2.47     | 🔴 Higher calls → higher churn risk
+day_charge       |   1.84     | 🔴 Heavy usage → higher risk
+intl_plan#0      |  -2.39     | 🟢 No intl plan → lower risk
+vmail_plan#1     |  -1.51     | 🟢 Has voicemail → lower risk
+
+💡 Key Insight: Customers with 3+ service calls are the highest churn risk.
+   Recommend: Proactive outreach for customers with custserv_calls > 3
+```
+
+- Always include:
+  - Top 5-10 features sorted by absolute importance
+  - Sign interpretation (positive = increases risk, negative = decreases risk)
+  - Business actionable insight
+
+### 6. Inspect score distribution
+
+- Retrieve score histogram:
+
+```bash
+# JSON:API
+tdx api -X GET --type cdp /entities/predictive_segments/{id}/model/score
+
+# Or legacy
+tdx api -X GET --type cdp /audiences/{audienceId}/predictive_segments/{id}/score_histogram
+```
+
+- **Present distribution summary immediately:**
+
+```
+Score Distribution (Total: 2,850 profiles)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Range    | Count  | % Total | Visual
+─────────────────────────────────────────────
+0-10     | 1,860  |  65.3%  | ████████████████████████████
+10-25    |   748  |  26.2%  | ██████████
+25-50    |   207  |   7.3%  | ███
+50+      |    35  |   1.2%  | ▌
+
+✓ Healthy distribution: 65% low-risk, only 1.2% very high-risk
+⚠ Action needed: 242 customers (8.5%) in high-risk range
+```
+
+- Follow up with SQL analysis to correlate scores with actual behavior:
+
+```bash
+tdx query "
+SELECT 
+  FLOOR(td_predictive_score_{id} / 10) * 10 AS score_bucket,
+  COUNT(*) AS customers,
+  ROUND(AVG(custserv_calls), 2) AS avg_calls
+FROM cdp_audience_{audienceId}.customers
+WHERE td_predictive_score_{id} IS NOT NULL
+GROUP BY 1 ORDER BY 1
+"
+```
+
+## Workflow 2 — Create a New Predictive Scoring Model
+
+### 1. Choose parent segment and candidate segments
+
+1. Confirm parent segment (audience) as in Workflow 1.
+2. List child segments:
+   - `tdx sg list --parent-segment "{ParentName}" --format json`
+3. With the user, choose:
+   - **Training Population** — base population segment or All Profiles.
+   - **Scoring Target** — profiles that already performed the target behavior.
+   - **Positive Samples** — optional seed segment of "ideal" examples.
+
+### 2. Check available fields and Column Visibility
+
+- Use segment fields to understand attributes/behaviors:
+
+```bash
+tdx sg fields "{ParentName}"
+```
+
+- Important:
+  - Only attributes/behaviors with Column Visibility = Clear can be used as features.
+  - PII / Blocked columns are excluded from feature selection and predictive reports.
+
+### 3. Build PredictiveSegmentParameters JSON (legacy Audience API)
+
+- Follow the documented schema for:
+
+```json
+{
+  "name": "Churn Risk Model",
+  "description": "Predict churn in next 60 days",
+  "baseSegmentId": 12345,
+  "segmentId": 23456,
+  "scoredSegmentId": 34567,
+  "gradeThresholds": [75, 50, 25],
+  "categoricalAsColumnNames": [
+    "gender",
+    "country"
+  ],
+  "categoricalArrayAsColumnNames": [
+    "interest_categories"
+  ],
+  "quantitativeAsColumnNames": [
+    "total_spend_90d",
+    "visit_days_30d",
+    "pageviews_30d"
+  ],
+  "preprocess": [
+    {
+      "column": "avg_spend_90d",
+      "source": {
+        "column": "total_spend_90d",
+        "table": "customers",
+        "functions": [
+          { "function": "/", "arg": 3 }
+        ]
+      }
+    }
+  ]
+}
+```
+
+- Always confirm with the user:
+  - Which segments are used for `baseSegmentId`, `segmentId`, `scoredSegmentId`.
+  - Which columns are used as features.
+
+### 4. Create the model
+
+- POST to Audience API:
+
+```bash
+tdx api -X POST --type cdp \
+  -H 'Content-Type: application/json' \
+  -d @predictive_segment.json \
+  /audiences/{audienceId}/predictive_segments
+```
+
+- On success, capture:
+  - New predictive segment `id`.
+  - `accuracy`, `areaUnderRocCurve`, `gradeThresholds`.
+
+### 5. Handle validation and permission errors
+
+Typical issues:
+
+- **Column visibility violations**:
+  - The API may return validation errors if any feature column is not allowed (e.g., PII/Blocked).
+  - Solution: drop those columns from the feature list or adjust Column Visibility in Control Panel.
+- **Insufficient folder/segment permissions**:
+  - 403 errors when:
+    - The user lacks View+ on Training Population / Scoring Target / Positive Samples segments.
+    - The model resides in a folder where the user has only View (no edit).
+  - Solution: instruct user to adjust Audience Studio folder permissions (or work with an admin).
+
+## Workflow 3 — Run / Retrain a Predictive Model
+
+### 1. Identify the model
+
+- Follow Workflow 1 to:
+  - Pick the correct parent segment.
+  - Choose a predictive segment by `id`.
+
+### 2. Run via JSON:API entities
+
+- Preferred:
+
+```bash
+tdx api -X POST --type cdp /entities/predictive_segments/{id}/run
+```
+
+- Optional legacy alternative:
+
+```bash
+tdx api -X POST --type cdp \
+  /audiences/{audienceId}/predictive_segments/{predictiveSegmentId}/run
+```
+
+- Always:
+  - Warn the user that running a predictive model consumes compute resources.
+  - Ask for explicit confirmation before issuing the run.
+
+### 3. Monitor execution status
+
+- Poll executions:
+
+```bash
+tdx api -X GET --type cdp /entities/predictive_segments/{id}/executions
+```
+
+- Stop polling when the latest execution has:
+  - `status: "success"` → done.
+  - `status: "error"`   → report failure and suggest checking workflow logs.
+
+- Optional:
+  - Show `workflowId` / `workflowSessionId` and instruct the user how to inspect with `tdx wf`.
+
+### 4. Verify that scores are written
+
+- Predictive scoring enriches the parent segment customers table (cdp_audience_{id}.customers) with new columns, for example:
+
+  - `predicted_churn_score`
+  - `predicted_conversion_score`
+  - `predicted_ltv`
+
+- Verify with:
+
+```bash
+tdx query "SELECT predicted_churn_score, COUNT(*) AS cnt
+           FROM cdp_audience_{audienceId}.customers
+           GROUP BY 1
+           ORDER BY 1"
+```
+
+## Workflow 4 — Use Predictive Scores for Segmentation
+
+### 1. Explore score distribution in SQL
+
+- Run comprehensive analysis:
+
+```bash
+tdx query "
+SELECT
+  CASE
+    WHEN td_predictive_score_{id} >= 75 THEN 'Very High Risk'
+    WHEN td_predictive_score_{id} >= 50 THEN 'High Risk'
+    WHEN td_predictive_score_{id} >= 25 THEN 'Medium Risk'
+    ELSE 'Low Risk'
+  END AS risk_band,
+  COUNT(*) AS customers,
+  ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 2) AS pct_total,
+  ROUND(AVG(custserv_calls), 2) AS avg_calls
+FROM cdp_audience_{audienceId}.customers
+WHERE td_predictive_score_{id} IS NOT NULL
+GROUP BY 1
+ORDER BY CASE risk_band 
+  WHEN 'Very High Risk' THEN 1 
+  WHEN 'High Risk' THEN 2 
+  WHEN 'Medium Risk' THEN 3 ELSE 4 END
+"
+```
+
+- **Present results with actionable recommendations:**
+
+```
+Churn Risk Segmentation Analysis
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Risk Band      | Customers | % Total | Avg Calls | Action
+────────────────────────────────────────────────────────
+Very High      |         3 |   0.1%  |      2.00 | Immediate intervention
+High           |        32 |   1.1%  |      2.50 | Retention campaign (7 days)
+Medium         |       207 |   7.3%  |      2.52 | Monitor & nurture email
+Low            |     2,608 |  91.5%  |      1.35 | Standard engagement
+
+💡 Business Recommendations:
+• Very High (3): Dedicated account manager + retention offer
+• High (32): Win-back campaign within 7 days
+• Medium (207): Automated satisfaction survey
+```
+
+### 2. Create score-based child segments (with `segment` skill)
+
+- Use the `segment` skill and YAML config to define segments like:
+
+```yaml
+name: "Churn Risk — Very High"
+kind: batch
+rule:
+  type: And
+  conditions:
+    - type: Value
+      attribute: predicted_churn_score
+      operator:
+        type: Greater
+        value: 0.8
+```
+
+- Validate and push:
+
+```bash
+tdx sg validate segments/{parent-slug}/Segments/churn-risk-very-high.yml
+tdx sg push -y "segments/{parent-slug}/Segments/churn-risk-very-high.yml"
+```
+
+- Suggest typical segments:
+  - High risk / Medium risk / Low risk.
+  - Top N% by predicted LTV.
+
+### 3. Link back to Predictive Scores UI
+
+- Explain how these score thresholds relate to:
+  - Predictive Scores "Profiles Distribution" chart.
+  - Score threshold slider in the UI.
+
+## Error Handling & Validation Codes
+
+If the API returns validation codes such as:
+
+- `PREDICTIVE_SEGMENT_NOT_YET_TRAINED`
+- `PREDICTIVE_SEGMENT_NOT_YET_SCORED`
+
+Then:
+
+- Explain that the model must be trained and scored before certain operations (like viewing scores or creating score-based segments) can succeed.
+
+For 4xx/5xx:
+
+- Surface HTTP status, short explanation, and which step failed (list/create/run/features/score).
+- Suggest concrete next actions (check permissions, check column visibility, rerun parent segment, etc.).
+
+## Related Skills
+
+- `parent-segment` — Manage parent segment configuration and schedule.
+- `segment` — Manage child segments via YAML rules.
+- `parent-segment-analysis` — Explore cdp_audience_* customers and behavior tables.
+- `workflow` — Inspect and debug underlying predictive scoring workflows.
+- `td-admin-cli` (internal) — For deep-dive troubleshooting via admin APIs.
+
+## Safety Guidelines
+
+Never create, update, delete, or run predictive models without:
+
+- Clearly identifying the parent segment and segment IDs.
+- Getting explicit confirmation from the user.
+
+Always:
+
+- Show a summary of the planned action (audience, model name, segments, feature columns).
+- Recommend testing on a non-production audience first when possible.

--- a/tests/trigger-tests.yml
+++ b/tests/trigger-tests.yml
@@ -64,6 +64,15 @@ tests:
   - prompt: "Query parent segment data to analyze customer behaviors"
     expected: parent-segment-analysis
 
+  - prompt: "Create a predictive scoring model to predict customer churn"
+    expected: predictive-scoring
+
+  - prompt: "Show me feature importance for my propensity model"
+    expected: predictive-scoring
+
+  - prompt: "Build a lookalike model in Audience Studio"
+    expected: predictive-scoring
+
   - prompt: "Manage workflows using tdx wf commands"
     expected: workflow
 


### PR DESCRIPTION
## Summary

Adds a new skill for generating Treasure AI branded PowerPoint presentations.

### Features
- **Brand compliance**: Follows official Treasure AI design system (Navy Blue #2D40AA, Manrope/Arial, 5 gradient themes)
- **Layout variation**: Intelligent layout selection to avoid repetitive patterns
- **Python-pptx support**: Recommended implementation with complete examples
- **Japanese typography**: Kinsoku shori (禁則処理) support for Japanese text
- **Logo space reserved**: Top-left corner reserved for logo (users add files separately)
- **Page numbering**: Optional bottom-right placement
- **English documentation**: Enables team collaboration

### Implementation
- `simple-python-example.py`: Python-pptx implementation (recommended)
- `working-example-v4.js`: pptxgenjs v4 implementation (fallback)
- Complete design system documentation in `references/`

### Files
- `SKILL.md`: Skill definition (English)
- `README.md`: User documentation (English)
- `references/design.md`: Complete design specification
- `references/brand-guidelines.md`: Quick reference
- `references/layouts.md`: Layout catalog
- `LOGO_SETUP.md`: Logo placement instructions

### Quality Checklist
- [x] Logo space reserved (no text overlay)
- [x] Page numbering support
- [x] English documentation
- [x] Python and Node.js examples
- [x] Japanese kinsoku shori support
- [x] Registered in `document-skills` plugin

### Usage

```bash
# Install
/plugin marketplace add https://github.com/treasure-data/td-skills
/plugin install document-skills@td-skills

# Use
"Create a Treasure AI presentation about platform features"
```

### Notes
- Logo image files must be placed separately (see LOGO_SETUP.md)
- Page numbering is optional (disabled by default in examples)
- Categorized under `document-skills` (not `creative-skills`) as it's a Treasure AI-specific brand template