### PR TITLE
docs(studio-skills): document profile field and create_schedule tool

### DIFF
--- a/studio-skills/graflow/SKILL.md
+++ b/studio-skills/graflow/SKILL.md
@@ -263,6 +263,7 @@ Every workflow directory contains a manifest, the workflow code, and pinned depe
 
 ```yaml
 name: my-workflow
+profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # AUTO-STAMPED by Studio at create time — DO NOT hand-author
 description: What this workflow does
 permissions:
   allow:

--- a/studio-skills/graflow/references/manifest-yml.md
+++ b/studio-skills/graflow/references/manifest-yml.md
@@ -7,6 +7,7 @@
 ```yaml
 # Required
 name: my-workflow                     # Unique identifier (lowercase, hyphens), must match directory name
+profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # AUTO-STAMPED by Studio at create time — DO NOT hand-author. Omit to make the workflow visible under every Studio account (reserved for system-installed templates).
 description: What this workflow does  # Human-readable description
 
 # Tool permissions — which tools Studio Agent calls may invoke.

--- a/studio-skills/graflow/references/manifest-yml.md
+++ b/studio-skills/graflow/references/manifest-yml.md
@@ -5,10 +5,12 @@
 ## Full Schema
 
 ```yaml
-# Required
+# Required (user-authored)
 name: my-workflow                     # Unique identifier (lowercase, hyphens), must match directory name
-profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # AUTO-STAMPED by Studio at create time — DO NOT hand-author. Omit to make the workflow visible under every Studio account (reserved for system-installed templates).
 description: What this workflow does  # Human-readable description
+
+# Studio-managed — DO NOT hand-author
+profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # Auto-stamped by Studio at create time. Omit to make the workflow visible under every Studio account (reserved for system-installed templates).
 
 # Tool permissions — which tools Studio Agent calls may invoke.
 permissions:

--- a/studio-skills/schedule-task/SKILL.md
+++ b/studio-skills/schedule-task/SKILL.md
@@ -25,7 +25,7 @@ Determine where to create the task based on your current working directory:
 
 1. **Capture Intent** — What to automate, how often, what tools/data needed, where results go
    - **Ask the user** for output format (Slack message, CSV, HTML report, etc.) and notification channels before creating files. Never assume a Slack channel — always confirm.
-2. **Create the Task** — Write files to the appropriate directory (workspace or standalone, see above)
+2. **Create the Task** — **Always use the `create_schedule` MCP tool**, never Write/Bash the files directly. The tool scaffolds schedule.yaml + TASK.md + the standard subdirs (`data/`, `reference/`, `scripts/`, `results/`) and stamps the active Studio profile into schedule.yaml. Extra files under `scripts/` or `reference/` are added afterwards with Write.
 3. **Validate** — Run `schedule_validate` to check schedule.yaml
 4. **Reload** — Run `schedule_reload` to pick up new/changed tasks
 5. **Review** — Load the `schedule-review` skill and run a full review (structure + quality checks in parallel)
@@ -51,7 +51,7 @@ Steps 5-8 are **mandatory** — a task is not complete until it has been reviewe
     └── output.md        # Execution summary (REQUIRED — agent writes this)
 ```
 
-Create the directory and files directly using Write/Bash tools. The system will pick them up after `schedule_reload`.
+Use `create_schedule` to scaffold the directory — it generates schedule.yaml, TASK.md, and the four subdirs in one call and auto-registers the task. Add extra files under `scripts/` and `reference/` afterwards with Write. The system will pick up subsequent edits after `schedule_reload`.
 
 ## TASK.md Anatomy
 
@@ -94,6 +94,7 @@ Additional sections (`## Notes`, `## Constraints`, `## Data Files`, `## Output F
 
 ```yaml
 name: daily-sales-report
+profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # AUTO-STAMPED by create_schedule — DO NOT hand-author. Omit to make the task visible under every Studio account (reserved for system-installed templates).
 schedule: "0 9 * * 1-5"
 enabled: false
 status: configured       # "configured" = ready to run, "template" = needs customization
@@ -149,6 +150,7 @@ Notification targets: use `slack:channel-name` for a Slack channel, or `slack:dm
 
 | Tool | Purpose |
 |------|---------|
+| `create_schedule` | **Preferred path** to create a new task — scaffolds schedule.yaml, TASK.md, and the standard subdirs; stamps the active Studio profile automatically |
 | `schedule_list` | List all tasks with status |
 | `schedule_get` | Full task details including TASK.md and recent results |
 | `schedule_validate` | Validate schedule.yaml against schema |

--- a/studio-skills/schedule-task/SKILL.md
+++ b/studio-skills/schedule-task/SKILL.md
@@ -25,7 +25,7 @@ Determine where to create the task based on your current working directory:
 
 1. **Capture Intent** — What to automate, how often, what tools/data needed, where results go
    - **Ask the user** for output format (Slack message, CSV, HTML report, etc.) and notification channels before creating files. Never assume a Slack channel — always confirm.
-2. **Create the Task** — **Always use the `create_schedule` MCP tool**, never Write/Bash the files directly. The tool scaffolds schedule.yaml + TASK.md + the standard subdirs (`data/`, `reference/`, `scripts/`, `results/`) and stamps the active Studio profile into schedule.yaml. Extra files under `scripts/` or `reference/` are added afterwards with Write.
+2. **Create the Task** — **Always use the `create_schedule` MCP tool for the initial task scaffold**; do not hand-create `schedule.yaml`, `TASK.md`, or the standard subdirs (`data/`, `reference/`, `scripts/`, `results/`) with Write/Bash. The tool generates those files/directories and stamps the active Studio profile into schedule.yaml. Extra files under `scripts/` or `reference/` may be added afterwards with Write.
 3. **Validate** — Run `schedule_validate` to check schedule.yaml
 4. **Reload** — Run `schedule_reload` to pick up new/changed tasks
 5. **Review** — Load the `schedule-review` skill and run a full review (structure + quality checks in parallel)


### PR DESCRIPTION
## Summary

Follow-up to the account-scoped-workflows change in tdx. Updates three skill documents so agents author manifests correctly under the new per-profile model:

- **schedule-task/SKILL.md** — step 2 now mandates the new `create_schedule` MCP tool (instead of hand-writing files with Write/Bash), and the MCP tools table surfaces `create_schedule` as the preferred scaffolding path.
- **schedule-task/SKILL.md + graflow/SKILL.md + graflow/references/manifest-yml.md** — document the new `profile:` field in `schedule.yaml` / `manifest.yml` examples with an explicit note that it is auto-stamped by Studio and must not be hand-authored.

Placeholder values are written as ``\`@tdx-studio:<site>:<account-id>:<user-id>\`\`\` to avoid leaking real account IDs.

## Test plan

- [ ] Render the updated SKILL.md files and confirm tables / code blocks display correctly
- [ ] Spot-check that a fresh Studio agent session loads these skills and follows the `create_schedule`-first flow
- [ ] Confirm no real account IDs or user IDs appear in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)