### PR TITLE
feat(treasure-work-skills): add treasure-work-skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -192,6 +192,23 @@
         "./studio-skills/web-search",
         "./studio-skills/graflow"
       ]
+    },
+    {
+      "name": "treasure-work-skills",
+      "description": "Treasure Work-specific skills including workspace document management, skill creation, scheduled task management, and UI rendering formats for grid dashboards and action reports. Uses the renamed `mcp__work__*` MCP tool namespace.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./treasure-work-skills/work",
+        "./treasure-work-skills/skill-creator",
+        "./treasure-work-skills/react-dashboard",
+        "./treasure-work-skills/grid-dashboard",
+        "./treasure-work-skills/action-report",
+        "./treasure-work-skills/schedule-task",
+        "./treasure-work-skills/schedule-review",
+        "./treasure-work-skills/web-search",
+        "./treasure-work-skills/graflow"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ Skills are folders of instructions and resources that Claude loads dynamically t
 - **[studio-skills/schedule-review](./studio-skills/schedule-review)** - Review and validate scheduled tasks before enabling, with structural and quality checks via parallel sub-agents
 - **[studio-skills/web-search](./studio-skills/web-search)** - Web search and URL content extraction using `web_search` with query optimization, search operators, and structured research patterns
 
+### Treasure Work Skills
+
+Mirror of `studio-skills` updated for the renamed `mcp__work__*` MCP namespace (formerly `mcp__tdx-studio__*`). Use this plugin with builds that ship the `work` MCP server name.
+
+- **[treasure-work-skills/work](./treasure-work-skills/work)** - Manage workspace documents (items, goals, notes, guides, references) using file operations with YAML frontmatter, wiki-links, and status lifecycles
+- **[treasure-work-skills/skill-creator](./treasure-work-skills/skill-creator)** - Create, write, and optimize custom skills (SKILL.md files) in Treasure Work with description optimization and writing patterns
+- **[treasure-work-skills/react-dashboard](./treasure-work-skills/react-dashboard)** - Build interactive React dashboards in Treasure Work using `render_react` for custom components beyond `render_chart`
+- **[treasure-work-skills/schedule-task](./treasure-work-skills/schedule-task)** - Create and configure scheduled tasks in Treasure Work: TASK.md authoring, schedule.yaml, and cron setup
+- **[treasure-work-skills/schedule-review](./treasure-work-skills/schedule-review)** - Review and validate scheduled tasks before enabling, with structural and quality checks via parallel sub-agents
+- **[treasure-work-skills/web-search](./treasure-work-skills/web-search)** - Web search and URL content extraction using `web_search` with query optimization, search operators, and structured research patterns
+
 ### Reference
 
 - **[template-skill](./template-skill)** - Template for creating new TD-specific skills
@@ -125,6 +136,7 @@ Skills are folders of instructions and resources that Claude loads dynamically t
    - `tdx-skills` - tdx CLI for managing TD from command line
    - `field-agent-skills` - Field Agent deployment, documentation, and visualization best practices
    - `studio-skills` - Treasure Studio skills: workspace management, skill creation, React dashboards, scheduled tasks, and web search
+   - `treasure-work-skills` - Treasure Work skills (same set as `studio-skills`, but updated for the renamed `mcp__work__*` MCP namespace)
    - `creative-skills` - Multi-channel ad ideation, brand compliance, and brand onboarding
    - `template-skill` - Template for creating new skills
 
@@ -137,6 +149,7 @@ Skills are folders of instructions and resources that Claude loads dynamically t
    /plugin install tdx-skills@td-skills
    /plugin install field-agent-skills@td-skills
    /plugin install studio-skills@td-skills
+   /plugin install treasure-work-skills@td-skills
    /plugin install creative-skills@td-skills
    ```
 

--- a/treasure-work-skills/action-report/SKILL.md
+++ b/treasure-work-skills/action-report/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: action-report
+description: "YAML format reference for action reports rendered via preview_action_report. MUST be read before writing any action report YAML — defines the report structure (title, summary, actions array) and action item fields (as_is, to_be, reason, priority, category, impact) with incremental build workflow. Required by seo-analysis and any skill that produces prioritized recommendations."
+---
+
+# Action Report
+
+Render prioritized action reports in the artifact panel via `preview_action_report`. The agent writes a YAML file defining an executive summary and a list of action items; the MCP App renders them as visual cards sorted by priority.
+
+## Building the Report Incrementally
+
+**CRITICAL**: Large reports (6+ actions) MUST be built in batches to avoid output truncation. Do NOT attempt to write the entire YAML in a single tool call.
+
+1. **Write** the file with `title`, `subtitle`, `summary`, and the first 2–3 actions
+2. **Edit** the file to append the next 2–3 actions at the end of the `actions` array
+3. Repeat step 2 until all actions are written
+4. Call `preview_action_report` **once** at the end — never mid-build
+
+Each Edit call should add at most 3 action items. This keeps individual tool call output small and prevents mid-generation truncation.
+
+## YAML Structure
+
+```yaml
+title: "SEO Action Report: example.com"
+subtitle: "Analyzed 2026-02-18 (28-day window)"    # optional
+summary: |
+  AEO Score: 58/100 (C). 12 quick wins identified.
+  Estimated total impact: +190-270 clicks/month.
+
+actions:
+  - title: "Rewrite H1 to include primary keyword"
+    priority: high              # high | medium | low
+    category: "Content Structure"  # optional — shown as badge
+    as_is: |
+      ```html
+      <h1>Making Marketers Superhuman</h1>
+      ```
+    to_be: |
+      ```html
+      <h1>Treasure Data CDP | AI-Native Customer Data Platform</h1>
+      ```
+    reason: |
+      Current H1 has no keyword signals. Top 5 competitors
+      all include "CDP" in H1. Expected: +15-20% CTR.
+    impact: "+35-40 clicks/month"  # optional — shown at bottom of card
+
+  - title: "Add FAQPage JSON-LD schema"
+    priority: high
+    category: "Structured Data"
+    as_is: |
+      Only Article schema present
+    to_be: |
+      ```json
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {"@type": "Question", "name": "How does a CDP work?", "acceptedAnswer": {"@type": "Answer", "text": "..."}},
+          {"@type": "Question", "name": "CDP vs DMP?", "acceptedAnswer": {"@type": "Answer", "text": "..."}}
+        ]
+      }
+      ```
+    reason: |
+      4/5 competitors have FAQPage schema. Sites with 3+ schema types
+      show ~13% higher AI citation rate.
+    impact: "+50-80 clicks/month"
+```
+
+## Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | Yes | Report title (e.g., "SEO Action Report: example.com") |
+| `subtitle` | No | Subtitle shown below title (e.g., date range, analysis scope) |
+| `summary` | Yes | Executive summary — markdown text shown at top of report |
+| `actions` | Yes | Array of action items (at least one) |
+
+### Action Item Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | Yes | Short action title (imperative form: "Add...", "Rewrite...", "Fix...") |
+| `priority` | Yes | `high`, `medium`, or `low` — determines sort order and color |
+| `category` | No | Category tag (e.g., "Content Structure", "Technical SEO") |
+| `as_is` | Yes | As-Is (current state) — markdown (use code blocks for HTML/JSON/config) |
+| `to_be` | Yes | To-Be (recommended state) — markdown (complete replacement, not a diff) |
+| `reason` | Yes | Why this change — cite data, competitor patterns, expected effect |
+| `impact` | No | Expected impact (e.g., "+35-40 clicks/month", "CTR +2%") |
+
+## Rendering
+
+The dashboard renders actions sorted by priority (high → medium → low) as flat cards with no expand/collapse. Each card shows:
+
+- **Header**: number badge, title, priority badge, category badge
+- **Diff area**: As-Is (red card) / To-Be (green card) stacked vertically
+- **Reason**: explanation text below the diff
+- **Impact**: metric at bottom of card (if provided)
+
+### Copy as Markdown
+
+A **Copy as Markdown** button in the header copies the entire report as formatted markdown to the clipboard. This allows users to paste into docs, tickets, or share with team members.
+
+### Calling the tool
+
+Write the YAML file and call:
+
+```
+preview_action_report({ file_path: "/absolute/path/to/action-report.yaml" })
+```
+
+## Writing Guidelines
+
+- **`as_is` and `to_be`**: Include **actual current content** and **complete replacement** — not vague descriptions. Use code blocks for HTML, JSON-LD, config snippets.
+- **`reason`**: Cite specific data — competitor patterns, SERP features, score dimensions, metrics. Not just "this is better."
+- **`priority`**: Based on effort-to-impact ratio. High = low effort + high impact. Low = high effort or low impact.
+- **`summary`**: Lead with the most important finding. Include key scores and total expected impact.
+
+## Fallback (No Artifact Panel)
+
+When `preview_action_report` is not available (CLI mode), output the same information as formatted markdown directly in the conversation.

--- a/treasure-work-skills/graflow/SKILL.md
+++ b/treasure-work-skills/graflow/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: graflow
+description: Build agentic workflow pipelines using Graflow (Python). Use when the user asks to create, edit, or debug a Graflow workflow, agentic pipeline, or automated multi-step business process. Covers @task decorator, workflow composition (>> sequential, | parallel), Studio Agent integration with the ephemeral-per-task session pattern (MCP tools, state via channels), subprocess for CLI tools, dynamic branching (next_task, next_iteration), HITL approval flows, and manifest.yml triggers and permissions.allow configuration. Also trigger on mentions of Graflow, agentic workflow, task graph, workflow.py, multi-step automation, CS health check, SDR sequence, or any request combining deterministic logic with AI decision points. For digdag/TD Workflow, see the digdag skill. For scheduled tasks with TASK.md, see the schedule-task skill.
+---
+
+# Graflow Agentic Workflow
+
+Build Python workflow pipelines combining **deterministic flow control** (branching, loops, parallelism) with **AI reasoning** (Studio Agent + MCP tools).
+
+> **Docs**: https://graflow.ai/
+
+| Task | Guide |
+|------|-------|
+| Build a new workflow | Follow the [3-phase process](#workflow-plan--implement--review) below |
+| Add Studio Agent to a task | See [Studio Agent Integration](#studio-agent-integration) |
+| Use CLI tools without agent overhead | See [Subprocess Tasks](#subprocess-tasks) |
+| Add branching or loops | See [Dynamic Control Flow](#dynamic-control-flow) |
+| Add human approval gates | See [HITL Patterns](references/advanced-patterns.md#human-in-the-loop-hitl) |
+| Configure triggers and tool permissions | See [manifest.yml Reference](references/manifest-yml.md) |
+| Browse templates | See [templates/](templates/) |
+
+## When to Use Graflow
+
+| Use Case | Tool |
+|---|---|
+| Multi-step process with branching, parallelism, HITL | **Graflow** |
+| Open-ended AI reasoning (research, analysis) | **Scheduled Task** (TASK.md) |
+| Data pipeline on TD platform | **TD Workflow** (digdag) |
+
+## Core Concepts
+
+### Three Types of Tasks
+
+Every task in a Graflow workflow falls into one of three categories. Choosing the right type for each step is the most important design decision — it affects performance, cost, and reliability.
+
+| Type | When to Use | Example |
+|---|---|---|
+| **Deterministic** (pure Python) | Scoring, filtering, classification, data transforms | Categorize items by keyword, compute risk scores |
+| **Studio Agent** (AI reasoning) | Need MCP tools, natural language analysis, content generation | Summarize data, draft reports, post to Slack |
+| **Subprocess** (CLI tools) | Call external CLIs directly — faster and more reliable than routing through an agent | `gh`, `tdx`, `curl`, `jq` |
+
+The subprocess type is important because spawning an agent session just to run a single CLI command adds significant latency and token cost. If the task is "fetch data from a CLI tool," `subprocess.run()` is the right choice.
+
+```python
+from graflow import task, workflow
+from graflow.core.context import TaskExecutionContext
+from studio_agent import StudioAgent
+import subprocess, json
+
+# 1. Deterministic — pure logic, no I/O overhead
+@task
+def score(accounts: list) -> list:
+    return [a for a in accounts if a["health"] < 0.5]
+
+# 2. Studio Agent — AI reasoning + MCP tools
+@task
+def analyze(account_id: str):
+    with StudioAgent() as agent:
+        return agent.run(
+            f"Check activity for account {account_id} "
+            f"and assess churn risk. Return as JSON."
+        )["output"]
+
+# 3. Subprocess — call a CLI tool directly
+@task(inject_context=True)
+def fetch_data(ctx: TaskExecutionContext) -> list:
+    result = subprocess.run(
+        ["gh", "api", "/repos/owner/repo/issues", "--paginate"],
+        capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh failed: {result.stderr}")
+    data = json.loads(result.stdout)
+    ctx.get_channel().set("data", data)
+    return data
+```
+
+### Workflow Composition
+
+```python
+a >> b                    # Sequential: b after a
+a | b                     # Parallel: a and b concurrently
+a >> (b | c) >> d         # Fan-out/fan-in
+(a | b) >> c >> (d | e)   # Multi-stage pipeline
+```
+
+### Studio Agent Integration
+
+Delegate AI reasoning to Studio's Claude Agent SDK with access to 100+ MCP tools (Slack, Google Calendar, CRM, etc.).
+
+**Canonical pattern**: open a fresh `StudioAgent` inside each task and let the `with` block close it when the task ends. Pass state between tasks through channel set/get — not through shared agent memory.
+
+```python
+from graflow import task, workflow
+from graflow.core.context import TaskExecutionContext
+from studio_agent import StudioAgent
+
+
+@task(inject_context=True)
+def research(ctx: TaskExecutionContext) -> str:
+    with StudioAgent() as agent:
+        result = agent.run(
+            "Find all active deals closing this week. Return as JSON."
+        )
+    summaries = result["output"]
+    ctx.get_channel().set("summaries", summaries)
+    return summaries
+
+
+@task(inject_context=True)
+def notify(ctx: TaskExecutionContext) -> str:
+    summaries = ctx.get_channel().get("summaries")
+    with StudioAgent() as agent:
+        # Name the tool explicitly so the agent doesn't guess
+        result = agent.run(
+            f"Deals:\n{summaries}\n\n"
+            f"Post a one-paragraph summary to #sales on Slack. "
+            f"Use slack_post_message tool."
+        )
+    return result["output"]
+
+
+with workflow("example") as ctx:
+    research >> notify
+    ctx.execute("research")
+```
+
+**Agent prompt tips:**
+- Name the MCP tool the agent should use (e.g. "Use slack_post_message tool.") — this prevents the agent from guessing or trying wrong tools.
+- Be specific about data format and expected output.
+- Re-supply all data the agent needs — each task gets a fresh session with no memory of prior tasks.
+
+**Do not** register an agent at the workflow level (`ctx.register_llm_agent(...)`) and share it across tasks. That keeps a Claude session open through every intervening deterministic task and couples tasks to implicit agent memory instead of explicit channel state. See [Studio Agent Bridge](references/studio-agent-bridge.md) for the one narrow exception (multi-turn chain-of-thought inside a single task) and the full `StudioAgent` API.
+
+### Subprocess Tasks
+
+When a task just calls a CLI tool and parses its output, use `subprocess.run()` directly instead of routing through a Studio Agent. This avoids agent session overhead (typically 30-60s per call) and gives deterministic, reproducible results.
+
+```python
+import subprocess, json
+
+@task(inject_context=True)
+def fetch_from_cli(ctx: TaskExecutionContext) -> list:
+    """Call an external CLI and parse its JSON output."""
+    result = subprocess.run(
+        ["some-cli", "list", "--json", "--limit", "100"],
+        capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"CLI failed: {result.stderr}")
+    items = json.loads(result.stdout)
+    ctx.get_channel().set("items", items)
+    return items
+```
+
+When using subprocess, add the corresponding CLI to `permissions.allow` in `manifest.yml`:
+
+```yaml
+permissions:
+  allow:
+    - "Bash(some-cli:*)"   # Argument-level pattern for the CLI
+```
+
+### Channel Communication
+
+Tasks share data through channels. There are two approaches:
+
+**Explicit channel set/get** — Reliable and recommended for complex workflows. Works well when multiple downstream tasks need the same data, or when the channel key name differs from the parameter name.
+
+```python
+@task(inject_context=True)
+def producer(ctx: TaskExecutionContext):
+    data = compute_something()
+    ctx.get_channel().set("results", data)
+    return data
+
+@task(inject_context=True)
+def consumer(ctx: TaskExecutionContext):
+    data = ctx.get_channel().get("results")
+```
+
+**Auto keyword resolution** — Graflow can auto-resolve task parameters from matching channel keys. Simpler for short pipelines where each value is consumed by exactly one downstream task.
+
+```python
+@task(inject_context=True)
+def setup(ctx: TaskExecutionContext):
+    ctx.get_channel().set("threshold", 0.5)
+
+@task
+def check(threshold: float):  # Auto-resolved from channel
+    print(threshold)  # 0.5
+```
+
+For workflows with more than 3-4 tasks, or where the data flow isn't strictly linear, prefer explicit channel set/get. It's clearer about what data flows where, and avoids subtle bugs when parameter names don't exactly match channel keys.
+
+**Priority**: channel < bound parameter < injection
+
+### Handling Empty or Missing Data
+
+When upstream tasks might return empty results, handle this gracefully instead of letting the workflow fail. Continue with a sensible default rather than terminating.
+
+```python
+@task(inject_context=True)
+def process(ctx: TaskExecutionContext) -> str:
+    items = ctx.get_channel().get("items")
+    if not items:
+        summary = "No items found for this period."
+        ctx.get_channel().set("summary", summary)
+        return summary
+    # ... normal processing ...
+```
+
+Use `ctx.terminate_workflow()` only for conditions where continuing would be meaningless (not just empty data). For most cases, propagate a "nothing to report" message through the pipeline so the final task can still produce useful output.
+
+### Dynamic Control Flow
+
+```python
+# Conditional branching — skip to a specific task
+@task(inject_context=True)
+def classify(context, data: dict):
+    if data["priority"] == "high":
+        context.next_task(urgent_handler, goto=True)
+    elif data["priority"] == "low":
+        context.terminate_workflow("Low priority — skipped")
+
+# Iterative refinement — loop until convergence
+@task(inject_context=True, max_cycles=10)
+def refine(context, draft: str = ""):
+    improved = improve(draft)
+    if quality_score(improved) >= 0.9:
+        return improved
+    context.next_iteration({"draft": improved})
+```
+
+### Parallel Error Policies
+
+```python
+from graflow.core.task import ParallelGroup
+from graflow.coordination.executor import ExecutionPolicy
+
+# Best effort — continue even if some tasks fail
+ParallelGroup([a, b, c], name="checks", execution_policy=ExecutionPolicy.BEST_EFFORT)
+
+# At least N — succeed if 2 of 3 complete
+ParallelGroup([a, b, c], name="quorum", execution_policy=ExecutionPolicy.AT_LEAST_N, min_successes=2)
+```
+
+## Output File Structure
+
+Every workflow directory contains a manifest, the workflow code, and pinned dependencies, plus optional supporting files:
+
+```
+{workflow-id}/
+├── manifest.yml          # Metadata, triggers, permissions, execution config
+├── workflow.py           # Graflow workflow definition
+├── requirements.txt      # Python dependencies (pinned versions)
+├── guide.md              # Human-readable description / run notes (optional)
+├── reference/            # Context files for AI nodes (optional)
+└── data/                 # Input data, configs (optional)
+```
+
+**manifest.yml** (minimal):
+
+```yaml
+name: my-workflow
+profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # AUTO-STAMPED by Studio at create time — DO NOT hand-author
+description: What this workflow does
+permissions:
+  allow:
+    - "mcp__work__slack_post_message"   # Full MCP tool name
+    - "Bash(gh:*)"                            # CLI with argument pattern
+triggers:
+  - type: cron
+    schedule: "0 9 * * *"
+execution:
+  timeout: 600             # Budget ~120s per agent task
+results:
+  max_retained: 30
+```
+
+See [manifest.yml Reference](references/manifest-yml.md) for all trigger types, the `permissions.allow` syntax, and every option.
+
+**requirements.txt**:
+
+```
+graflow>=0.1.8
+studio-agent @ file:///path/to/studio/python/studio_agent
+```
+
+Studio's scaffold fills in the correct `file://` path to the bundled `studio_agent` package automatically.
+
+Pin dependency versions. Avoid open-ended ranges for production workflows.
+
+## Workflow: Plan → Implement → Review
+
+### Phase 1: Plan
+
+1. **Gather requirements** — Ask the user:
+   - Purpose and trigger conditions?
+   - Data sources / external services involved?
+   - Which steps need AI reasoning vs deterministic logic vs subprocess?
+   - Approval/review gates (HITL)?
+   - Output destinations (Slack, email, CRM)?
+
+2. **Create design document** (`workflow_design.md`):
+
+```markdown
+# Workflow Design: {name}
+
+## Tasks
+| Task ID | Type | Responsibility |
+|---------|------|---------------|
+| fetch | Subprocess | Pull data from external CLI |
+| summarize | Studio Agent | Summarize and analyze data |
+| categorize | Deterministic | Classify items by rules |
+| draft | Studio Agent | Compose report |
+| post | Studio Agent | Post to Slack |
+
+## Task Graph
+fetch >> summarize >> categorize >> draft >> post
+
+## Studio Agent Usage
+- summarize: ephemeral session; receives raw data via channel
+- draft: ephemeral session; receives categorized data via channel
+- post: ephemeral session; receives draft via channel; use slack_post_message tool
+```
+
+3. **Present to user** — Show the task graph diagram and key decisions. Iterate until approved. **Do not proceed to Phase 2 without explicit approval.**
+
+### Phase 2: Implement
+
+Write `workflow.py` + `manifest.yml` + `requirements.txt` based on the approved design.
+
+**Checklist**:
+- [ ] `@task` decorators with appropriate injections (`inject_context=True` when using channels or control flow)
+- [ ] `>>` / `|` composition matching the design graph
+- [ ] Every agent-backed task opens its own `with StudioAgent() as agent:` block
+- [ ] Agent prompts name the specific MCP tool to use (e.g. "Use slack_post_message tool.")
+- [ ] Cross-task state flows through explicit `channel.set()` / `channel.get()`
+- [ ] CLI-calling tasks use `subprocess.run()` with `timeout` and error checking
+- [ ] Deterministic tasks for scoring, filtering, routing
+- [ ] Empty/missing data handled gracefully (no unnecessary `terminate_workflow`)
+- [ ] `manifest.yml` with correct triggers, a minimal `permissions.allow` list, and adequate timeout
+- [ ] Pinned dependencies in `requirements.txt`
+
+### Phase 3: Review
+
+**Checklist**:
+- [ ] All tasks from design are implemented
+- [ ] Graph matches design diagram
+- [ ] Studio Agent prompts are specific (not vague) and re-supply all data the task needs
+- [ ] Deterministic tasks handle edge cases (empty lists, missing data)
+- [ ] `manifest.yml` triggers are correct and `permissions.allow` is as narrow as possible
+- [ ] `execution.timeout` is large enough — budget ~120s per agent task plus time for subprocess/deterministic tasks
+- [ ] No open-ended dependency ranges
+
+**Common issues**:
+- Missing `inject_context=True` when using `ctx.get_channel()` or `context.next_task()`
+- Assuming the agent "remembers" a previous task's output — each task has a fresh session, so re-supply the data in the prompt
+- Registering a workflow-level `ctx.register_llm_agent(...)` instead of the ephemeral-per-task pattern
+- Vague agent prompts that don't name the tool to use — the agent wastes time guessing
+- Using subprocess to call a CLI but forgetting to add the corresponding `Bash(cli:*)` to `permissions.allow`
+- Default `timeout: 300` being too short for workflows with multiple agent tasks
+- Using `terminate_workflow` for empty data when the pipeline should continue with a "nothing to report" message
+
+## Templates
+
+| Template | Pattern | Use Case |
+|---|---|---|
+| [simple-pipeline.py](templates/simple-pipeline.py) | `fetch >> process >> notify` | Starting point for new workflows |
+| [cs-health-check.py](templates/cs-health-check.py) | `scan >> evaluate >> alert` | CS account monitoring |
+| [sdr-sequence.py](templates/sdr-sequence.py) | `qualify >> (enrich_co \| enrich_ct) >> personalize >> schedule` | SDR outreach automation |
+| [parallel-enrichment.py](templates/parallel-enrichment.py) | `fetch >> (crm \| usage \| support) >> merge >> report` | Multi-source data enrichment |
+| [hitl-approval.py](templates/hitl-approval.py) | `draft >> approve >> send/revise` | Human-gated content delivery with Studio approval UI |
+
+## References
+
+- [Workflow Patterns](references/workflow-patterns.md) — Task definitions, composition, channels, binding
+- [Advanced Patterns](references/advanced-patterns.md) — Dynamic tasks, HITL, checkpoints
+- [Studio Agent Bridge](references/studio-agent-bridge.md) — StudioAgent API, prompt tips, ephemeral-per-task pattern
+- [manifest.yml Reference](references/manifest-yml.md) — Triggers, `permissions.allow` syntax (including argument-level patterns), execution settings
+
+## Related Skills
+
+- **digdag** — TD-hosted workflow orchestration (`.dig` files, `td>` operator)
+- **llm-workflow** — LLM processing within digdag workflows
+- **workflow-management** — Debugging and monitoring TD workflows with `tdx wf`
+- **schedule-task** — Scheduled tasks using TASK.md and Claude Agent SDK

--- a/treasure-work-skills/graflow/references/advanced-patterns.md
+++ b/treasure-work-skills/graflow/references/advanced-patterns.md
@@ -1,0 +1,239 @@
+# Advanced Graflow Patterns
+
+## Table of Contents
+- [Dynamic Task Generation](#dynamic-task-generation)
+- [Fan-Out and Fan-In Patterns](#fan-out-and-fan-in-patterns)
+- [Human-in-the-Loop (HITL)](#human-in-the-loop-hitl)
+- [Checkpoint and Resume](#checkpoint-and-resume)
+
+---
+
+## Dynamic Task Generation
+
+### next_task() — Add Task at Runtime
+```python
+from graflow import task
+from graflow.core.context import TaskExecutionContext
+
+@task(inject_context=True)
+def dispatcher(ctx: TaskExecutionContext):
+    data = ctx.get_channel().get("data")
+
+    if data["type"] == "priority":
+        ctx.next_task(priority_handler(data=data))
+    else:
+        ctx.next_task(normal_handler(data=data))
+```
+
+### next_task() with goto — Skip Static Successors
+```python
+@task(inject_context=True)
+def validate(ctx: TaskExecutionContext, record: dict):
+    if not record.get("ok"):
+        ctx.next_task(error_handler, goto=True)  # Skip process >> publish
+        return
+    # Fall through to normal pipeline: validate >> process >> publish
+```
+
+### next_iteration() — Loop with New Data
+```python
+@task(inject_context=True, max_cycles=10)
+def optimize(ctx: TaskExecutionContext, params: dict = None):
+    params = params or {"iter": 0, "accuracy": 0.5}
+    params["iter"] += 1
+    params["accuracy"] = min(params["accuracy"] + 0.15, 0.95)
+
+    if params["accuracy"] >= 0.9:
+        return params  # Converged — exit loop
+    ctx.next_iteration({"params": params})  # Loop with updated data
+```
+
+### terminate_workflow() — Early Normal Exit
+```python
+@task(inject_context=True)
+def check_complete(ctx: TaskExecutionContext):
+    if all_done():
+        ctx.terminate_workflow(result="completed early")
+        return
+    ctx.next_task(continue_processing())
+```
+
+### cancel_workflow() — Abort with Error
+```python
+@task(inject_context=True)
+def validate(ctx: TaskExecutionContext):
+    if critical_error():
+        ctx.cancel_workflow(error="Critical validation failed")
+```
+
+---
+
+## Fan-Out and Fan-In Patterns
+
+### Dynamic Parallel Group
+```python
+from graflow.core.task import parallel
+
+@task(inject_context=True)
+def create_workers(ctx: TaskExecutionContext):
+    items = ctx.get_channel().get("items")
+
+    workers = [
+        process_item(task_id=f"worker_{i}", item=item)
+        for i, item in enumerate(items)
+    ]
+    ctx.next_task(parallel(*workers))
+```
+
+### Fan-Out-then-Fan-In (Single Convergence Point)
+```python
+@task(inject_context=True)
+def root(ctx: TaskExecutionContext):
+    parallel_group = parallel(
+        branch_a(task_id="branch_a"),
+        branch_b(task_id="branch_b"),
+    )
+    # integrator runs ONCE after both branches complete
+    chained = parallel_group >> integrator(task_id="integrator")
+    ctx.next_task(chained)
+```
+
+---
+
+## Human-in-the-Loop (HITL)
+
+Studio provides a built-in HITL mechanism via `request_feedback()` from the `studio_agent` package. When a workflow calls `request_feedback()`, Studio displays an approval card in the Agentic Workflows panel (plus an OS notification), and the call blocks until the user responds or the timeout expires.
+
+Use `request_feedback()` instead of Graflow's native `ctx.request_feedback()` for workflows running under Studio. The Studio function uses HTTP long-polling to the Local API Server rather than filesystem polling, and surfaces a rich approval UI with options, context display, and free-form comments.
+
+### Basic Approval
+```python
+from studio_agent import request_feedback
+
+@task
+def approval_gate(draft: str) -> dict:
+    decision = request_feedback(
+        prompt=f"Approve this draft?\n\n{draft}",
+        timeout=3600,
+    )
+    if decision["status"] != "approved":
+        raise RuntimeError(f"Rejected: {decision.get('comment') or 'no reason'}")
+    return decision
+```
+
+### Selection with Options
+```python
+@task(inject_context=True)
+def select_action(ctx: TaskExecutionContext):
+    decision = request_feedback(
+        prompt="Select action for at-risk account:",
+        options=["Schedule call", "Send email", "Escalate to manager", "Skip"],
+        timeout=300,
+    )
+    ctx.get_channel().set("action", decision["choice"])
+```
+
+### Rich Context Display
+```python
+@task(inject_context=True)
+def review_outreach(ctx: TaskExecutionContext):
+    email_body = ctx.get_channel().get("email_body")
+    account = ctx.get_channel().get("account")
+    decision = request_feedback(
+        prompt="Send this outreach email?",
+        options=["Send now", "Queue for tomorrow", "Discard"],
+        context={
+            "account": account["name"],
+            "ARR": f"${account['arr']:,.0f}",
+            "email_preview": email_body[:500],
+        },
+        timeout=3600,
+    )
+    ctx.get_channel().set("send_decision", decision)
+```
+
+### Handling All Response Statuses
+```python
+decision = request_feedback(prompt="Deploy to production?", timeout=1800)
+
+if decision["status"] == "approved":
+    # User clicked Approve
+    print(f"Approved. Choice: {decision['choice']}, Comment: {decision['comment']}")
+elif decision["status"] == "rejected":
+    # User clicked Reject
+    print(f"Rejected. Reason: {decision['comment']}")
+elif decision["status"] == "timeout":
+    # No response within timeout
+    print("No response — aborting.")
+elif decision["status"] == "cancelled":
+    # Studio closed or workflow run cancelled
+    print("Cancelled — exiting cleanly.")
+```
+
+### `request_feedback()` API
+
+```python
+from studio_agent import request_feedback
+
+decision = request_feedback(
+    prompt="Question for the user (1–2000 chars)",
+    options=["Option A", "Option B"],   # Up to 4 labeled options (optional)
+    context={"key": "value"},           # Key/value pairs shown beside the prompt (optional)
+    timeout=3600,                       # Max seconds to wait (clamped to [60, 86400])
+)
+```
+
+**Returns** a dict:
+
+| Key | Type | Description |
+|---|---|---|
+| `status` | `str` | `"approved"` \| `"rejected"` \| `"timeout"` \| `"cancelled"` |
+| `choice` | `str \| None` | Selected option label, or `None` |
+| `comment` | `str \| None` | Free-form text the user entered, or `None` |
+
+**Raises** `StudioAgentError` if Studio is unreachable.
+
+### Timeout Strategy for HITL Workflows
+
+When a workflow includes `request_feedback()`, the `execution.timeout` in `manifest.yml` must account for human response time. Budget the `request_feedback` timeout **plus** agent task time:
+
+| Workflow Shape | Recommended `execution.timeout` |
+|---|---|
+| 1 agent task + 1 HITL (1h) | 3900 (3600 + 300 margin) |
+| 2 agent tasks + 1 HITL (1h) | 4200 |
+| Agent + HITL + agent (chain) | 4500+ |
+
+Set `execution.timeout` >= the sum of all `request_feedback` timeouts plus agent execution time.
+
+---
+
+## Checkpoint and Resume
+
+### Basic Checkpoint
+```python
+@task(inject_context=True)
+def long_running(ctx: TaskExecutionContext):
+    for i, batch in enumerate(batches):
+        process(batch)
+        if i % 10 == 0:
+            ctx.checkpoint()
+```
+
+### Resume from Checkpoint
+```python
+from graflow.core.checkpoint import CheckpointManager
+
+manager = CheckpointManager(checkpoint_dir="./checkpoints")
+result = manager.resume_from_checkpoint("checkpoint_path.pkl")
+```
+
+### Fault Recovery Pattern
+```python
+with workflow("fault_tolerant") as wf:
+    try:
+        result = wf.execute("entry_task", checkpoint_dir="./checkpoints")
+    except Exception as e:
+        print(f"Failed: {e}, resuming from checkpoint...")
+        manager = CheckpointManager(checkpoint_dir="./checkpoints")
+        result = manager.resume_from_latest()
+```

--- a/treasure-work-skills/graflow/references/manifest-yml.md
+++ b/treasure-work-skills/graflow/references/manifest-yml.md
@@ -1,0 +1,204 @@
+# manifest.yml Reference
+
+`manifest.yml` defines metadata, triggers, tool permissions, and execution settings for a Graflow workflow. Studio scaffolds this file alongside `workflow.py` when you create a new agentic workflow.
+
+## Full Schema
+
+```yaml
+# Required (user-authored)
+name: my-workflow                     # Unique identifier (lowercase, hyphens), must match directory name
+description: What this workflow does  # Human-readable description
+
+# Studio-managed — DO NOT hand-author
+profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # Auto-stamped by Studio at create time. Omit to make the workflow visible under every Studio account (reserved for system-installed templates).
+
+# Tool permissions — which tools Studio Agent calls may invoke.
+permissions:
+  allow:
+    - "Write"                                    # Built-in Write tool (all invocations)
+    - "Bash(gh:*)"                               # Argument-level pattern — only gh commands
+    - "Bash"                                     # All Bash invocations (any command)
+    - "mcp__work__slack_post_message"            # Full MCP tool name
+    - "slack_post_message"                       # Short name — also matches mcp__work__slack_post_message
+    - "mcp__td-docs__*"                          # Wildcard for all tools from an MCP server
+
+# Triggers — when the workflow should run
+triggers:
+  - type: cron
+    schedule: "0 9 * * *"             # 5-field vixie cron (minimum 5-minute interval)
+
+  - type: webhook                     # Phase 2
+    path: /my-endpoint                # POST http://localhost:9876/webhooks/{path}
+
+  - type: slack                       # Phase 2
+    channel: "#channel-name"
+    keywords:
+      - "run health check"
+      - "account scan"
+
+# Execution settings
+execution:
+  timeout: 300                        # Max execution time in seconds (default: 300)
+  max_retries: 2                      # Retry on failure (default: 0)
+
+# Results retention
+results:
+  max_retained: 30                    # Number of run results to keep (default: 30)
+```
+
+## Permissions
+
+The `permissions.allow` list is the **single source of truth** for which tools the Studio Agent may call from this workflow. Studio enforces it server-side for every `agent.run()` call — individual tasks cannot widen the allowlist at runtime.
+
+### Syntax
+
+Each entry is a tool name, a Studio MCP short name, a full SDK tool name, or a wildcard. Studio supports **argument-level patterns** using the Claude Agent SDK `Tool(pattern:*)` form, which is useful for restricting shell access to specific CLI tools.
+
+| Entry | Matches |
+|---|---|
+| `Bash` | All Bash invocations (any command) |
+| `Bash(gh:*)` | Bash invocations where the command starts with `gh` |
+| `Bash(tdx:*)` | Bash invocations where the command starts with `tdx` |
+| `Read` | All `Read` tool invocations |
+| `Write` | All `Write` tool invocations |
+| `slack_post_message` | Short name — matches `mcp__work__slack_post_message` |
+| `mcp__work__slack_post_message` | Full SDK name — also works |
+| `mcp__td-docs__search` | Exact full SDK name for an external MCP server tool |
+| `mcp__td-docs__*` | All tools from the `td-docs` external MCP server |
+
+**Both short names and full names work** for Studio MCP tools. `slack_post_message` and `mcp__work__slack_post_message` are equivalent. Use whichever is clearer — short names are more readable, full names are more explicit.
+
+**Argument-level patterns** like `Bash(gh:*)` are the preferred way to grant shell access because they limit the agent to a specific CLI tool rather than giving it unrestricted shell access. This is important for security — a prompt-injection vulnerability in upstream data could otherwise let the agent run arbitrary shell commands.
+
+### Minimum viable allowlist
+
+A workflow that posts a Slack message and calls a CLI tool needs:
+
+```yaml
+permissions:
+  allow:
+    - "slack_post_message"   # or mcp__work__slack_post_message
+    - "Bash(gh:*)"           # restricted to gh commands only
+```
+
+Keep the allowlist as narrow as the workflow actually needs — every extra entry is extra attack surface if prompt-injection-tainted data reaches the agent.
+
+### Always-allowed tools
+
+A small set of read-only built-in tools (Read / Glob / Grep / TodoWrite / Skill and similar) is always enabled for agentic workflows and does not need to appear in `permissions.allow`. Tools **not** in that set — including `Write`, `Bash`, `WebFetch`, `WebSearch`, and every MCP tool — must be declared explicitly.
+
+## Triggers
+
+### Cron Trigger
+
+Standard 5-field vixie cron syntax. Minimum interval: 5 minutes.
+
+```yaml
+triggers:
+  - type: cron
+    schedule: "0 9 * * *"       # Daily at 9:00 AM
+```
+
+**Common schedules**:
+
+| Schedule | Cron Expression |
+|---|---|
+| Every hour | `0 * * * *` |
+| Daily at 9am | `0 9 * * *` |
+| Weekdays at 8am | `0 8 * * 1-5` |
+| Every Monday at 6am | `0 6 * * 1` |
+| First day of month | `0 0 1 * *` |
+| Every 15 minutes | `*/15 * * * *` |
+
+### Webhook Trigger (Phase 2)
+
+HTTP endpoint that triggers the workflow when called.
+
+```yaml
+triggers:
+  - type: webhook
+    path: /health-check
+```
+
+Trigger: `POST http://localhost:9876/webhooks/health-check`
+
+The request body is passed as workflow input via the channel.
+
+### Slack Trigger (Phase 2)
+
+Monitors a Slack channel for messages containing specific keywords.
+
+```yaml
+triggers:
+  - type: slack
+    channel: "#cs-ops"
+    keywords: ["health check", "scan accounts"]
+```
+
+The message context (user, thread, text) is passed as workflow input.
+
+### Multiple Triggers
+
+A workflow can have multiple triggers. Any trigger can start it.
+
+```yaml
+triggers:
+  - type: cron
+    schedule: "0 9 * * *"
+  - type: webhook
+    path: /force-run
+  - type: slack
+    channel: "#ops"
+    keywords: ["run now"]
+```
+
+## Execution Settings
+
+```yaml
+execution:
+  timeout: 300       # Kill workflow after 300 seconds (default)
+  max_retries: 2     # Retry up to 2 times on failure (default: 0)
+```
+
+### Choosing the right timeout
+
+The default 300s (5 minutes) works for simple workflows with 1-2 agent tasks. For longer pipelines, budget roughly **120 seconds per agent task** plus a small margin for subprocess and deterministic tasks.
+
+| Workflow Shape | Recommended Timeout |
+|---|---|
+| 1 agent task + deterministic | 300 (default) |
+| 2-3 agent tasks | 480–600 |
+| 4-5 agent tasks | 600–900 |
+| Workflows with large data volumes | 900+ (up to your judgment) |
+
+Setting the timeout too low is a common failure mode — the workflow gets killed mid-run and produces no output. When in doubt, round up.
+
+## Results Retention
+
+```yaml
+results:
+  max_retained: 30   # Keep last 30 run results (default)
+```
+
+Results are stored in `{workflow-dir}/results/{run-id}/`:
+- `result.json` — workflow output
+- `logs.txt` — stdout/stderr
+
+Older results are automatically pruned when `max_retained` is exceeded.
+
+## Minimal Example
+
+```yaml
+name: daily-report
+description: Generate and send daily report
+permissions:
+  allow:
+    - "slack_post_message"
+triggers:
+  - type: cron
+    schedule: "0 8 * * 1-5"
+execution:
+  timeout: 300
+```
+
+All other fields use defaults (max_retries: 0, max_retained: 30).

--- a/treasure-work-skills/graflow/references/studio-agent-bridge.md
+++ b/treasure-work-skills/graflow/references/studio-agent-bridge.md
@@ -1,0 +1,305 @@
+# Studio Agent Bridge
+
+Graflow workflows delegate AI reasoning to Treasure Studio's Claude Agent SDK via the `StudioAgent` class. This gives workflow tasks access to Studio's 100+ MCP tools (Slack, Google Calendar, CRM, etc.) without configuring credentials in Python.
+
+## Prerequisites
+
+- Treasure Studio running on the same machine (127.0.0.1:9877 by default — the port may change and is published to subprocesses via `STUDIO_API_PORT`)
+- `studio-agent` package installed in the workflow's venv
+
+## Canonical Pattern — Ephemeral Session Per Task
+
+**Open a fresh `StudioAgent` inside each task and let the context manager close it when the task ends.** Pass state between tasks through explicit `channel.set()` / `channel.get()`, not through shared agent memory.
+
+```python
+from graflow import task, workflow
+from graflow.core.context import TaskExecutionContext
+from studio_agent import StudioAgent
+
+
+@task(inject_context=True)
+def fetch_data(ctx: TaskExecutionContext) -> str:
+    with StudioAgent() as agent:
+        result = agent.run(
+            "List all active deals closing this month. Return as JSON."
+        )
+    data = result["output"]
+    ctx.get_channel().set("deals", data)
+    return data
+
+
+@task(inject_context=True)
+def summarize(ctx: TaskExecutionContext) -> str:
+    deals = ctx.get_channel().get("deals")
+    # Fresh session — no memory of fetch_data's session.
+    # Re-supply the data explicitly and name the tool to use.
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Summarize these deals in one paragraph:\n\n{deals}\n\n"
+            f"Then post the summary to #sales on Slack. Use slack_post_message tool."
+        )
+    return result["output"]
+
+
+with workflow("example") as ctx:
+    fetch_data >> summarize
+    ctx.execute("fetch_data")
+```
+
+### Why ephemeral?
+
+- **No idle sessions during deterministic tasks.** If a workflow interleaves Python-only tasks (scoring, filtering, merging) with agent tasks, a shared session would stay open — holding Studio resources — the whole time. Ephemeral sessions exist only while an agent is actively running.
+- **Parallel branches are independent.** Each parallel task gets its own session, so a slow or failed branch never blocks another from closing.
+- **Matches digdag's task-independent model.** State moves between tasks through explicit outputs, not through implicit agent memory, so the graph stays readable and each task is unit-testable on its own.
+
+## Agent Prompt Tips
+
+The prompt you pass to `agent.run()` is the single most important factor in task reliability. These patterns come from production workflows:
+
+### Name the MCP tool explicitly
+
+The agent has access to many tools but doesn't always pick the right one. Naming the tool removes ambiguity:
+
+```python
+# Good — agent knows exactly which tool to call
+agent.run("Post a summary to #ops. Use slack_post_message tool.")
+
+# Bad — agent may try slack_search_messages, read_channel, or other tools first
+agent.run("Post a summary to #ops on Slack.")
+```
+
+### Re-supply all data the task needs
+
+Each task starts a fresh agent session with no memory of prior tasks. Include all necessary data in the prompt, even if it feels redundant:
+
+```python
+@task(inject_context=True)
+def draft_report(ctx: TaskExecutionContext) -> str:
+    stats = ctx.get_channel().get("stats")
+    summaries = ctx.get_channel().get("summaries")
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Write a weekly report.\n\n"
+            f"## Stats\n{stats}\n\n"
+            f"## Summaries\n{summaries}\n\n"
+            f"Structure as: Highlights, Details by Category, Metrics."
+        )
+    return result["output"]
+```
+
+### Be specific about output format
+
+Tell the agent exactly what format you need, especially when the next task will parse the output:
+
+```python
+agent.run("List overdue items. Return as a JSON array of objects with keys: id, title, days_overdue.")
+```
+
+## When to Use Each Task Type
+
+| Approach | Use When |
+|---|---|
+| **Ephemeral `StudioAgent`** | Need MCP tools (Slack, Calendar, CRM), AI reasoning, natural language analysis, content generation |
+| **Direct Python** (no agent) | Deterministic logic, data transformation, scoring, filtering, classification |
+| **`subprocess.run()`** | Calling external CLIs (`gh`, `tdx`, `curl`) — faster and cheaper than routing a CLI call through an agent |
+| **Mix all three** | Most real workflows — subprocess for data fetching, agent for analysis/notification, Python for logic |
+
+### Example: Mixed Approach
+
+```python
+import subprocess, json
+
+@task(inject_context=True)
+def fetch_data(ctx: TaskExecutionContext) -> list:
+    """Subprocess: call a CLI tool directly."""
+    result = subprocess.run(
+        ["some-cli", "list", "--json"],
+        capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"CLI failed: {result.stderr}")
+    items = json.loads(result.stdout)
+    ctx.get_channel().set("items", items)
+    return items
+
+
+@task(inject_context=True)
+def analyze(ctx: TaskExecutionContext) -> str:
+    """Agent: AI reasoning on the fetched data."""
+    items = ctx.get_channel().get("items")
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Analyze these items and identify key trends:\n\n"
+            f"{json.dumps(items[:50], indent=2)}\n\n"
+            f"Return as a structured markdown report."
+        )
+    analysis = result["output"]
+    ctx.get_channel().set("analysis", analysis)
+    return analysis
+
+
+@task
+def calculate_score(items: list) -> float:
+    """Deterministic: pure logic, no I/O overhead."""
+    weights = {"activity": 0.4, "tickets": 0.3, "engagement": 0.3}
+    return sum(items.get(k, 0) * w for k, w in weights.items())
+
+
+fetch_data >> (analyze | calculate_score) >> report
+```
+
+## StudioAgent API
+
+### Constructor
+
+```python
+StudioAgent(base_url: str | None = None, auth_token: str | None = None)
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `base_url` | Resolved from `STUDIO_API_PORT` env var, falling back to `http://127.0.0.1:9877` | Studio Local API server URL |
+| `auth_token` | Read from `STUDIO_AUTH_TOKEN` env var | Per-launch auth token, auto-injected by the Studio agentic-workflow runner |
+
+Both defaults are what Studio sets when launching a workflow subprocess — **call `StudioAgent()` with no arguments** in template code.
+
+### `run(input_text, **kwargs) -> dict`
+
+Send a prompt to Studio's Claude Agent SDK.
+
+```python
+result = agent.run("Check account A123 and assess churn risk")
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `input_text` | `str` | The prompt for the agent |
+| `timeout` | `int` (kwarg, optional) | Per-call HTTP timeout in seconds (default: 300) |
+
+> Tool filtering is **not** done per-call. The set of tools the agent may use is declared once in `manifest.yml` under `permissions.allow` and enforced by Studio server-side. See [manifest.yml Reference](manifest-yml.md#permissions) for the allowlist syntax.
+
+**Returns** a dict:
+
+```python
+{
+    "output": "Analysis: Account A123 shows...",  # Agent's final text response
+    "steps": ["mcp__hubspot__get_company", ...],   # Tools the agent invoked
+    "metadata": {
+        "model": "studio-agent",
+        "session_id": "sess_abc123",
+        "usage": {"input_tokens": 1200, "output_tokens": 450},
+    },
+}
+```
+
+### `close()`
+
+Close the Studio Agent session. Called automatically when exiting the `with` block or when the process ends (Studio also has a server-side idle reaper as a safety net).
+
+```python
+with StudioAgent() as agent:
+    agent.run("...")
+# Session closed here — no manual close() needed.
+```
+
+### `is_available() -> bool`
+
+Check whether Studio's Local API Server is reachable.
+
+```python
+with StudioAgent() as agent:
+    if not agent.is_available():
+        raise RuntimeError("Studio is not running")
+    result = agent.run("...")
+```
+
+## Human-in-the-Loop: `request_feedback()`
+
+The `studio_agent` package provides a standalone `request_feedback()` function that pauses the workflow until a human responds via Studio's approval UI.
+
+```python
+from studio_agent import request_feedback
+
+decision = request_feedback(
+    prompt="Send the renewal pitch to Acme Corp?",
+    options=["Send now", "Queue for tomorrow"],
+    context={
+        "summary": "3 sessions this week, ARR $120k",
+        "draft": "Hi Pat — just checking in on Q2 goals...",
+    },
+    timeout=3600,
+)
+
+if decision["status"] == "approved":
+    selected = decision["choice"]    # "Send now" or "Queue for tomorrow"
+    comment = decision["comment"]    # Optional free-form text from user
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `prompt` | `str` | (required) | Question shown to the user (1–2000 chars) |
+| `options` | `list[str] \| None` | `None` | Up to 4 labeled options. `None` = free-form only |
+| `context` | `dict \| None` | `None` | Key/value pairs rendered beside the prompt |
+| `timeout` | `int` | `3600` | Max seconds to wait. Server clamps to [60, 86400] |
+| `base_url` | `str \| None` | env-resolved | Override Studio API base URL |
+| `auth_token` | `str \| None` | env-resolved | Override per-run auth token |
+
+### Return Value
+
+Returns a dict with three keys:
+
+| Key | Type | Description |
+|---|---|---|
+| `status` | `str` | `"approved"` \| `"rejected"` \| `"timeout"` \| `"cancelled"` |
+| `choice` | `str \| None` | Selected option label, or `None` if no options provided |
+| `comment` | `str \| None` | Free-form text the user entered, or `None` |
+
+### How It Works
+
+1. `request_feedback()` POSTs to Studio's `/feedback/create` endpoint
+2. Studio displays an approval card in the Agentic Workflows panel + sends an OS notification
+3. The function blocks on HTTP long-polling (`/feedback/{id}/wait`) until the user responds
+4. When the user clicks Approve/Reject, the resolution is returned to the caller
+
+### Notes
+
+- `request_feedback()` is independent of `StudioAgent` — it doesn't require an active agent session. Call it anywhere in your workflow code.
+- `auth_token` and `base_url` are auto-resolved from environment variables (`STUDIO_AUTH_TOKEN`, `STUDIO_API_PORT`) set by Studio when launching the workflow subprocess.
+- If Studio is closed while a feedback request is pending, `status` becomes `"cancelled"`.
+- Set `execution.timeout` in `manifest.yml` high enough to cover human response time (e.g. 3900s for a 1-hour HITL + 300s agent margin).
+
+## Error Handling
+
+```python
+from studio_agent import StudioAgent, StudioAgentError
+
+
+@task
+def safe_query() -> str:
+    try:
+        with StudioAgent() as agent:
+            return agent.run("Fetch account data")["output"]
+    except StudioAgentError as exc:
+        # Studio unreachable, HTTP error, or session creation failed.
+        return f"ERROR: {exc}"
+```
+
+`StudioAgentError` wraps both connection failures (`requests.ConnectionError`) and HTTP errors from the server, with the Studio base URL and response text included.
+
+## Exception: Shared Session Within a Single Task
+
+The canonical pattern is one session per task. There is one narrow case where a **shared session lives inside a single task**: when the task performs a multi-turn reasoning chain where each turn must see the previous agent response in full context (chain-of-thought refinement that cannot be flattened into one prompt).
+
+```python
+@task
+def deep_analysis(case: dict) -> dict:
+    with StudioAgent() as agent:
+        draft = agent.run(f"Analyze case {case['id']}...")["output"]
+        critique = agent.run(f"Critique your own analysis: {draft}")["output"]
+        final = agent.run("Incorporate the critique into a final recommendation.")["output"]
+    return {"draft": draft, "critique": critique, "final": final}
+```
+
+The session lifetime is still bounded by the single task — it closes as soon as the task exits. **Do not register an agent at the workflow level and share it across tasks**: that keeps the session open through every deterministic task in between and couples tasks to implicit agent memory instead of explicit channel state.

--- a/treasure-work-skills/graflow/references/studio-agent-bridge.md
+++ b/treasure-work-skills/graflow/references/studio-agent-bridge.md
@@ -1,10 +1,10 @@
 # Studio Agent Bridge
 
-Graflow workflows delegate AI reasoning to Treasure Studio's Claude Agent SDK via the `StudioAgent` class. This gives workflow tasks access to Studio's 100+ MCP tools (Slack, Google Calendar, CRM, etc.) without configuring credentials in Python.
+Graflow workflows delegate AI reasoning to Treasure Work's Claude Agent SDK via the `StudioAgent` class. This gives workflow tasks access to Studio's 100+ MCP tools (Slack, Google Calendar, CRM, etc.) without configuring credentials in Python.
 
 ## Prerequisites
 
-- Treasure Studio running on the same machine (127.0.0.1:9877 by default — the port may change and is published to subprocesses via `STUDIO_API_PORT`)
+- Treasure Work running on the same machine (127.0.0.1:9877 by default — the port may change and is published to subprocesses via `STUDIO_API_PORT`)
 - `studio-agent` package installed in the workflow's venv
 
 ## Canonical Pattern — Ephemeral Session Per Task

--- a/treasure-work-skills/graflow/references/workflow-patterns.md
+++ b/treasure-work-skills/graflow/references/workflow-patterns.md
@@ -1,0 +1,264 @@
+# Graflow Workflow Patterns
+
+## Table of Contents
+- [Basic Task Definition](#basic-task-definition)
+- [Workflow Context](#workflow-context)
+- [Composition Operators](#composition-operators)
+- [Channel Communication](#channel-communication)
+- [Task Instance Binding](#task-instance-binding)
+- [Error Handling Policies](#error-handling-policies)
+
+---
+
+## Basic Task Definition
+
+### Simple Task
+```python
+from graflow import task
+
+@task
+def hello():
+    print("Hello, Graflow!")
+    return "success"
+
+result = hello.run()
+```
+
+### Task with Parameters
+```python
+@task
+def process_data(value: int, multiplier: int = 2) -> int:
+    return value * multiplier
+
+result = process_data.run(value=10, multiplier=3)  # Returns 30
+```
+
+### Task with Context Injection
+```python
+from graflow.core.context import TaskExecutionContext
+
+@task(inject_context=True)
+def context_task(ctx: TaskExecutionContext):
+    print(f"Session: {ctx.session_id}")
+    print(f"Task ID: {ctx.task_id}")
+    channel = ctx.get_channel()
+    channel.set("status", "running")
+```
+
+---
+
+## Workflow Context
+
+### Basic Workflow
+```python
+from graflow import task, workflow
+
+with workflow("my_workflow") as wf:
+    @task
+    def step_a():
+        return "a"
+
+    @task
+    def step_b():
+        return "b"
+
+    step_a >> step_b
+    wf.execute("step_a")
+```
+
+### Workflow with Return Value
+```python
+with workflow("pipeline") as wf:
+    # ... define tasks and graph ...
+    result = wf.execute("entry_task")
+    print(f"Final result: {result}")
+```
+
+### Workflow with Context Return
+```python
+with workflow("pipeline") as wf:
+    # ... define tasks ...
+    result, exec_ctx = wf.execute("entry_task", ret_context=True)
+    final_channel = exec_ctx.get_channel()
+    print(final_channel.get("accumulated_data"))
+```
+
+### Workflow with Initial Channel
+```python
+with workflow("pipeline") as wf:
+    @task
+    def process(config: dict):
+        # config is auto-resolved from channel
+        return config["value"] * 2
+
+    wf.execute("process", initial_channel={"config": {"value": 10}})
+```
+
+---
+
+## Composition Operators
+
+### Sequential (`>>`)
+```python
+# Tasks execute one after another
+fetch >> validate >> transform >> store
+```
+
+### Parallel (`|`)
+```python
+# Tasks execute concurrently, then converge
+(task_a | task_b | task_c).set_group_name("parallel_tasks") >> aggregate
+```
+
+### Diamond Pattern (Fan-out + Fan-in)
+```python
+source >> (transform_a | transform_b) >> sink
+```
+
+### Multi-stage Pipeline
+```python
+(load_a | load_b) >> validate >> (process_a | process_b) >> store
+```
+
+### Complex DAG
+```python
+a >> (b | c) >> d >> (e | f | g) >> h
+```
+
+---
+
+## Channel Communication
+
+### Two Approaches: Explicit set/get vs Auto Resolution
+
+Graflow offers two ways for tasks to share data through channels. Choose based on your workflow's complexity.
+
+**Explicit channel set/get** — The recommended approach for most workflows, especially those with 3+ tasks or non-linear data flow. You control exactly what data is written and read, and channel key names don't need to match parameter names.
+
+```python
+@task(inject_context=True)
+def producer(ctx: TaskExecutionContext):
+    channel = ctx.get_channel()
+    channel.set("data", [1, 2, 3])
+    channel.set("config", {"batch_size": 100})
+
+@task(inject_context=True)
+def consumer(ctx: TaskExecutionContext):
+    channel = ctx.get_channel()
+    data = channel.get("data")        # [1, 2, 3]
+    config = channel.get("config")    # {"batch_size": 100}
+```
+
+**Auto keyword resolution** — Simpler syntax for short, linear pipelines. Parameters matching channel keys are resolved automatically. Works well when each value is consumed by exactly one downstream task and names match exactly.
+
+```python
+@task(inject_context=True)
+def setup(ctx: TaskExecutionContext):
+    ctx.get_channel().set("user_name", "Alice")
+    ctx.get_channel().set("count", 5)
+
+@task
+def greet(user_name: str, count: int = 1):
+    # user_name="Alice", count=5 — auto-resolved from channel
+    for _ in range(count):
+        print(f"Hello, {user_name}!")
+```
+
+**When to prefer explicit set/get:**
+- Workflow has more than 3 tasks
+- Multiple downstream tasks need the same data
+- Channel key names differ from parameter names
+- You want to read and write channels within the same task (common when a task both consumes upstream data and produces downstream data)
+
+### Channel Append
+```python
+@task(inject_context=True)
+def accumulator(ctx: TaskExecutionContext):
+    channel = ctx.get_channel()
+    channel.append("results", "item1")
+    channel.append("results", "item2")
+    # channel.get("results") == ["item1", "item2"]
+```
+
+### Parameter Priority
+```
+channel < bound < injection
+```
+
+1. **Channel** (lowest): Auto-resolved from `channel.set()`
+2. **Bound**: Passed at task creation `task(param=value)`
+3. **Injection** (highest): `inject_context`
+
+> Graflow also supports `inject_llm_agent`, but Studio workflows do **not** use it. The canonical Studio pattern opens an ephemeral `StudioAgent` inside the task body instead of registering a workflow-level agent. See [Studio Agent Bridge](studio-agent-bridge.md).
+
+---
+
+## Task Instance Binding
+
+### Multiple Instances from Single Task
+```python
+@task
+def process(query: str) -> str:
+    return f"Processing: {query}"
+
+# Create separate instances with bound parameters
+task1 = process(task_id="task1", query="Tokyo")
+task2 = process(task_id="task2", query="Paris")
+
+with workflow("multi_instance") as wf:
+    task1 >> task2
+    wf.execute("task1")
+```
+
+### Bound Parameters Override Channel
+```python
+with workflow("test") as wf:
+    task = process(task_id="test", value=10)  # value=10 is bound
+    wf.execute("test", initial_channel={"value": 100})
+    # Uses value=10 (bound), not value=100 (channel)
+```
+
+---
+
+## Error Handling Policies
+
+### Strict Mode (Default)
+```python
+from graflow.core.task import ParallelGroup
+
+# All tasks must succeed — if any fails, entire group fails
+group = ParallelGroup([task_a, task_b, task_c], name="strict_group")
+```
+
+### Best Effort
+```python
+from graflow.coordination.executor import ExecutionPolicy
+
+group = ParallelGroup(
+    [task_a, task_b, task_c],
+    name="best_effort",
+    execution_policy=ExecutionPolicy.BEST_EFFORT,
+)
+# Continues even if some tasks fail
+```
+
+### At Least N
+```python
+group = ParallelGroup(
+    [task_a, task_b, task_c],
+    name="at_least_2",
+    execution_policy=ExecutionPolicy.AT_LEAST_N,
+    min_successes=2,
+)
+# Succeeds if at least 2 tasks complete
+```
+
+### Critical Tasks Only
+```python
+group = ParallelGroup(
+    [task_a, task_b, task_c],
+    name="critical",
+    execution_policy=ExecutionPolicy.CRITICAL_ONLY,
+    critical_tasks=["task_a"],  # Only task_a must succeed
+)
+```

--- a/treasure-work-skills/graflow/templates/cs-health-check.py
+++ b/treasure-work-skills/graflow/templates/cs-health-check.py
@@ -1,0 +1,80 @@
+"""CS Health Check Workflow
+
+Scans active accounts via Studio Agent (HubSpot), evaluates churn risk
+with deterministic scoring, and sends personalized Slack alerts for
+at-risk accounts.
+
+Graph: scan_accounts >> evaluate_risk >> notify_csm
+
+Each agent-backed task opens its own ephemeral Studio Agent session.
+Cross-task context is passed explicitly through return values —
+``notify_csm`` re-supplies the at-risk accounts to its fresh session
+because a new session does not share memory with prior ones.
+"""
+
+from graflow import task, workflow
+from graflow.core.context import TaskExecutionContext
+from studio_agent import StudioAgent
+
+
+@task
+def scan_accounts() -> list:
+    """Fetch all active accounts with recent activity data from HubSpot."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            "List all active accounts from HubSpot. For each account, include: "
+            "company name, account owner, last activity date, open support tickets count, "
+            "and contract renewal date. Return as a structured JSON list."
+        )
+    return result["output"]
+
+
+@task(inject_context=True)
+def evaluate_risk(ctx: TaskExecutionContext, accounts: list):
+    """Deterministic churn risk scoring — no agent needed."""
+    from datetime import datetime, timedelta
+
+    at_risk = []
+    threshold = datetime.now() - timedelta(days=14)
+
+    for account in accounts:
+        risk_score = 0.0
+        if account.get("last_activity_date", "") < threshold.isoformat():
+            risk_score += 0.4
+        if account.get("open_tickets", 0) > 3:
+            risk_score += 0.3
+        if account.get("days_to_renewal", 365) < 30:
+            risk_score += 0.3
+
+        if risk_score >= 0.5:
+            account["risk_score"] = risk_score
+            at_risk.append(account)
+
+    if not at_risk:
+        ctx.terminate_workflow("No at-risk accounts found today")
+
+    at_risk.sort(key=lambda a: a["risk_score"], reverse=True)
+    return at_risk
+
+
+@task
+def notify_csm(at_risk: list) -> str:
+    """Draft and send personalized Slack alerts for at-risk accounts.
+
+    The prompt re-supplies the structured ``at_risk`` list because this
+    task runs in a fresh Studio Agent session and does not share memory
+    with ``scan_accounts``.
+    """
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Here are {len(at_risk)} at-risk accounts:\n\n{at_risk}\n\n"
+            f"For each one, draft a concise alert with: account name, "
+            f"risk score, key risk factors, and a suggested next action. "
+            f"Post the summary to #cs-alerts on Slack."
+        )
+    return result["output"]
+
+
+with workflow("cs-health-check") as ctx:
+    scan_accounts >> evaluate_risk >> notify_csm
+    ctx.execute("scan_accounts")

--- a/treasure-work-skills/graflow/templates/hitl-approval.py
+++ b/treasure-work-skills/graflow/templates/hitl-approval.py
@@ -1,0 +1,98 @@
+"""HITL Approval Workflow
+
+Drafts content using Studio Agent, pauses for human approval via
+Studio's approval UI, then sends or revises based on feedback.
+
+Graph: draft_content >> request_approval >> route_action
+
+Each agent-backed task opens its own ephemeral Studio Agent session.
+The ``request_approval`` task uses ``request_feedback()`` from the
+``studio_agent`` package to display an approval card in Studio and
+block until the user responds. Decision state is stored on the channel
+so ``route_action`` can branch deterministically.
+"""
+
+from graflow import task, workflow
+from graflow.core.context import TaskExecutionContext
+from studio_agent import StudioAgent, request_feedback
+
+
+@task
+def draft_content() -> str:
+    """Generate the initial draft in a fresh agent session."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            "Draft a weekly CS update email for our executive team. "
+            "Include: key metrics (accounts at risk, recently churned, "
+            "expansion opportunities), top 3 actions taken this week, "
+            "and priorities for next week. Keep it concise and professional."
+        )
+    return result["output"]
+
+
+@task(inject_context=True)
+def request_approval(ctx: TaskExecutionContext, draft: str) -> bool:
+    """Pause workflow and wait for human review via Studio approval UI."""
+    decision = request_feedback(
+        prompt="Review this executive update draft. Approve to send, or reject with revision notes.",
+        options=["Send as-is", "Send with edits"],
+        context={
+            "draft": draft[:1000],
+            "type": "Weekly CS Update",
+        },
+        timeout=3600,
+    )
+
+    channel = ctx.get_channel()
+    if decision["status"] == "approved" and decision.get("choice") != "Send with edits":
+        channel.set("action", "send")
+        channel.set("final_content", draft)
+    elif decision["status"] in ("approved", "rejected"):
+        channel.set("action", "revise")
+        channel.set("revision_notes", decision.get("comment") or "No specific notes provided")
+        channel.set("original_draft", draft)
+    else:
+        channel.set("action", "abort")
+
+    return channel.get("action") == "send"
+
+
+@task(inject_context=True)
+def route_action(ctx: TaskExecutionContext, approved: bool) -> str:
+    """Send if approved, otherwise produce a revised draft.
+
+    Uses channel-stored decision state (set by ``request_approval``)
+    and a fresh agent session for whichever branch runs.
+    """
+    channel = ctx.get_channel()
+    action = channel.get("action")
+
+    if action == "abort":
+        return "Workflow aborted — no human response or run cancelled."
+
+    if action == "send":
+        content = channel.get("final_content")
+        with StudioAgent() as agent:
+            result = agent.run(
+                f"Send this executive update via email to the CS leadership "
+                f"distribution list and post to #cs-leadership on Slack. "
+                f"Use slack_post_message tool.\n\n{content}"
+            )
+        return result["output"]
+
+    notes = channel.get("revision_notes")
+    original = channel.get("original_draft")
+    with StudioAgent() as agent:
+        revised = agent.run(
+            f"Revise this draft based on feedback:\n\n"
+            f"Original:\n{original}\n\n"
+            f"Revision notes:\n{notes}\n\n"
+            f"Apply the feedback and return the revised version."
+        )["output"]
+    channel.set("revised_draft", revised)
+    return revised
+
+
+with workflow("hitl-approval") as ctx:
+    draft_content >> request_approval >> route_action
+    ctx.execute("draft_content")

--- a/treasure-work-skills/graflow/templates/parallel-enrichment.py
+++ b/treasure-work-skills/graflow/templates/parallel-enrichment.py
@@ -1,0 +1,100 @@
+"""Parallel Enrichment Workflow
+
+Fetches a target list, enriches from multiple sources in parallel
+(best-effort — continue if one source fails), merges the results,
+and generates a report.
+
+Graph: fetch_targets >> (enrich_crm | enrich_usage | enrich_support) >> merge >> report
+
+Each parallel branch runs in its own ephemeral Studio Agent session,
+so a slow or failed branch never blocks another session from closing.
+``merge`` is deterministic (no agent), and ``report`` opens a fresh
+session to compose the Slack summary.
+"""
+
+from graflow import task, workflow
+from graflow.core.task import ParallelGroup
+from graflow.coordination.executor import ExecutionPolicy
+from studio_agent import StudioAgent
+
+
+@task
+def fetch_targets() -> list:
+    """Get the list of accounts to enrich."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            "List all enterprise accounts from HubSpot with contract value "
+            "over $50k. Include account ID, name, and owner."
+        )
+    return result["output"]
+
+
+@task
+def enrich_crm(targets: list) -> dict:
+    """Enrich with CRM data (HubSpot deals, activities)."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"For these {len(targets)} accounts:\n\n{targets}\n\n"
+            f"Get from HubSpot: last deal stage, pipeline value, and "
+            f"recent activities."
+        )
+    return result["output"]
+
+
+@task
+def enrich_usage(targets: list) -> dict:
+    """Enrich with product usage data."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"For these {len(targets)} accounts:\n\n{targets}\n\n"
+            f"Check product usage: last login date, feature adoption rate, "
+            f"and API call volume."
+        )
+    return result["output"]
+
+
+@task
+def enrich_support(targets: list) -> dict:
+    """Enrich with support ticket data."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"For these {len(targets)} accounts:\n\n{targets}\n\n"
+            f"Get support data: open tickets, average resolution time, "
+            f"and CSAT score."
+        )
+    return result["output"]
+
+
+@task
+def merge(crm_data: dict, usage_data: dict, support_data: dict) -> dict:
+    """Merge enrichment results into unified account profiles."""
+    merged: dict = {}
+    for source in [crm_data, usage_data, support_data]:
+        for account_id, data in (source or {}).items():
+            merged.setdefault(account_id, {}).update(data)
+    return merged
+
+
+@task
+def report(profiles: dict) -> str:
+    """Generate executive summary and post to Slack."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Enterprise account profiles:\n\n{profiles}\n\n"
+            f"Create an executive summary of {len(profiles)} accounts. "
+            f"Highlight: top 5 expansion opportunities, top 5 churn risks, "
+            f"and any accounts needing immediate attention. "
+            f"Post to #account-intelligence on Slack."
+        )
+    return result["output"]
+
+
+with workflow("parallel-enrichment") as ctx:
+    # Fan-out: enrich from 3 sources in parallel — continue even if one fails.
+    enrichment = ParallelGroup(
+        [enrich_crm, enrich_usage, enrich_support],
+        name="enrichment",
+        execution_policy=ExecutionPolicy.BEST_EFFORT,
+    )
+    fetch_targets >> enrichment >> merge >> report
+    ctx.execute("fetch_targets")

--- a/treasure-work-skills/graflow/templates/sdr-sequence.py
+++ b/treasure-work-skills/graflow/templates/sdr-sequence.py
@@ -1,0 +1,86 @@
+"""SDR Outreach Sequence Workflow
+
+Qualifies leads, enriches with company and contact data in parallel,
+generates personalized outreach drafts, and schedules follow-up actions.
+
+Graph: qualify_leads >> (enrich_company | enrich_contacts) >> personalize >> schedule_actions
+
+Each agent-backed task opens its own ephemeral Studio Agent session.
+The parallel enrichment branches run in separate sessions concurrently
+and their outputs are recombined through the channel for
+``personalize``.
+"""
+
+from graflow import task, workflow
+from studio_agent import StudioAgent
+
+
+@task
+def qualify_leads() -> list:
+    """Pull new leads from HubSpot and qualify based on ICP criteria."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            "Find all new leads from HubSpot created in the last 7 days. "
+            "For each lead, check: company size (>50 employees), industry "
+            "(SaaS, e-commerce, or fintech), and whether they visited our "
+            "pricing page. Return only leads matching at least 2 of 3 criteria."
+        )
+    return result["output"]
+
+
+@task
+def enrich_company(qualified: list) -> dict:
+    """Enrich with company-level data in a fresh agent session."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"For these {len(qualified)} qualified leads:\n\n{qualified}\n\n"
+            f"Gather company info: recent funding rounds, tech stack, "
+            f"competitor products they use, and any recent news mentions."
+        )
+    return result["output"]
+
+
+@task
+def enrich_contacts(qualified: list) -> dict:
+    """Enrich with contact-level data in a fresh agent session."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"For these {len(qualified)} qualified leads:\n\n{qualified}\n\n"
+            f"Find the best contact per lead: job title, LinkedIn activity, "
+            f"shared connections, and any conference appearances."
+        )
+    return result["output"]
+
+
+@task
+def personalize(company_data: dict, contact_data: dict) -> list:
+    """Generate personalized outreach drafts."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Company enrichment:\n{company_data}\n\n"
+            f"Contact enrichment:\n{contact_data}\n\n"
+            f"Draft a personalized outreach email for each lead. Reference "
+            f"specific company details (recent funding, tech stack) and "
+            f"contact details (role, interests). Keep each email under "
+            f"150 words. Return as a list of drafts."
+        )
+    return result["output"]
+
+
+@task
+def schedule_actions(drafts: list) -> str:
+    """Create follow-up tasks and calendar blocks."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Here are {len(drafts)} outreach drafts:\n\n{drafts}\n\n"
+            f"For each: 1) Create a follow-up HubSpot task for 3 days out. "
+            f"2) Block 15 minutes on the account owner's Google Calendar for "
+            f"a potential discovery call next week. 3) Post a summary to "
+            f"#sdr-pipeline on Slack."
+        )
+    return result["output"]
+
+
+with workflow("sdr-sequence") as ctx:
+    qualify_leads >> (enrich_company | enrich_contacts) >> personalize >> schedule_actions
+    ctx.execute("qualify_leads")

--- a/treasure-work-skills/graflow/templates/simple-pipeline.py
+++ b/treasure-work-skills/graflow/templates/simple-pipeline.py
@@ -1,0 +1,59 @@
+"""Simple Pipeline Workflow
+
+Minimal example: fetch data, process it, send notification.
+Good starting point for new workflows.
+
+Graph: fetch >> process >> notify
+
+Pattern: each task opens its own ephemeral Studio Agent session
+(``with StudioAgent() as agent:``). Data flows between tasks via
+return values / channel parameters — the session does not carry
+conversational state across tasks. This mirrors digdag's
+task-independent model and avoids holding a session open while
+deterministic (non-agent) tasks run.
+"""
+
+from graflow import task, workflow
+from studio_agent import StudioAgent
+
+
+@task
+def fetch() -> dict:
+    """Gather data using an ephemeral Studio Agent session."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            "Get today's key metrics: active users, new signups, "
+            "and open support tickets from HubSpot. Return as JSON."
+        )
+    return result["output"]
+
+
+@task
+def process(metrics: dict) -> dict:
+    """Deterministic data processing — no agent session at all."""
+    summary = {
+        "total_users": metrics.get("active_users", 0),
+        "growth": metrics.get("new_signups", 0),
+        "support_load": metrics.get("open_tickets", 0),
+        "health": "good" if metrics.get("open_tickets", 0) < 10 else "needs_attention",
+    }
+    return summary
+
+
+@task
+def notify(summary: dict) -> str:
+    """Send the notification using a fresh Studio Agent session."""
+    with StudioAgent() as agent:
+        result = agent.run(
+            f"Post a daily metrics summary to #daily-standup on Slack. "
+            f"Health status: {summary['health']}. "
+            f"Include: {summary['total_users']} active users, "
+            f"{summary['growth']} new signups, "
+            f"{summary['support_load']} open tickets."
+        )
+    return result["output"]
+
+
+with workflow("simple-pipeline") as ctx:
+    fetch >> process >> notify
+    ctx.execute("fetch")

--- a/treasure-work-skills/grid-dashboard/SKILL.md
+++ b/treasure-work-skills/grid-dashboard/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: grid-dashboard
+description: "YAML format reference for grid dashboards rendered via preview_grid_dashboard. MUST be read before writing any dashboard YAML — defines the page structure, 6 cell types (kpi, gauge, scores, table, chart, markdown), grid layout rules, cell merging syntax, and incremental build workflow. Required by seo-analysis and any skill that produces visual data dashboards."
+---
+
+# Grid Dashboard
+
+Build visual dashboards rendered in the artifact panel via `preview_grid_dashboard`. The agent writes a YAML file defining pages of grid cells; the MCP App renders them with a page selector.
+
+(IMPORTANT): Include all analysis findings in the dashboard — do not omit relevant insights, metrics, or supporting facts. Build incrementally (see "Building YAML Incrementally" below).
+
+## YAML Structure
+
+The YAML is **page-based**: top-level `pages` object where each key is a page identifier (e.g., URL, label) and each value defines a grid with cells.
+
+```yaml
+pages:
+  "Page A":
+    title: "Page A Dashboard"        # optional — shown as header
+    description: "Brief description"  # optional — shown below title
+    grid:
+      columns: 3                     # number of columns
+      rows: 3                        # number of rows
+    cells:
+      - pos: "1-1"                   # row-column (1-based)
+        type: kpi                    # cell type
+        title: "Cell Title"          # optional — uppercase label above content
+        kpi:                         # type-specific config
+          value: "1,234"
+          change: "+12%"
+          trend: up
+
+  "Page B":
+    title: "Page B Dashboard"
+    grid:
+      columns: 4
+      rows: 8
+    cells:
+      - pos: "1-1"
+        type: kpi
+        # ...
+```
+
+The UI renders a **select box** at the top to switch between pages.
+
+## Building YAML Incrementally
+
+**CRITICAL**: Large dashboards MUST be built incrementally. Do NOT attempt to write the entire YAML in a single tool call — this causes output truncation mid-generation.
+
+**Multi-page dashboards** — build one page at a time:
+
+1. **Write** the file with `pages:` header and the first page's complete grid + cells
+2. **Edit** the file to append the next page
+3. Repeat step 2 until all pages are written
+4. Call `preview_grid_dashboard` **once** at the end
+
+**Single pages with many cells (12+ rows)** — build in row batches:
+
+1. **Write** the file with `pages:` header, grid config, and the first 4–6 rows of cells
+2. **Edit** to append the next 4–6 rows at the end of the `cells` array
+3. Repeat until all rows are written
+4. Call `preview_grid_dashboard` once at the end
+
+Each tool call should produce a manageable amount of YAML. Never write more than ~6 grid rows in a single tool call.
+
+## Grid Layout
+
+**This is NOT a CSS framework 12-column grid (like Bootstrap).** `columns` is the literal number of columns displayed. If you want 3 columns, set `columns: 3` — do NOT set `columns: 12` and merge cells to simulate 3 columns. The tool validates cell positions and will return errors for invalid formats.
+
+- `grid.columns` and `grid.rows` must be **numbers** matching the actual cell count (not strings, not `auto`). Do not declare more rows/columns than cells occupy
+- `pos: "row-col"` — 1-based coordinates (e.g., `"1-1"` = top-left)
+- **Cell merging**: `pos: ["1-1", "1-3"]` merges from row 1 col 1 to row 1 col 3. **MUST be a YAML array** of two strings
+- Each row has a fixed height range (120px–360px) — do not overfill cells
+- **Horizontal merging is useful** — tables and charts benefit from full-width display (e.g., `pos: ["3-1", "3-4"]`)
+- **Vertical merging is rarely needed** — each row is at least 120px tall, so spanning 3 rows creates 360px+ of height, which is excessive for most content. Only merge vertically for very long markdown or tables with many rows. In most cases, let each cell occupy a single row.
+
+**Correct pos format**:
+```yaml
+pos: "1-1"              # single cell at row 1, column 1
+pos: ["1-1", "1-3"]     # merged cell from (1,1) to (1,3)
+pos: ["3-1", "5-4"]     # merged cell spanning rows 3-5 and columns 1-4
+```
+
+**WRONG — these will cause tool errors**:
+```yaml
+pos: "1-1:1-3"          # ✗ colon separator
+pos: "1-1to1-3"         # ✗ "to" separator
+pos: "1-1,1-3"          # ✗ comma in string
+pos: [1, 1]             # ✗ numbers instead of "row-col" strings
+```
+
+**Common grid sizes**:
+- 3×3 — compact overview (9 cells)
+- 4×4 — standard dashboard (16 cells)
+- 4×6 — detailed analysis with tables (24 cells)
+
+## Cell Types
+
+### `kpi` — Metric Card
+
+Large number with optional trend indicator. Use for headline metrics in the top row.
+
+```yaml
+- pos: "1-1"
+  type: kpi
+  title: "Total Revenue"
+  kpi:
+    value: "$1.2M"          # string or number — displayed large
+    change: "+15.3%"         # optional — shown below value
+    trend: up                # optional — up | down | flat (colors the change)
+    subtitle: "vs. last quarter"  # optional — small text below change
+```
+
+### `gauge` — Half-Circle Meter
+
+Score visualization with color thresholds. Use for scores, completion rates, health indicators.
+
+```yaml
+- pos: "2-1"
+  type: gauge
+  title: "Health Score"
+  gauge:
+    value: 72                # current value
+    max: 100                 # maximum value
+    label: "B"               # optional — displayed in center (defaults to value)
+    thresholds:              # optional — color breakpoints (use hex values, NOT color names)
+      - { limit: 40, color: "#ef4444" }
+      - { limit: 70, color: "#f59e0b" }
+      - { limit: 100, color: "#22c55e" }
+```
+
+### `scores` — Progress Bar List
+
+Labeled horizontal bars showing value/max ratios. Use for dimension breakdowns, skill assessments, category comparisons.
+
+```yaml
+- pos: "2-2"
+  type: scores
+  title: "Score Breakdown"
+  scores:
+    - label: "Content Structure"
+      value: 14
+      max: 26
+    - label: "Structured Data"
+      value: 8
+      max: 26
+    - label: "E-E-A-T Signals"
+      value: 16
+      max: 21
+```
+
+Bar colors: green (≥75%), yellow (40–74%), red (<40%).
+
+### `table` — Sortable Table
+
+Structured data with click-to-sort columns. Two formats accepted:
+
+**Format 1 — Flat arrays** (compact):
+```yaml
+- pos: ["3-1", "3-4"]            # merged across columns 1-4
+  type: table
+  title: "Top Keywords"
+  table:
+    headers: ["Keyword", "Position", "Impressions", "CTR"]
+    rows:
+      - ["what is cdp", 11.2, 1840, "1.8%"]
+      - ["cdp vs dmp", 8.5, 920, "3.2%"]
+    sortable: true           # optional — defaults to true
+```
+
+**Format 2 — Column definitions** (readable, preferred for many columns):
+```yaml
+- pos: "3-1"
+  type: table
+  title: "Top Keywords"
+  table:
+    columns:
+      - key: query
+        label: "Keyword"
+      - key: position
+        label: "Position"
+      - key: impressions
+        label: "Impressions"
+      - key: ctr
+        label: "CTR"
+    rows:
+      - query: "what is cdp"
+        position: 11.2
+        impressions: 1840
+        ctr: "1.8%"
+      - query: "cdp vs dmp"
+        position: 8.5
+        impressions: 920
+        ctr: "3.2%"
+    sortable: true
+```
+
+### `chart` — Chart.js Chart
+
+Pass standard Chart.js config (`type`, `data`, `options`).
+
+**Standard types**: `bar`, `line`, `pie`, `doughnut`, `radar`, `polarArea`, `bubble`, `scatter`
+
+**Plugin types** (also available): `sankey`, `treemap`, `matrix`, `wordCloud`, `candlestick`, `ohlc`
+
+**YAML constraint**: Never use JS function strings for callbacks or scriptable options — they are passed as plain strings and will be stripped. Use declarative alternatives:
+
+- **treemap**: Set `key` to specify the value field. Put `backgroundColor` and `label` inside each tree item (not at dataset level). Use `labels: { display: true }` to show labels.
+- **matrix**: Data uses `{x, y, v}`. Width, height, scales, and tooltip are auto-configured. For multi-color heatmaps, use `colorScale` on the dataset: `colorScale: [{limit: 20, color: "#3b82f6"}, {limit: 50, color: "#10b981"}, ...]`. Omit for single-color alpha gradient from `backgroundColor`.
+
+```yaml
+- pos: "3-2"
+  type: chart
+  title: "Traffic Trend"
+  chart:
+    type: line
+    data:
+      labels: ["Jan", "Feb", "Mar", "Apr"]
+      datasets:
+        - label: "Impressions"
+          data: [1200, 1900, 3000, 2500]
+          borderColor: "#4a6cf7"
+          fill: false
+    options:                 # optional — Chart.js options
+      scales:
+        y:
+          beginAtZero: true
+```
+
+### `markdown` — Rich Text
+
+GFM markdown content. Use `content` or `markdown` key — **must be a top-level string, NOT a nested object**.
+
+```yaml
+- pos: "4-1"
+  type: markdown
+  title: "Summary"
+  content: |
+    ### Key Finding
+    **Impact**: High — content depth is 1/6 of competitors
+```
+
+**WRONG** — `markdown.content` nested object will cause a tool error:
+```yaml
+  markdown:
+    content: |       # ✗ nested under markdown — must be a top-level key
+      Some text
+```
+
+## Rendering
+
+Write the YAML file and call:
+
+```
+preview_grid_dashboard({ file_path: "/absolute/path/to/dashboard.yaml" })
+```
+
+The dashboard renders in the artifact panel with light/dark theme support and a page selector dropdown.
+
+## Fallback (No Artifact Panel)
+
+When `preview_grid_dashboard` is not available (CLI mode), output the same information as formatted markdown instead.
+
+## Layout Tips
+
+- **KPIs in row 1**: Place 3–4 KPI cells across the top for at-a-glance metrics
+- **Gauges + scores in row 2**: Pair a gauge with a scores breakdown
+- **Full-width tables**: Merge across all columns with `pos: ["3-1", "3-4"]` for data tables
+- **Mixed rows**: Split a row into halves (e.g., table on left, markdown on right)
+- **Keep rows balanced**: Avoid putting a large table next to a small KPI in the same row

--- a/treasure-work-skills/react-dashboard/SKILL.md
+++ b/treasure-work-skills/react-dashboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-dashboard
-description: Build interactive React dashboards in Treasure Studio using render_react. Use when the user explicitly asks for an interactive dashboard or custom React component beyond what render_chart supports.
+description: Build interactive React dashboards in Treasure Work using render_react. Use when the user explicitly asks for an interactive dashboard or custom React component beyond what render_chart supports.
 ---
 
 # React Dashboard

--- a/treasure-work-skills/react-dashboard/SKILL.md
+++ b/treasure-work-skills/react-dashboard/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: react-dashboard
+description: Build interactive React dashboards in Treasure Studio using render_react. Use when the user explicitly asks for an interactive dashboard or custom React component beyond what render_chart supports.
+---
+
+# React Dashboard
+
+Use `mcp__work__render_react`. For simple charts, prefer `render_chart`.
+
+## Sandbox Globals
+
+Do NOT import anything — these are pre-loaded:
+
+- **React 18**: all hooks (`useState`, `useEffect`, `useMemo`, etc.)
+- **Recharts**: all components
+- **Tailwind CSS**: all utility classes
+- **Theme**: `isDark` (boolean) and `theme` (`"light"` / `"dark"`) — reactive, update on toggle
+
+## Dark Mode
+
+**HTML elements** — Tailwind `dark:` variants:
+```jsx
+<div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+```
+
+**Recharts props** — `isDark` ternary:
+```jsx
+<XAxis stroke={isDark ? "#9ca3af" : "#6b7280"} />
+<Tooltip contentStyle={{ backgroundColor: isDark ? "#1f2937" : "#fff" }} />
+<CartesianGrid strokeDasharray="3 3" stroke={isDark ? "#374151" : "#e5e7eb"} />
+```
+
+## Example
+
+```jsx
+export default function KPIDashboard({ data }) {
+  const { kpis, trend } = data;
+  const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'];
+
+  return (
+    <div className="p-6 space-y-6 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <div className="grid grid-cols-4 gap-4">
+        {kpis.map((kpi, i) => (
+          <div key={i} className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+            <div className="text-sm text-gray-500 dark:text-gray-400">{kpi.label}</div>
+            <div className="text-2xl font-bold" style={{ color: COLORS[i] }}>{kpi.value}</div>
+          </div>
+        ))}
+      </div>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={trend}>
+          <CartesianGrid strokeDasharray="3 3" stroke={isDark ? "#374151" : "#e5e7eb"} />
+          <XAxis dataKey="date" stroke={isDark ? "#9ca3af" : "#6b7280"} />
+          <YAxis stroke={isDark ? "#9ca3af" : "#6b7280"} />
+          <Tooltip contentStyle={{ backgroundColor: isDark ? "#1f2937" : "#fff" }} />
+          <Line type="monotone" dataKey="value" stroke="#3b82f6" />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+```

--- a/treasure-work-skills/schedule-review/SKILL.md
+++ b/treasure-work-skills/schedule-review/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: schedule-review
+description: Use when the user wants to review, validate, or check a scheduled task before enabling it. Runs two parallel sub-agent checks — structural validation and quality assessment. Triggers on "review this task", "check my scheduled task", "validate task", "is this task ready", etc.
+---
+
+# Schedule Task Review
+
+Review a scheduled task by running two parallel sub-agent checks using TaskCreate:
+
+1. **Structure check** — Validates directory layout, file formats, and schema
+2. **Quality check** — Assesses whether the task meets the user's intent
+
+## Workflow
+
+1. Ask the user which task to review (or infer from context)
+2. Locate the task directory:
+   - If inside a workspace: check `{workspace}/schedules/{task-name}/`
+   - Otherwise: check `~/.tdx/schedule-tasks/{task-name}/`
+   - Use `schedule_get` to find the task if the path is unclear
+3. Read the task's TASK.md and schedule.yaml
+4. Launch both checks in parallel using TaskCreate
+5. Wait for results using TaskGet
+6. Present a unified report with pass/fail and actionable suggestions
+
+## Step 1: Read Task Files
+
+```
+Read {task-dir}/TASK.md
+Read {task-dir}/schedule.yaml
+List files in scripts/, reference/, data/
+```
+
+## Step 2: Launch Parallel Checks
+
+Use `TaskCreate` to spawn two sub-agents simultaneously.
+
+### Sub-agent 1: Structure Check
+
+```
+TaskCreate with prompt:
+"Review this scheduled task for structural correctness.
+
+TASK.md content:
+{paste TASK.md content}
+
+schedule.yaml content:
+{paste schedule.yaml content}
+
+Files in task directory:
+{list of files}
+
+Check the following:
+1. TASK.md has valid YAML frontmatter with `name` and `description`
+2. schedule.yaml has required fields (name, schedule, enabled) and only valid optional fields (status, catch_up, skills, permissions, notify, context, goal, skill, output). Note: `skills` (list of capability packs/MCP tools) and `skill` (workspace skill to invoke) serve different purposes and can coexist.
+2a. If status field is present, it must be either 'configured' or 'template'. Warn if missing (defaults to 'configured').
+3. Task name in TASK.md matches schedule.yaml name
+4. Cron expression is valid and not too frequent (minimum 5 minutes)
+5. permissions.allow lists all tools referenced in TASK.md steps (Bash for scripts, Write for output, slack_* for notifications)
+6. Scripts referenced in TASK.md steps exist in scripts/
+7. Reference files mentioned in TASK.md exist in reference/
+8. data/ files described in TASK.md exist if the task expects prior state
+9. No Slack channels or notification targets hardcoded in TASK.md (should be in schedule.yaml notify section only)
+10. output.md is mentioned as a required output in Steps
+11. If `goal` is set, verify the goal file exists in the workspace (workspace tasks only)
+12. If `output.note: true` is set, verify this is a workspace task (inside schedules/ directory)
+
+Report: PASS/FAIL for each item, with specific fix instructions for failures."
+```
+
+### Sub-agent 2: Quality Check
+
+```
+TaskCreate with prompt:
+"Review this scheduled task for quality and fitness for purpose.
+
+TASK.md content:
+{paste TASK.md content}
+
+schedule.yaml content:
+{paste schedule.yaml content}
+
+The user's original request was: {describe what the user asked for}
+
+Check the following:
+1. Steps are clear and unambiguous — could another agent execute them without guessing?
+2. Steps are in a logical order (fetch → process → analyze → output → notify)
+3. Error handling is addressed (what to do if a script fails, API is down, etc.)
+4. output.md requirements are clear (what should be in the summary?)
+5. The schedule frequency matches the task's purpose (e.g., not checking hourly for a daily report)
+6. Skills listed are appropriate for the task
+7. If data/ is used, the update cycle is clear (when to save, when to compare)
+8. The task is self-contained — no implicit dependencies on external state
+9. For workspace tasks: does the goal/skill configuration make sense for the intended purpose?
+
+Report: Rate each item as GOOD/NEEDS IMPROVEMENT/MISSING, with specific suggestions."
+```
+
+## Step 3: Collect and Report
+
+Wait for both tasks to complete using `TaskGet`, then present a unified report:
+
+```markdown
+## Task Review: {task-name}
+
+### Structure: {PASS/FAIL}
+- [x] Valid TASK.md frontmatter
+- [x] Valid schedule.yaml schema
+- [ ] Missing permission: Bash (needed for scripts/fetch.sh)
+...
+
+### Quality: {GOOD/NEEDS IMPROVEMENT/MISSING}
+- [x] Steps are clear
+- [ ] No error handling for script failure
+- [ ] output.md format not specified
+...
+
+### Recommended Fixes
+1. Add `Bash` to permissions.allow
+2. Add error handling step: "If fetch script fails, retry once..."
+3. Specify output.md format in a `## Output Format` section
+```

--- a/treasure-work-skills/schedule-task/SKILL.md
+++ b/treasure-work-skills/schedule-task/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: schedule-task
-description: Use when the user wants to create, set up, or configure a scheduled task in Treasure Studio. Covers TASK.md authoring, schedule.yaml configuration, script creation, and direct file-based task setup. Triggers on "create a scheduled task", "set up a recurring job", "automate daily report", "schedule a task", "cron job", etc.
+description: Use when the user wants to create, set up, or configure a scheduled task in Treasure Work. Covers TASK.md authoring, schedule.yaml configuration, script creation, and direct file-based task setup. Triggers on "create a scheduled task", "set up a recurring job", "automate daily report", "schedule a task", "cron job", etc.
 ---
 
 # Schedule Task Creator
 
-Create scheduled tasks in Treasure Studio that mix deterministic script execution with agent-driven analysis and delivery.
+Create scheduled tasks in Treasure Work that mix deterministic script execution with agent-driven analysis and delivery.
 
 ## Task Directory Placement
 

--- a/treasure-work-skills/schedule-task/SKILL.md
+++ b/treasure-work-skills/schedule-task/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: schedule-task
+description: Use when the user wants to create, set up, or configure a scheduled task in Treasure Studio. Covers TASK.md authoring, schedule.yaml configuration, script creation, and direct file-based task setup. Triggers on "create a scheduled task", "set up a recurring job", "automate daily report", "schedule a task", "cron job", etc.
+---
+
+# Schedule Task Creator
+
+Create scheduled tasks in Treasure Studio that mix deterministic script execution with agent-driven analysis and delivery.
+
+## Task Directory Placement
+
+Determine where to create the task based on your current working directory:
+
+1. **If inside a workspace**: find the nearest ancestor directory (including the current one) that contains a `tdx.json` file **and** at least one of `goals/` or `items/` folders. That directory is `{workspace}`.
+   - Create under `{workspace}/schedules/{task-name}/`
+   - Workspace context (accepted guides, goals) is automatically available at execution time
+   - `{workspace}` becomes the working directory during execution
+
+2. **Otherwise** (standalone):
+   - Create under `~/.tdx/schedule-tasks/{task-name}/`
+
+## Workflow
+
+**CRITICAL: Never just create files and stop. Always run the task and iterate until it works.**
+
+1. **Capture Intent** — What to automate, how often, what tools/data needed, where results go
+   - **Ask the user** for output format (Slack message, CSV, HTML report, etc.) and notification channels before creating files. Never assume a Slack channel — always confirm.
+2. **Create the Task** — **Always use the `create_schedule` MCP tool for the initial task scaffold**; do not hand-create `schedule.yaml`, `TASK.md`, or the standard subdirs (`data/`, `reference/`, `scripts/`, `results/`) with Write/Bash. The tool generates those files/directories and stamps the active Studio profile into schedule.yaml. Extra files under `scripts/` or `reference/` may be added afterwards with Write.
+3. **Validate** — Run `schedule_validate` to check schedule.yaml
+4. **Reload** — Run `schedule_reload` to pick up new/changed tasks
+5. **Review** — Load the `schedule-review` skill and run a full review (structure + quality checks in parallel)
+6. **Fix Issues** — Address any findings from the review
+7. **Test Run** — Run `schedule_run` to execute immediately
+8. **Check Results** — Use `schedule_results` to review output.md and check for errors
+9. **Fix & Retry** — If the run failed or output is wrong, edit the files and repeat from step 4
+10. **Enable** — Only after a successful test run, use `schedule_enable` to activate the cron schedule
+
+Steps 5-8 are **mandatory** — a task is not complete until it has been reviewed and executed successfully at least once.
+
+## Task Directory Structure
+
+```text
+{task-dir}/
+├── TASK.md              # Instructions (frontmatter + markdown body)
+├── schedule.yaml        # Cron schedule, permissions, notifications
+├── scripts/             # Deterministic scripts (bash, python, etc.)
+├── reference/           # Immutable reference files (templates, specs, configs)
+├── data/                # Persistent data across runs (snapshots, state, caches)
+└── results/{run_id}/    # Auto-created per execution (pruned over time)
+    ├── metadata.json    # System-managed run metadata
+    └── output.md        # Execution summary (REQUIRED — agent writes this)
+```
+
+Use `create_schedule` to scaffold the directory — it generates schedule.yaml, TASK.md, and the four subdirs in one call and auto-registers the task. Add extra files under `scripts/` and `reference/` afterwards with Write. The system will pick up subsequent edits after `schedule_reload`.
+
+## TASK.md Anatomy
+
+YAML frontmatter with `name` and `description`, followed by markdown instructions:
+
+```markdown
+---
+name: daily-sales-report
+description: Fetch sales data, analyze trends, and post to Slack
+---
+
+## Steps
+
+1. Run `bash scripts/fetch-sales-data.sh` to download data
+2. Analyze the CSV: revenue, order count, top products
+3. Compare with previous run (check results/ for yesterday's output.md)
+4. Write results/{run_id}/output.md with findings
+5. Post summary to Slack, attach chart via slack_upload_file
+
+## Data Files
+
+- `data/previous-metrics.csv` — Yesterday's metrics for trend comparison. Update after analysis.
+
+## Notes
+
+- Revenue thresholds: flag if daily total < $10K
+- Use reference/report-template.html for formatting
+- If fetch script fails, retry once then report the error
+```
+
+Additional sections (`## Notes`, `## Constraints`, `## Data Files`, `## Output Format`, etc.) are welcome. The `run_id` is provided to the agent automatically in the prompt.
+
+**Do NOT write Slack channel names or notification targets in TASK.md.** Notification channels are configured in `schedule.yaml` (`notify.on_success` / `notify.on_failure`) and injected into the prompt automatically at execution time. Writing them in TASK.md causes conflicts when the yaml is updated.
+
+### Using data/ for Cross-Run State
+
+`data/` persists across runs (unlike `results/` which is pruned). When a task uses `data/`, **describe the files and their purpose in TASK.md** under a `## Data Files` section.
+
+## schedule.yaml Format
+
+```yaml
+name: daily-sales-report
+profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # AUTO-STAMPED by create_schedule — DO NOT hand-author. Omit to make the task visible under every Studio account (reserved for system-installed templates).
+schedule: "0 9 * * 1-5"
+enabled: false
+status: configured       # "configured" = ready to run, "template" = needs customization
+catch_up: false          # true = run missed schedule once on next Studio startup
+skills:
+  - sql-skills:trino
+permissions:
+  allow:
+    - Bash
+    - Write
+    - slack_post_message
+    - slack_upload_file
+notify:
+  on_success: slack:channel-name   # or "slack:dm" for DM
+  on_failure: slack:channel-name   # or "slack:dm" for DM
+context:
+  max_turns: 20
+  timeout: 600
+  autonomous: false      # true = Supervisor Agent auto-continues until task complete
+```
+
+Task name: lowercase, hyphens/underscores only, max 64 chars. Minimum cron interval: 5 minutes.
+
+### Workspace-Only Fields
+
+These fields are only meaningful for tasks inside a workspace `schedules/` directory:
+
+```yaml
+# Target Goal — agent scopes work to this goal's linked items
+goal: auth-redesign
+
+# Workspace skill to invoke (different from `skills` which lists capability packs/MCP tools)
+skill: weekly-review
+
+# Output configuration — create a Note from execution results
+output:
+  note: true                    # Create a Note in workspace notes/ from output.md
+  note_tags: [weekly, auto]     # Tags added to the auto-created Note
+```
+
+When `goal` is set, the agent receives the goal content and linked item statuses in its prompt. When `output.note: true` is set, a Note is automatically created in the workspace's `notes/` folder after successful execution.
+
+### Status Field
+
+- `configured` — Task is ready to run. Use this when creating a task specific to the user's environment.
+- `template` — Task is a reusable template that needs customization before enabling. Use this when the user wants to create a shareable template with placeholder values (e.g., `GITHUB_REPO`, `SLACK_CHANNEL`) that others will customize later.
+
+Tasks with `status: template` should not be enabled directly. First customize them and change `status` to `configured` before enabling.
+
+Notification targets: use `slack:channel-name` for a Slack channel, or `slack:dm` for the user's DM. **Always use `slack:dm` exactly** — not "direct message", "DM", or other variations.
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `create_schedule` | **Preferred path** to create a new task — scaffolds schedule.yaml, TASK.md, and the standard subdirs; stamps the active Studio profile automatically |
+| `schedule_list` | List all tasks with status |
+| `schedule_get` | Full task details including TASK.md and recent results |
+| `schedule_validate` | Validate schedule.yaml against schema |
+| `schedule_reload` | Reload tasks from disk (after creating/editing files) |
+| `schedule_run` | Trigger immediate execution (for testing) |
+| `schedule_results` | View past run summaries and output files (optional `limit`, default 10) |
+| `schedule_enable` / `schedule_disable` | Toggle task on/off |
+| `schedule_delete` | Remove task and all files |

--- a/treasure-work-skills/skill-creator/SKILL.md
+++ b/treasure-work-skills/skill-creator/SKILL.md
@@ -5,7 +5,7 @@ description: Use when the user asks to create, write, build, or define a new ski
 
 # Skill Creator
 
-You are an expert at writing custom skills for Treasure Studio. Skills are SKILL.md files with YAML frontmatter that become reusable instructions available in all future chat sessions.
+You are an expert at writing custom skills for Treasure Work. Skills are SKILL.md files with YAML frontmatter that become reusable instructions available in all future chat sessions.
 
 ## Workflow
 

--- a/treasure-work-skills/skill-creator/SKILL.md
+++ b/treasure-work-skills/skill-creator/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: skill-creator
+description: Use when the user asks to create, write, build, or define a new skill, or when they want to save reusable instructions for future chat sessions. Covers SKILL.md authoring, description optimization, and writing patterns.
+---
+
+# Skill Creator
+
+You are an expert at writing custom skills for Treasure Studio. Skills are SKILL.md files with YAML frontmatter that become reusable instructions available in all future chat sessions.
+
+## Workflow
+
+1. **Capture Intent** — Before writing, understand:
+   - What should the skill do?
+   - When should it trigger? (What keywords, contexts, or user requests?)
+   - What are the expected inputs and outputs?
+   - Are there edge cases or constraints?
+
+2. **Write the Skill** — Use the `write_skill` tool to create or update the skill. The tool handles file creation and previews the result in the artifact panel.
+
+3. **Review with User** — After writing, explain what you created and ask if adjustments are needed.
+
+## SKILL.md Anatomy
+
+Every skill is a single markdown file with YAML frontmatter:
+
+```markdown
+---
+name: my-skill-name
+description: When to use this skill and what it does. Be specific and "pushy" about triggers.
+---
+
+# Skill Title
+
+Instructions for Claude written in imperative form.
+
+## Steps
+1. First, do X
+2. Then, do Y
+
+## Output Format
+- Use this template: ...
+
+## Examples
+
+### Example 1: [scenario]
+**Input:** User asks "..."
+**Output:** [expected response pattern]
+```
+
+### Frontmatter Fields
+
+- **name** (required): Lowercase identifier with hyphens/underscores (e.g., `code-review`, `sql_helper`). Max 64 characters.
+- **description** (required): Controls when the skill triggers. This is the most important field.
+
+### Writing an Effective Description
+
+The description determines whether Claude activates the skill. Write it to be **specific and assertive**:
+
+**Bad:** `Helps with code review`
+**Good:** `Use when the user asks to review code, check for bugs, audit code quality, or requests a PR review. Covers best practices, security issues, performance, and readability.`
+
+Tips:
+- Start with "Use when..." to clearly define trigger contexts
+- List specific keywords and phrases that should activate the skill
+- Mention what the skill covers (scope)
+- Be "pushy" — undertriggering is more common than overtriggering
+
+## Writing Effective Instructions
+
+### Use Imperative Form
+Write instructions as direct commands, not descriptions.
+
+**Bad:** `This skill helps users write SQL queries`
+**Good:** `Write optimized SQL queries for Treasure Data's Trino engine.`
+
+### Progressive Disclosure
+Structure content from most-used to least-used:
+1. **Overview** — What the skill does (2-3 sentences)
+2. **Core Instructions** — The main workflow (steps)
+3. **Output Format** — Templates for consistent output
+4. **Examples** — Concrete input/output pairs
+5. **Edge Cases** — Special situations (at the end)
+
+### Include Examples with Input/Output
+Examples are the most effective way to guide behavior:
+
+```markdown
+## Examples
+
+### Example: Summarize a table
+**Input:** "Describe the users table"
+**Output:**
+The `users` table contains 3 columns:
+- `id` (bigint) — Primary key
+- `name` (varchar) — User display name
+- `created_at` (timestamp) — Account creation time
+```
+
+### Define Output Formats
+When the skill produces structured output, provide templates:
+
+```markdown
+## Output Format
+Always respond with:
+1. A one-line summary
+2. A bullet list of findings
+3. A code block with the fix (if applicable)
+```
+
+### Keep It Focused
+- One skill = one capability
+- Under 200 lines is ideal; under 500 lines maximum
+- Remove fluff — every line should influence Claude's behavior
+- Explain *why* when rules aren't obvious (models follow reasoning better than arbitrary rules)
+
+### Writing Style
+- Use markdown headers to organize sections
+- Use code blocks for templates and examples
+- Use bullet lists for rules and constraints
+- Bold key terms on first use
+- Don't over-qualify with "MUST", "ALWAYS", "NEVER" — use them sparingly for truly critical rules

--- a/treasure-work-skills/web-search/SKILL.md
+++ b/treasure-work-skills/web-search/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: web-search
+description: Use when performing web searches, extracting content from URLs, or researching topics requiring up-to-date information. Triggers on: "search", "look up", "find out", "what's the latest", "extract from URL", "fetch this page", "research", "check online".
+---
+
+# Web Search
+
+Use `web_search` for research and page extraction. Powered by OpenAI web search (Bing-backed): **search + extraction + summarization** in one call.
+
+## Key Insight
+
+The `query` is a **prompt to an LLM with web access**. Write instructions, not bare keywords.
+
+```
+✗ "Snowflake pricing"
+✓ "List all pricing tiers from https://snowflake.com/pricing in a table with features"
+```
+
+## Parameters
+
+- `search_context_size: low` — quick facts
+- `search_context_size: medium` — general research (default)
+- `search_context_size: high` — URL extraction, deep analysis
+
+Use `high` whenever a specific URL is in the query.
+
+## Query Patterns
+
+**URL extraction** — read a specific page and structure the output:
+```
+"Extract all items from https://example.com/page and list each with details in a table"
+```
+
+**Structured research** — request comparison tables, bullet summaries:
+```
+"Compare {A} vs {B} vs {C} covering pricing, features, and target audience"
+```
+
+**Search operators** — `"exact phrase"`, `site:domain.com`, `AND`/`OR`, `-exclude`:
+```
+site:reddit.com "nextjs" vs "remix" experience
+"{company}" AND ("funding" OR "revenue") 2025 2026
+```
+
+**Translation** — read non-English pages:
+```
+"Translate and summarize: https://example.co.jp/news/"
+```
+
+**API endpoints** — read JSON responses:
+```
+"Describe the JSON structure of https://api.github.com/repos/{owner}/{repo}"
+```
+
+## Strengths
+
+- Bypasses bot protection (Reddit, G2, Gartner) via Bing's index
+- Extracts structured data (pricing, jobs, reviews, changelogs)
+- Reads and translates any language
+- Supports search operators (`site:`, `AND`/`OR`, `"quoted"`)
+
+## Limitations
+
+- **No verbatim full-text** — summarizes copyrighted content instead of reproducing it
+- **24-48h recency lag** — not suitable for real-time monitoring
+- **No PDF internals** — `filetype:pdf` is unreliable
+- **No auth pages** — cannot access login-required content
+- **Paywalls** — reads public portions only
+
+## Workarounds for Limitations
+
+When `web_search` falls short, suggest these alternatives to the user:
+
+- **Real-time monitoring** → RSS feeds (many sites expose `/feed` or `/rss`)
+- **Raw HTML / interactive pages** → Playwright (headless browser; click, scroll, screenshot)
+- **Full-text extraction** → Playwright to fetch raw HTML, then parse locally
+
+## Examples
+
+### Example: Extract page content
+**Input:** "What jobs are open at Company X?"
+**Action:** `"List all job openings from https://company-x.com/careers/ with title and location"` (high)
+
+### Example: Research with multiple angles
+**Input:** "Research Company X's market position"
+**Action:** Run in parallel:
+1. `"Company X market position analyst reports 2026"` (medium)
+2. `"Extract key metrics from https://company-x.com/about"` (high)
+3. `site:reddit.com "Company X" opinions experience` (medium)
+
+### Example: Translate foreign page
+**Input:** "What does this Japanese press release say?"
+**Action:** `"Translate to English and summarize: https://example.co.jp/press/"` (high)

--- a/treasure-work-skills/work/SKILL.md
+++ b/treasure-work-skills/work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work
-description: Use when the user asks to create, update, list, or manage work items, goals, notes, guides, or references in a Treasure Studio workspace. Triggers on "create a task", "add a work item", "move to done", "show my tasks", "goal progress", "create a note", "what's next", or any workspace document management. Also use when operating on files in goals/, items/, guides/, notes/, or references/ folders.
+description: Use when the user asks to create, update, list, or manage work items, goals, notes, guides, or references in a Treasure Work workspace. Triggers on "create a task", "add a work item", "move to done", "show my tasks", "goal progress", "create a note", "what's next", or any workspace document management. Also use when operating on files in goals/, items/, guides/, notes/, or references/ folders.
 ---
 
 # Work Basic

--- a/treasure-work-skills/work/SKILL.md
+++ b/treasure-work-skills/work/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: work
+description: Use when the user asks to create, update, list, or manage work items, goals, notes, guides, or references in a Treasure Studio workspace. Triggers on "create a task", "add a work item", "move to done", "show my tasks", "goal progress", "create a note", "what's next", or any workspace document management. Also use when operating on files in goals/, items/, guides/, notes/, or references/ folders.
+---
+
+# Work Basic
+
+Manage workspace documents (items, goals, notes, guides, references) using file operations. All state lives in markdown files with YAML frontmatter.
+
+## Workspace Location
+
+Workspaces are stored under `~/tdx/work/`:
+- **Local workspaces:** `~/tdx/work/local/{name}/` (default workspace: `~/tdx/work/local/default/`)
+- **GitHub workspaces:** `~/tdx/work/github/{owner}/{repo}/`
+
+Each workspace root contains a `tdx.json` config file. The current working directory is typically set to the active workspace.
+
+## Folder Structure
+
+| Folder | Kind | Filename Pattern |
+|--------|------|------------------|
+| `goals/` | goal | `{slug}.md` (no date prefix) |
+| `items/` | item | `YYYY-MM-DD-{slug}.md` |
+| `schedules/` | schedule | `{task-name}/` (subdirectory with TASK.md + schedule.yaml) |
+| `guides/` | guide | `YYYY-MM-DD-{slug}.md` |
+| `notes/` | note | `YYYY-MM-DD-{slug}.md` |
+| `notes/weekly/` | weekly note | `YYYY-WNN.md` |
+| `references/` | reference | `YYYY-MM-DD-{slug}.md` |
+
+## Frontmatter
+
+Every document has YAML frontmatter:
+
+```yaml
+---
+title: My Work Item
+status: todo              # items/goals: backlog|todo|planning|design_review|in_progress|review|done|void
+                          # guides: proposed|accepted|deprecated|superseded
+tags: [feature, auth]
+priority: medium          # critical|high|medium|low (items/goals only)
+assignee: Name            # items/goals only
+due: 2026-04-01           # items/goals only
+github: owner/repo#123    # link to GitHub issue or PR (items/goals only)
+jira: atlassian-org/PROJ-456   # link to Jira ticket (items/goals only)
+created: 2026-03-23
+updated: 2026-03-23
+---
+```
+
+**Guides** also support `description:` — a one-line summary shown in the guide index and injected into agent context for accepted guides.
+
+Notes and references only need `title`, `tags`, `created`. References add `source: URL`.
+
+## Slug Rules
+
+Slugify the title: lowercase, replace non-alphanumeric with hyphens, trim edges, max 60 chars.
+- "Fix Login Bug" → `fix-login-bug`
+- "2026-03-23-fix-login-bug.md" for items, "fix-login-bug.md" for goals
+
+## Core Operations
+
+### Create a Document
+
+1. Slugify the title
+2. Write to the correct folder with proper filename pattern
+3. Include frontmatter with `title`, `created` (today), `status` (default: `todo` for items, `proposed` for guides)
+
+**Item example:**
+```markdown
+---
+title: Fix Login Bug
+status: todo
+tags: [bug, auth]
+priority: high
+created: 2026-03-23
+---
+
+Login fails when password contains special characters.
+```
+→ Write to `items/2026-03-23-fix-login-bug.md`
+
+**Goal example:**
+```markdown
+---
+title: Auth Redesign
+status: todo
+tags: [q2, security]
+created: 2026-03-23
+---
+
+Redesign the authentication system.
+
+## Linked Items
+- [[fix-login-bug|Fix Login Bug]]
+```
+→ Write to `goals/auth-redesign.md`
+
+### Link Items to Goals
+
+Use wiki-links for bidirectional linking:
+1. In the goal body, add `- [[item-slug|Display Title]]`
+2. In the item body, add `Part of [[goal-slug]].`
+
+Wiki-link format: `[[slug]]` or `[[slug|Display Text]]`
+
+### Move Status
+
+Read the file, update the `status` field in frontmatter, set `updated` to today.
+
+### List Documents
+
+Use Glob to find files, Read to inspect frontmatter:
+- All items: `Glob("items/*.md")`
+- All goals: `Glob("goals/*.md")`
+- By status: Grep for `status: in_progress` in the target folder
+
+### Search Knowledge
+
+Use Grep to search across notes, guides, and references:
+- By content: `Grep(pattern, path: "notes/")` or across all knowledge folders
+- By tag: `Grep("tags:.*keyword", glob: "{notes,guides,references}/**/*.md")`
+
+### Goal Progress
+
+1. Read the goal file
+2. Parse wiki-links from the body: `[[slug]]` or `[[slug|Display Text]]`
+3. For each linked slug, find the matching item file (Glob for `items/*{slug}.md`)
+4. Read each item's `status` field
+5. Calculate: done count / total, percentage, list in-progress items
+
+### What's Next
+
+Find the first linked item in a goal that isn't `done` or `void`.
+
+## Wiki-Link Resolution
+
+When resolving `[[slug]]`:
+1. Try exact filename match: `Glob("{goals,items,guides,notes,references}/{slug}.md")` or `Glob("{goals,items,guides,notes,references}/*-{slug}.md")`
+2. Priority: goals > items > guides > notes > references
+
+For backlinks (who links to this document): `Grep("\\[\\[{slug}", glob: "**/*.md")`
+
+## Git Conventions
+
+When committing workspace changes, use this message format:
+- Status changes: `work: move "Title" old_status → new_status`
+- New documents: `work: create "Title"`
+- Updates: `work: update "Title"`
+
+## Sub-item Wiki-links
+
+When an item has sub-tasks, use `[[wiki-link]]` in checklists — even if the target page doesn't exist yet:
+
+```markdown
+- [ ] [[2026-03-26-add-auth-refresh]] — Token refresh logic
+- [ ] [[2026-03-26-update-api-docs]] — Update REST docs
+- [x] [[2026-03-26-fix-session-expiry]] — Session timeout fix
+```
+
+When starting work on a sub-task, create the actual `.md` file in `items/` so it becomes a trackable item with its own status and links.
+
+## External Tracker Links
+
+**Frontmatter fields** (field name provides the type):
+
+```yaml
+jira: <atlassian-org>/<TICKET-ID>    # e.g., acme-corp/PROJ-1234
+github: <owner>/<repo>#<number>       # e.g., acme-corp/my-app#456
+```
+
+**Inline references** in markdown body (prefix with `jira:` or `github:`):
+
+```markdown
+- [x] Auth token refresh — jira:acme-corp/PROJ-1234
+- [ ] Update API docs — github:acme-corp/my-app#789
+```
+
+## Knowledge Loop
+
+1. **Before work** — search guides for relevant conventions: `Grep(pattern, path: "guides/")`
+2. **During work** — capture learnings as notes
+3. **After work** — check if insights should become guides (proposed → accepted)
+4. **Accepted guides** are auto-injected into future sessions — promote guides when patterns are validated
+5. **Before creating** — search existing docs to avoid duplicates
+
+## Schedule Tasks
+
+Workspace schedules live in `schedules/{task-name}/` with TASK.md + schedule.yaml.
+Built-in schedules (weekly-review, synthesize-knowledge, stale-item-cleanup) are auto-created.
+
+To create a new workspace schedule:
+1. Write `schedules/{task-name}/TASK.md` and `schedules/{task-name}/schedule.yaml`
+2. Run `schedule_reload` to register the task
+3. Use `schedule_run` to test, then `schedule_enable` to activate
+
+Workspace-only schedule.yaml fields:
+- `goal: {slug}` — scope to a goal's linked items
+- `skill: {name}` — invoke a workspace skill (different from `skills` which lists capability packs)
+- `output.note: true` — auto-create a Note from results
+- `output.note_tags: [tag1, tag2]` — tags added to the auto-created Note


### PR DESCRIPTION
## Summary

- Adds a new `treasure-work-skills` plugin that mirrors `studio-skills`, with `mcp__tdx-studio__*` references rewritten to `mcp__work__*` to match the MCP server rename in [treasure-data/treasure-work#140](https://github.com/treasure-data/treasure-work/pull/140).
- `studio-skills` stays in place — both plugins coexist until the `BUILTIN_PLUGINS` wiring on the treasure-work side lands.
- The `@tdx-studio:` profile prefix is intentionally **not** changed; PR #140 explicitly lists that rename as a separate follow-up.

## What changed

- `treasure-work-skills/` — new directory, copy of `studio-skills/` (9 skills + graflow references/templates).
- `mcp__tdx-studio__*` → `mcp__work__*` in:
  - `treasure-work-skills/react-dashboard/SKILL.md`
  - `treasure-work-skills/graflow/SKILL.md`
  - `treasure-work-skills/graflow/references/manifest-yml.md`
- `.claude-plugin/marketplace.json` — new `treasure-work-skills` plugin entry.
- `README.md` — new "Treasure Work Skills" section + install instructions.

Skill `name`s in YAML frontmatter are unchanged from `studio-skills` (e.g. `name: graflow` exists in both), so existing trigger tests cover both plugins; no test duplication needed.

## Test plan

- [ ] `./tests/run-tests.sh` — confirm trigger tests still pass with the duplicated skill names.
- [ ] Install the plugin locally (`/plugin install treasure-work-skills@td-skills`) and verify the skills load.
- [ ] Verify `mcp__work__render_react` / `mcp__work__slack_post_message` references resolve once the treasure-work side ships PR #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)