### PR TITLE
fix(document-skills): inline description to fix YAML parsing

### DIFF
--- a/document-skills/google-slides-review/SKILL.md
+++ b/document-skills/google-slides-review/SKILL.md
@@ -1,17 +1,6 @@
 ---
 name: google-slides-review
-description: >
-  Use this skill at the end of a Google Slides deck-creation flow run
-  by the same agent in the current session, before reporting the
-  finished URL to the user. Catches the failure modes a creating
-  agent reliably misses — surviving placeholder text, unswapped
-  template imagery, layout overflow, hidden-original leaks. Trigger
-  when the parent google-slides workflow reaches Step 9 / QA, or
-  when the user asks "is this deck ready?" / "QA my deck" about a
-  deck this agent itself just edited. Do NOT trigger for reviewing
-  decks the agent did not create — without the Step 5 pre-fill
-  snapshot the leak check silently degrades and the result is
-  misleading.
+description: Use this skill at the end of a Google Slides deck-creation flow run by the same agent in the current session, before reporting the finished URL to the user. Catches the failure modes a creating agent reliably misses — surviving placeholder text, unswapped template imagery, layout overflow, hidden-original leaks. Trigger when the parent google-slides workflow reaches Step 9 / QA, or when the user asks "is this deck ready?" / "QA my deck" about a deck this agent itself just edited. Do NOT trigger for reviewing decks the agent did not create — without the Step 5 pre-fill snapshot the leak check silently degrades and the result is misleading.
 ---
 
 # Google Slides Review

--- a/document-skills/google-slides/SKILL.md
+++ b/document-skills/google-slides/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: google-slides
-description: >
-  Use this skill any time the user wants to create a Google Slides deck
-  from a template, mentions "Google Slides" with a template in mind,
-  provides a Google Slides URL plus a content brief, or asks to "make
-  slides", "build a deck", "generate a presentation", or "fill this
-  template" in a Google Workspace context. Requires the Studio Google
-  Slides + Google Drive MCP connectors. Do NOT use for PowerPoint
-  (.pptx) creation (use the pptx skill), for editing without a template,
-  or for authoring a new template (template authoring has its own skill).
+description: Use this skill any time the user wants to create a Google Slides deck from a template, mentions "Google Slides" with a template in mind, provides a Google Slides URL plus a content brief, or asks to "make slides", "build a deck", "generate a presentation", or "fill this template" in a Google Workspace context. Requires the Studio Google Slides + Google Drive MCP connectors. Do NOT use for PowerPoint (.pptx) creation (use the pptx skill), for editing without a template, or for authoring a new template (template authoring has its own skill).
 ---
 
 # Google Slides (Template-Driven Deck Editor)

--- a/document-skills/pptx/SKILL.md
+++ b/document-skills/pptx/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: pptx
-description: >
-  Use this skill any time the user wants to create a new PowerPoint presentation, slide deck,
-  pitch deck, or .pptx file from scratch. Covers creating business presentations, quarterly
-  reports, project proposals, product roadmaps, training materials, and any multi-slide
-  document destined for PowerPoint. Works by generating HTML/CSS slides (which LLMs excel at),
-  rendering them in agent-browser for pixel-accurate DOM position extraction, and assembling
-  the final PPTX with native PowerPoint charts, tables, and images via PptxGenJS.
-  Includes bundled scripts for validation, DOM extraction, and PPTX assembly.
-  Do NOT use this skill for editing existing PPTX files, converting other formats to PPTX,
-  or extracting content from PPTX files.
+description: Use this skill any time the user wants to create a new PowerPoint presentation, slide deck, pitch deck, or .pptx file from scratch. Covers creating business presentations, quarterly reports, project proposals, product roadmaps, training materials, and any multi-slide document destined for PowerPoint. Works by generating HTML/CSS slides (which LLMs excel at), rendering them in agent-browser for pixel-accurate DOM position extraction, and assembling the final PPTX with native PowerPoint charts, tables, and images via PptxGenJS. Includes bundled scripts for validation, DOM extraction, and PPTX assembly. Do NOT use this skill for editing existing PPTX files, converting other formats to PPTX, or extracting content from PPTX files.
 ---
 
 # HTML-to-PPTX Presentation Generator


### PR DESCRIPTION
## Summary

- The three SKILL.md files under `document-skills/` (pptx, google-slides, google-slides-review) used YAML folded block scalars (`description: >`) for the description field
- The skill loader does not handle folded block scalars — the description was being parsed as just `>`, breaking skill triggering
- Converted all three to single-line strings to match the format used by every other skill in the repo

## Test plan

- [ ] Run `./tests/run-tests.sh` to verify trigger tests still pass
- [ ] Confirm the affected skills are correctly triggered after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)