### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .claude/worktrees
 .playwright
+.DS_Store


### PR DESCRIPTION
Add `.DS_Store` to `.gitignore` to prevent macOS Finder metadata files from being committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)