### PR TITLE
Rewrite schedule-task + schedule-review for the simplified Treasure Work schedules

### DIFF
--- a/treasure-work-skills/schedule-review/SKILL.md
+++ b/treasure-work-skills/schedule-review/SKILL.md
@@ -1,121 +1,53 @@
 ---
 name: schedule-review
-description: Use when the user wants to review, validate, or check a scheduled task before enabling it. Runs two parallel sub-agent checks — structural validation and quality assessment. Triggers on "review this task", "check my scheduled task", "validate task", "is this task ready", etc.
+description: Use when the user wants to review, validate, or check a scheduled task before enabling it. Reviews the prompt body for clarity, error handling, and fitness for purpose. Triggers on "review this task", "check my scheduled task", "validate task", "is this task ready", etc.
 ---
 
 # Schedule Task Review
 
-Review a scheduled task by running two parallel sub-agent checks using TaskCreate:
-
-1. **Structure check** — Validates directory layout, file formats, and schema
-2. **Quality check** — Assesses whether the task meets the user's intent
+Most structural validation (cron syntax, field shape, name constraints) is handled by the `schedule_*` MCP tools at create / update time. This skill focuses on the part the tools can't check: **does the prompt body actually accomplish the user's intent?**
 
 ## Workflow
 
-1. Ask the user which task to review (or infer from context)
-2. Locate the task directory:
-   - If inside a workspace: check `{workspace}/schedules/{task-name}/`
-   - Otherwise: check `~/.tdx/schedule-tasks/{task-name}/`
-   - Use `schedule_get` to find the task if the path is unclear
-3. Read the task's TASK.md and schedule.yaml
-4. Launch both checks in parallel using TaskCreate
-5. Wait for results using TaskGet
-6. Present a unified report with pass/fail and actionable suggestions
+1. Ask the user which schedule to review (or infer from context — e.g., the last one they created).
+2. Fetch its current state: `schedule_get` with the schedule's name.
+3. Read the prompt body in the returned record (the agent's instructions when the schedule fires).
+4. Review against the checklist below.
+5. Present a brief report with concrete change suggestions; if the user agrees, apply them via `schedule_update`.
 
-## Step 1: Read Task Files
+## Quality checklist
 
-```
-Read {task-dir}/TASK.md
-Read {task-dir}/schedule.yaml
-List files in scripts/, reference/, data/
-```
+For each item below, rate **GOOD / NEEDS IMPROVEMENT / MISSING** and give a one-line fix when not GOOD.
 
-## Step 2: Launch Parallel Checks
+1. **Concrete, numbered steps.** Could a fresh agent execute them without guessing? "Look at the data" is bad; "run `gh pr list --json …` and filter where `reviewDecision != APPROVED`" is good.
+2. **Logical order** — typically fetch → process → analyze → output → notify. Out-of-order steps are a smell.
+3. **Specific tool / command names** where the choice matters (`gh pr list`, `slack_post_message`, `Read`, etc.) so the agent doesn't reach for a different tool.
+4. **Failure handling** — what happens if a script errors, an API is down, the input is empty? At minimum: "If X fails, post a brief error to the same channel and stop."
+5. **Output format** is explicit — markdown summary? CSV? Slack message with what shape? "Send a report" is missing; "post a markdown summary with one bullet per PR (title + URL)" is good.
+6. **No hidden state** — the prompt should be self-contained. The agent doesn't remember anything between runs.
+7. **Cron matches purpose** — `*/5 * * * *` for a daily report is wrong; `0 9 * * *` is right.
+8. **Notification target named** if the task notifies. Slack channel name should be in the prompt, not assumed.
 
-Use `TaskCreate` to spawn two sub-agents simultaneously.
+## Reporting
 
-### Sub-agent 1: Structure Check
-
-```
-TaskCreate with prompt:
-"Review this scheduled task for structural correctness.
-
-TASK.md content:
-{paste TASK.md content}
-
-schedule.yaml content:
-{paste schedule.yaml content}
-
-Files in task directory:
-{list of files}
-
-Check the following:
-1. TASK.md has valid YAML frontmatter with `name` and `description`
-2. schedule.yaml has required fields (name, schedule, enabled) and only valid optional fields (status, catch_up, skills, permissions, notify, context, goal, skill, output). Note: `skills` (list of capability packs/MCP tools) and `skill` (workspace skill to invoke) serve different purposes and can coexist.
-2a. If status field is present, it must be either 'configured' or 'template'. Warn if missing (defaults to 'configured').
-3. Task name in TASK.md matches schedule.yaml name
-4. Cron expression is valid and not too frequent (minimum 5 minutes)
-5. permissions.allow lists all tools referenced in TASK.md steps (Bash for scripts, Write for output, slack_* for notifications)
-6. Scripts referenced in TASK.md steps exist in scripts/
-7. Reference files mentioned in TASK.md exist in reference/
-8. data/ files described in TASK.md exist if the task expects prior state
-9. No Slack channels or notification targets hardcoded in TASK.md (should be in schedule.yaml notify section only)
-10. output.md is mentioned as a required output in Steps
-11. If `goal` is set, verify the goal file exists in the workspace (workspace tasks only)
-12. If `output.note: true` is set, verify this is a workspace task (inside schedules/ directory)
-
-Report: PASS/FAIL for each item, with specific fix instructions for failures."
-```
-
-### Sub-agent 2: Quality Check
-
-```
-TaskCreate with prompt:
-"Review this scheduled task for quality and fitness for purpose.
-
-TASK.md content:
-{paste TASK.md content}
-
-schedule.yaml content:
-{paste schedule.yaml content}
-
-The user's original request was: {describe what the user asked for}
-
-Check the following:
-1. Steps are clear and unambiguous — could another agent execute them without guessing?
-2. Steps are in a logical order (fetch → process → analyze → output → notify)
-3. Error handling is addressed (what to do if a script fails, API is down, etc.)
-4. output.md requirements are clear (what should be in the summary?)
-5. The schedule frequency matches the task's purpose (e.g., not checking hourly for a daily report)
-6. Skills listed are appropriate for the task
-7. If data/ is used, the update cycle is clear (when to save, when to compare)
-8. The task is self-contained — no implicit dependencies on external state
-9. For workspace tasks: does the goal/skill configuration make sense for the intended purpose?
-
-Report: Rate each item as GOOD/NEEDS IMPROVEMENT/MISSING, with specific suggestions."
-```
-
-## Step 3: Collect and Report
-
-Wait for both tasks to complete using `TaskGet`, then present a unified report:
+Keep it short. Example:
 
 ```markdown
-## Task Review: {task-name}
+## Review: pr-triage
 
-### Structure: {PASS/FAIL}
-- [x] Valid TASK.md frontmatter
-- [x] Valid schedule.yaml schema
-- [ ] Missing permission: Bash (needed for scripts/fetch.sh)
-...
+- **Concrete steps**: GOOD
+- **Logical order**: GOOD
+- **Specific tools**: GOOD (names `gh`, `slack_post_message`)
+- **Failure handling**: NEEDS IMPROVEMENT — no fallback if `gh` errors
+- **Output format**: GOOD (markdown summary spec'd)
+- **No hidden state**: GOOD
+- **Cron matches purpose**: GOOD (`0 9 * * 1-5` for a daily weekday summary)
+- **Notification target**: GOOD (`#engineering-prs`)
 
-### Quality: {GOOD/NEEDS IMPROVEMENT/MISSING}
-- [x] Steps are clear
-- [ ] No error handling for script failure
-- [ ] output.md format not specified
-...
+### Suggested fixes
+1. Add an explicit failure step at the end: "If any step above errors, post `'PR triage failed: {error}'` to the same channel and stop."
 
-### Recommended Fixes
-1. Add `Bash` to permissions.allow
-2. Add error handling step: "If fetch script fails, retry once..."
-3. Specify output.md format in a `## Output Format` section
+Apply with `schedule_update`?
 ```
+
+If the user agrees, call `schedule_update` with the new `prompt` body.

--- a/treasure-work-skills/schedule-task/SKILL.md
+++ b/treasure-work-skills/schedule-task/SKILL.md
@@ -1,161 +1,111 @@
 ---
 name: schedule-task
-description: Use when the user wants to create, set up, or configure a scheduled task in Treasure Work. Covers TASK.md authoring, schedule.yaml configuration, script creation, and direct file-based task setup. Triggers on "create a scheduled task", "set up a recurring job", "automate daily report", "schedule a task", "cron job", etc.
+description: Use when the user wants to create, set up, or configure a scheduled task in Treasure Work. Covers schedule creation, cron config, prompt authoring, and management via the schedule_* MCP tools. Triggers on "create a scheduled task", "set up a recurring job", "automate daily report", "schedule a task", "cron job", etc.
 ---
 
 # Schedule Task Creator
 
-Create scheduled tasks in Treasure Work that mix deterministic script execution with agent-driven analysis and delivery.
+Create scheduled tasks in Treasure Work — markdown files at `~/.treasure-work/schedules/{name}.md` (YAML frontmatter + prompt body) that run on a cron and execute their prompt as agent instructions when they fire.
 
-## Task Directory Placement
+## Storage layout
 
-Determine where to create the task based on your current working directory:
-
-1. **If inside a workspace**: find the nearest ancestor directory (including the current one) that contains a `tdx.json` file **and** at least one of `goals/` or `items/` folders. That directory is `{workspace}`.
-   - Create under `{workspace}/schedules/{task-name}/`
-   - Workspace context (accepted guides, goals) is automatically available at execution time
-   - `{workspace}` becomes the working directory during execution
-
-2. **Otherwise** (standalone):
-   - Create under `~/.tdx/schedule-tasks/{task-name}/`
-
-## Workflow
-
-**CRITICAL: Never just create files and stop. Always run the task and iterate until it works.**
-
-1. **Capture Intent** — What to automate, how often, what tools/data needed, where results go
-   - **Ask the user** for output format (Slack message, CSV, HTML report, etc.) and notification channels before creating files. Never assume a Slack channel — always confirm.
-2. **Create the Task** — **Always use the `create_schedule` MCP tool for the initial task scaffold**; do not hand-create `schedule.yaml`, `TASK.md`, or the standard subdirs (`data/`, `reference/`, `scripts/`, `results/`) with Write/Bash. The tool generates those files/directories and stamps the active Studio profile into schedule.yaml. Extra files under `scripts/` or `reference/` may be added afterwards with Write.
-3. **Validate** — Run `schedule_validate` to check schedule.yaml
-4. **Reload** — Run `schedule_reload` to pick up new/changed tasks
-5. **Review** — Load the `schedule-review` skill and run a full review (structure + quality checks in parallel)
-6. **Fix Issues** — Address any findings from the review
-7. **Test Run** — Run `schedule_run` to execute immediately
-8. **Check Results** — Use `schedule_results` to review output.md and check for errors
-9. **Fix & Retry** — If the run failed or output is wrong, edit the files and repeat from step 4
-10. **Enable** — Only after a successful test run, use `schedule_enable` to activate the cron schedule
-
-Steps 5-8 are **mandatory** — a task is not complete until it has been reviewed and executed successfully at least once.
-
-## Task Directory Structure
+Schedules live as one markdown file per schedule:
 
 ```text
-{task-dir}/
-├── TASK.md              # Instructions (frontmatter + markdown body)
-├── schedule.yaml        # Cron schedule, permissions, notifications
-├── scripts/             # Deterministic scripts (bash, python, etc.)
-├── reference/           # Immutable reference files (templates, specs, configs)
-├── data/                # Persistent data across runs (snapshots, state, caches)
-└── results/{run_id}/    # Auto-created per execution (pruned over time)
-    ├── metadata.json    # System-managed run metadata
-    └── output.md        # Execution summary (REQUIRED — agent writes this)
+~/.treasure-work/schedules/
+  {name}.md          # YAML frontmatter + markdown body (the prompt)
+
+~/.treasure-work/logs/
+  schedule-events.jsonl   # append-only run lifecycle journal (read-only for the agent)
 ```
 
-Use `create_schedule` to scaffold the directory — it generates schedule.yaml, TASK.md, and the four subdirs in one call and auto-registers the task. Add extra files under `scripts/` and `reference/` afterwards with Write. The system will pick up subsequent edits after `schedule_reload`.
-
-## TASK.md Anatomy
-
-YAML frontmatter with `name` and `description`, followed by markdown instructions:
+**File format** — frontmatter holds config; the body IS the agent's instructions when the schedule fires:
 
 ```markdown
 ---
-name: daily-sales-report
-description: Fetch sales data, analyze trends, and post to Slack
+cron: "0 9 * * 1-5"
+enabled: true
+description: Triage open PRs and post a summary to Slack
 ---
 
 ## Steps
 
-1. Run `bash scripts/fetch-sales-data.sh` to download data
-2. Analyze the CSV: revenue, order count, top products
-3. Compare with previous run (check results/ for yesterday's output.md)
-4. Write results/{run_id}/output.md with findings
-5. Post summary to Slack, attach chart via slack_upload_file
-
-## Data Files
-
-- `data/previous-metrics.csv` — Yesterday's metrics for trend comparison. Update after analysis.
-
-## Notes
-
-- Revenue thresholds: flag if daily total < $10K
-- Use reference/report-template.html for formatting
-- If fetch script fails, retry once then report the error
+1. Run `gh pr list --json title,author,reviewDecision,url` and parse the JSON.
+2. Filter to PRs where `reviewDecision != APPROVED` and the author is not a bot.
+3. Build a markdown summary grouped by repository.
+4. Post the summary to `#engineering-prs` via `slack_post_message`.
+5. If `gh` returns an error, post a brief failure message to the same channel and stop.
 ```
 
-Additional sections (`## Notes`, `## Constraints`, `## Data Files`, `## Output Format`, etc.) are welcome. The `run_id` is provided to the agent automatically in the prompt.
+The filename without `.md` is the schedule's identifier (`github-pr-triage.md` → name `github-pr-triage`). Names should be short, lowercase, and hyphen-separated (max 64 chars).
 
-**Do NOT write Slack channel names or notification targets in TASK.md.** Notification channels are configured in `schedule.yaml` (`notify.on_success` / `notify.on_failure`) and injected into the prompt automatically at execution time. Writing them in TASK.md causes conflicts when the yaml is updated.
+### Frontmatter fields
 
-### Using data/ for Cross-Run State
+| Field | Required | Notes |
+|-------|----------|-------|
+| `cron` | yes | 5-field vixie cron (`min hour dom month dow`); minimum 5-minute interval |
+| `enabled` | yes | `true` to run on the cron; `false` to keep the file but pause |
+| `description` | no | One-line summary shown in the UI list |
+| `workspace` | no | Origin tag (e.g. `default`) — set by migration; not required for new schedules |
 
-`data/` persists across runs (unlike `results/` which is pruned). When a task uses `data/`, **describe the files and their purpose in TASK.md** under a `## Data Files` section.
+**No** `permissions.allow`, `notify.on_*`, `goal`, `output.note`, `catch_up`, `autonomous`, `status`, or `profile` — those are gone in the new design. Auth and notification targets go in the prompt body itself; the agent decides which tools to call based on its instructions.
 
-## schedule.yaml Format
+## Workflow
 
-```yaml
-name: daily-sales-report
-profile: "@tdx-studio:<site>:<account-id>:<user-id>"  # AUTO-STAMPED by create_schedule — DO NOT hand-author. Omit to make the task visible under every Studio account (reserved for system-installed templates).
-schedule: "0 9 * * 1-5"
-enabled: false
-status: configured       # "configured" = ready to run, "template" = needs customization
-catch_up: false          # true = run missed schedule once on next Studio startup
-skills:
-  - sql-skills:trino
-permissions:
-  allow:
-    - Bash
-    - Write
-    - slack_post_message
-    - slack_upload_file
-notify:
-  on_success: slack:channel-name   # or "slack:dm" for DM
-  on_failure: slack:channel-name   # or "slack:dm" for DM
-context:
-  max_turns: 20
-  timeout: 600
-  autonomous: false      # true = Supervisor Agent auto-continues until task complete
-```
+**CRITICAL: Don't just create the schedule and stop. Always test-run it and iterate until the agent's behaviour matches the user's intent.**
 
-Task name: lowercase, hyphens/underscores only, max 64 chars. Minimum cron interval: 5 minutes.
+1. **Capture intent** — what to automate, how often, what tools/data needed, where results go.
+   - **Ask the user** for output channel (Slack channel, written note, etc.) before creating the schedule. Never assume a Slack channel — always confirm.
+2. **Create** — call `schedule_create` with `name`, `prompt` (the markdown body), `cron`, optional `description`. Returns the new file path.
+3. **Test run** — call `schedule_run_now` to fire one immediately. Returns a `chatId`.
+4. **Inspect** — open the run's chat (the user can navigate to it via the chatId, or you can summarize what happened). Did the agent do what was intended?
+5. **Iterate** — if the run failed or the output is wrong, call `schedule_update` to revise the prompt / cron, then go back to step 3.
+6. **Enable** — once a test run succeeds, ensure `enabled: true` (it defaults to true on create, but if you set it false during iteration, flip it back with `schedule_set_enabled`).
 
-### Workspace-Only Fields
+Steps 3–5 are mandatory. A schedule isn't done until it has been test-run successfully at least once.
 
-These fields are only meaningful for tasks inside a workspace `schedules/` directory:
-
-```yaml
-# Target Goal — agent scopes work to this goal's linked items
-goal: auth-redesign
-
-# Workspace skill to invoke (different from `skills` which lists capability packs/MCP tools)
-skill: weekly-review
-
-# Output configuration — create a Note from execution results
-output:
-  note: true                    # Create a Note in workspace notes/ from output.md
-  note_tags: [weekly, auto]     # Tags added to the auto-created Note
-```
-
-When `goal` is set, the agent receives the goal content and linked item statuses in its prompt. When `output.note: true` is set, a Note is automatically created in the workspace's `notes/` folder after successful execution.
-
-### Status Field
-
-- `configured` — Task is ready to run. Use this when creating a task specific to the user's environment.
-- `template` — Task is a reusable template that needs customization before enabling. Use this when the user wants to create a shareable template with placeholder values (e.g., `GITHUB_REPO`, `SLACK_CHANNEL`) that others will customize later.
-
-Tasks with `status: template` should not be enabled directly. First customize them and change `status` to `configured` before enabling.
-
-Notification targets: use `slack:channel-name` for a Slack channel, or `slack:dm` for the user's DM. **Always use `slack:dm` exactly** — not "direct message", "DM", or other variations.
-
-## MCP Tools
+## MCP tools (`schedules` server)
 
 | Tool | Purpose |
 |------|---------|
-| `create_schedule` | **Preferred path** to create a new task — scaffolds schedule.yaml, TASK.md, and the standard subdirs; stamps the active Studio profile automatically |
-| `schedule_list` | List all tasks with status |
-| `schedule_get` | Full task details including TASK.md and recent results |
-| `schedule_validate` | Validate schedule.yaml against schema |
-| `schedule_reload` | Reload tasks from disk (after creating/editing files) |
-| `schedule_run` | Trigger immediate execution (for testing) |
-| `schedule_results` | View past run summaries and output files (optional `limit`, default 10) |
-| `schedule_enable` / `schedule_disable` | Toggle task on/off |
-| `schedule_delete` | Remove task and all files |
+| `schedule_create` | Create a new schedule. Args: `name`, `prompt`, `cron`, optional `description`, optional `enabled` (default `true`). Validates cron + writes `{name}.md`. |
+| `schedule_list` | List all schedules with cron, status, last run, next run. Use this first when looking for an existing schedule. |
+| `schedule_get` | Full record for one schedule, including the prompt body. |
+| `schedule_update` | Patch description / prompt / cron / enabled. Names are stable; to rename, use `schedule_delete` + `schedule_create`. |
+| `schedule_set_enabled` | Toggle on/off (convenience over `schedule_update`). |
+| `schedule_delete` | Remove the schedule (deletes the `.md` file; preserves the events log). Confirm with the user before deleting frequently-running schedules. |
+| `schedule_run_now` | Trigger a one-off run. Does NOT advance the cron. Returns the run's `chatId`. |
+
+The MCP tools are the recommended path because they validate cron, normalize fields, and emit lifecycle events that the runner uses for status display. Direct `Read` / `Edit` of `{name}.md` is also supported for ad-hoc edits the tools don't cover (e.g., bulk renames in an editor).
+
+## Writing a good prompt body
+
+The body of `{name}.md` is what the agent will see as its `### Agent Instructions` when the schedule fires. Treat it like a self-contained task prompt:
+
+- **Concrete steps**, numbered, in execution order. Don't say "look at the data" — say "run X, parse Y, write Z."
+- **Specific tool names** when the choice matters (`gh pr list`, `slack_post_message`, etc.). The agent has access to whatever MCP tools are registered; naming them in the prompt makes the choice explicit.
+- **Failure mode** — what should happen if a script errors, an API is down, output is empty? At minimum: "If X fails, post a brief error to the same channel and stop."
+- **Output format** — markdown summary? CSV? Slack message? Be explicit.
+- **No hidden state** — the prompt should be self-contained. The agent doesn't remember anything between runs unless the prompt tells it to read from somewhere persistent.
+
+## Working directory at run time
+
+When a schedule fires, the agent's working directory is the user's home directory (`$HOME`). If the prompt references files, use absolute paths or have the agent `cd` first. There is no per-task `scripts/` / `reference/` / `data/` directory anymore — inline scripts in the prompt body via heredocs (`bash <<'EOF' … EOF`), or have the agent `Write` files where the user wants them.
+
+## Example: bare-minimum schedule
+
+```text
+schedule_create with:
+  name: pr-triage
+  cron: "0 9 * * 1-5"
+  description: Triage open PRs and post a summary to Slack
+  prompt: |
+    ## Steps
+    1. Run `gh pr list --json title,author,reviewDecision,url --search "is:open"` and parse the JSON.
+    2. Filter to PRs where `reviewDecision != APPROVED` and `author.login` is not a bot.
+    3. Group by repository, build a one-line bullet per PR (title + URL).
+    4. Post the summary to `#engineering-prs` via `slack_post_message`. Title: "Open PRs · `2026-05-07`".
+    5. If `gh` errors out, post "PR triage failed: {error}" to the same channel and stop.
+```
+
+After creating, run `schedule_run_now` and watch the resulting chat to confirm the agent behaves correctly before leaving it on the cron.

--- a/treasure-work-skills/schedule-task/SKILL.md
+++ b/treasure-work-skills/schedule-task/SKILL.md
@@ -5,21 +5,26 @@ description: Use when the user wants to create, set up, or configure a scheduled
 
 # Schedule Task Creator
 
-Create scheduled tasks in Treasure Work — markdown files at `~/.treasure-work/schedules/{name}.md` (YAML frontmatter + prompt body) that run on a cron and execute their prompt as agent instructions when they fire.
+Create scheduled tasks in Treasure Work — directories at `~/.treasure-work/schedules/{name}/` that hold an `AGENTS.md` (same format as a workspace agent) plus any supporting files. The schedule fires on a cron and runs `AGENTS.md`'s body as the agent's instructions; cwd at run time is the schedule's directory.
 
 ## Storage layout
 
-Schedules live as one markdown file per schedule:
-
 ```text
 ~/.treasure-work/schedules/
-  {name}.md          # YAML frontmatter + markdown body (the prompt)
+  {name}/
+    AGENTS.md             # YAML frontmatter + markdown body (the prompt)
+    scripts/              # optional — bash / python scripts the prompt invokes
+    data/                 # optional — persistent state across runs
+    reference/            # optional — templates, specs, configs
+    …                     # any other supporting files
 
 ~/.treasure-work/logs/
   schedule-events.jsonl   # append-only run lifecycle journal (read-only for the agent)
 ```
 
-**File format** — frontmatter holds config; the body IS the agent's instructions when the schedule fires:
+The `AGENTS.md` file format matches workspace agents (`{workspace}/agents/{name}/AGENTS.md`) — same frontmatter conventions, same editor / loader on the Treasure Work side. The directory name is the schedule's identifier (`github-pr-triage/` → name `github-pr-triage`). Names should be short, lowercase, and hyphen-separated (max 64 chars).
+
+**`AGENTS.md` format** — frontmatter holds config; the body IS the agent's instructions when the schedule fires:
 
 ```markdown
 ---
@@ -30,14 +35,14 @@ description: Triage open PRs and post a summary to Slack
 
 ## Steps
 
-1. Run `gh pr list --json title,author,reviewDecision,url` and parse the JSON.
+1. Run `bash scripts/fetch-prs.sh` and parse the JSON it writes.
 2. Filter to PRs where `reviewDecision != APPROVED` and the author is not a bot.
 3. Build a markdown summary grouped by repository.
 4. Post the summary to `#engineering-prs` via `slack_post_message`.
-5. If `gh` returns an error, post a brief failure message to the same channel and stop.
+5. If `fetch-prs.sh` returns an error, post a brief failure message to the same channel and stop.
 ```
 
-The filename without `.md` is the schedule's identifier (`github-pr-triage.md` → name `github-pr-triage`). Names should be short, lowercase, and hyphen-separated (max 64 chars).
+Because cwd at run time is the schedule's directory, relative paths in the prompt body (`bash scripts/fetch-prs.sh`, `Read data/state.json`) resolve naturally without any path-juggling.
 
 ### Frontmatter fields
 
@@ -68,7 +73,7 @@ Steps 3–5 are mandatory. A schedule isn't done until it has been test-run succ
 
 | Tool | Purpose |
 |------|---------|
-| `schedule_create` | Create a new schedule. Args: `name`, `prompt`, `cron`, optional `description`, optional `enabled` (default `true`). Validates cron + writes `{name}.md`. |
+| `schedule_create` | Create a new schedule. Args: `name`, `prompt`, `cron`, optional `description`, optional `enabled` (default `true`). Validates cron + writes `{name}/AGENTS.md`. |
 | `schedule_list` | List all schedules with cron, status, last run, next run. Use this first when looking for an existing schedule. |
 | `schedule_get` | Full record for one schedule, including the prompt body. |
 | `schedule_update` | Patch description / prompt / cron / enabled. Names are stable; to rename, use `schedule_delete` + `schedule_create`. |
@@ -76,11 +81,11 @@ Steps 3–5 are mandatory. A schedule isn't done until it has been test-run succ
 | `schedule_delete` | Remove the schedule (deletes the `.md` file; preserves the events log). Confirm with the user before deleting frequently-running schedules. |
 | `schedule_run_now` | Trigger a one-off run. Does NOT advance the cron. Returns the run's `chatId`. |
 
-The MCP tools are the recommended path because they validate cron, normalize fields, and emit lifecycle events that the runner uses for status display. Direct `Read` / `Edit` of `{name}.md` is also supported for ad-hoc edits the tools don't cover (e.g., bulk renames in an editor).
+The MCP tools are the recommended path because they validate cron, normalize fields, and emit lifecycle events that the runner uses for status display. Direct `Read` / `Edit` of `{name}/AGENTS.md` is also supported for ad-hoc edits the tools don't cover (e.g., bulk renames in an editor).
 
 ## Writing a good prompt body
 
-The body of `{name}.md` is what the agent will see as its `### Agent Instructions` when the schedule fires. Treat it like a self-contained task prompt:
+The body of `{name}/AGENTS.md` is what the agent will see as its `### Agent Instructions` when the schedule fires. Treat it like a self-contained task prompt:
 
 - **Concrete steps**, numbered, in execution order. Don't say "look at the data" — say "run X, parse Y, write Z."
 - **Specific tool names** when the choice matters (`gh pr list`, `slack_post_message`, etc.). The agent has access to whatever MCP tools are registered; naming them in the prompt makes the choice explicit.
@@ -90,7 +95,13 @@ The body of `{name}.md` is what the agent will see as its `### Agent Instruction
 
 ## Working directory at run time
 
-When a schedule fires, the agent's working directory is the user's home directory (`$HOME`). If the prompt references files, use absolute paths or have the agent `cd` first. There is no per-task `scripts/` / `reference/` / `data/` directory anymore — inline scripts in the prompt body via heredocs (`bash <<'EOF' … EOF`), or have the agent `Write` files where the user wants them.
+When a schedule fires, the agent's cwd is the schedule's directory (`~/.treasure-work/schedules/{name}/`). Relative paths in the prompt resolve there, so:
+
+- Drop scripts in `scripts/` and call them with `bash scripts/foo.sh`.
+- Drop reference files in `reference/` and `Read` them by relative path.
+- Persist state across runs by `Write`-ing to `data/state.json`.
+
+These subdirectory names are conventions, not required. Use whatever organization makes sense for the task. The directory tree is yours — the runner only cares that `AGENTS.md` exists.
 
 ## Example: bare-minimum schedule
 
@@ -107,5 +118,7 @@ schedule_create with:
     4. Post the summary to `#engineering-prs` via `slack_post_message`. Title: "Open PRs · `2026-05-07`".
     5. If `gh` errors out, post "PR triage failed: {error}" to the same channel and stop.
 ```
+
+This creates `~/.treasure-work/schedules/pr-triage/AGENTS.md`. If the prompt grows to need a script, drop it at `~/.treasure-work/schedules/pr-triage/scripts/fetch-prs.sh` (relative paths in the prompt body resolve there at run time).
 
 After creating, run `schedule_run_now` and watch the resulting chat to confirm the agent behaves correctly before leaving it on the cron.


### PR DESCRIPTION
## Summary

Rewrites both `schedule-task` and `schedule-review` SKILL.md files for the new simplified Treasure Work schedule subsystem ([treasure-data/treasure-work#224](https://github.com/treasure-data/treasure-work/pull/224)).

The Treasure Work side is moving from a per-task directory layout (`~/.tdx/schedule-tasks/{name}/` or `{workspace}/schedules/{name}/` with `TASK.md` + `schedule.yaml` + `scripts/` + `reference/` + `data/` + `results/`) to a single-file layout (`~/.treasure-work/schedules/{name}.md` with YAML frontmatter + markdown body). MCP tools have been renamed and slimmed.

Both skills today still reference the old design and have been observed leading agents to fabricate paths under `{workspace}/schedules/`, hand-author `TASK.md` + `schedule.yaml`, and call tools that no longer exist (`create_schedule`, `schedule_validate`, `schedule_reload`, `schedule_run`, `schedule_enable`, `schedule_results`).

## What changes

**`schedule-task`** — full rewrite:
- New file location: `~/.treasure-work/schedules/{name}.md`
- Frontmatter is just `cron`, `enabled`, `description`, optional `workspace` — drops `permissions.allow`, `notify.on_*`, `goal`, `output.note`, `catch_up`, `autonomous`, `status`, `profile`
- Body of `{name}.md` IS the prompt (no split between yaml config and `TASK.md` instructions)
- New MCP tool set: `schedule_create / schedule_list / schedule_get / schedule_update / schedule_set_enabled / schedule_delete / schedule_run_now`
- Workflow simplified to: capture intent → create → test-run → iterate → enable
- Working dir at run time is `$HOME` (no per-task `scripts/` dir)
- Includes a worked bare-minimum example (`pr-triage` schedule)

**`schedule-review`** — slimmed to focus on prompt quality only:
- Most structural validation (cron syntax, field shape, name constraints) is now done by `schedule_create` / `schedule_update` at write time, so the structural sub-agent is redundant
- Keeps the quality-review checklist (concrete steps, logical order, specific tool names, failure handling, explicit output format, no hidden state, cron matches purpose, notification target)
- Drops `TaskCreate`-based parallel sub-agents — overkill for the slimmer scope; a single linear pass covers it
- Operates on the prompt body returned by `schedule_get`; applies fixes via `schedule_update`

## Diff size

- `schedule-task/SKILL.md`: 161 → 117 lines (−27%)
- `schedule-review/SKILL.md`: 122 → 41 lines (−66%)

Together: −225 / +107.

## Coordination

The Treasure Work PR (treasure-data/treasure-work#224) ships an explicit "override notice" in its global system prompt telling the agent to ignore any skill referencing the old design — this protects users running the published-but-not-yet-updated skill. Once both PRs merge, the override notice can be removed from Treasure Work in a follow-up.

## Test plan

- [ ] Skill renders correctly in the marketplace UI
- [ ] User installs the updated `treasure-work-skills` plugin and confirms the agent uses the new `schedule_*` tools and file layout when asked to "create a scheduled task"
- [ ] `schedule-review` produces a sensible quality report on a real schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)