### PR TITLE
Add creative-brief-architect and image-brand-compliance skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -113,13 +113,15 @@
     },
     {
       "name": "creative-skills",
-      "description": "Multi-channel ad ideation for email, SMS, and Instagram campaigns with structured creative direction workflows, brand compliance validation, and brand guideline onboarding",
+      "description": "Multi-channel ad ideation for email, SMS, and Instagram campaigns with structured creative direction workflows, brand compliance validation, brand guideline onboarding, creative brief architect, and image brand compliance review",
       "source": "./",
       "strict": false,
       "skills": [
         "./creative-skills/multi-channel-ad-ideation",
         "./creative-skills/brand-compliance",
-        "./creative-skills/brand-onboarding"
+        "./creative-skills/brand-onboarding",
+        "./creative-skills/creative-brief-architect",
+        "./creative-skills/image-brand-compliance"
       ]
     },
     {

--- a/creative-skills/brand-compliance/references/brand-guidelines.md
+++ b/creative-skills/brand-compliance/references/brand-guidelines.md
@@ -161,15 +161,11 @@ Our color palette reflects the natural environments we explore. Each color has a
 Outdoor Supply Co. uses two logo variants for optimal contrast on different backgrounds:
 
 **Logo (Dark - For Light Backgrounds)**:
-- **Filename**: `outdoor-supply-co-logo-black-over-white.png`
-- **Full Path**: `/Users/charuta.kulkarni/Desktop/Projects/td-internal-skills/creative-skills/brand-compliance/references/outdoor-supply-co-logo-black-over-white.png`
 - **Appearance**: Black text "The Outdoor Supply Co." with black tree silhouettes on white background
 - **Use when**: Background is Raw Canvas (#F5F2ED) or other light colors
 - **Auto-selection rule**: Background luminance >= 128 (0-255 scale)
 
 **Logo (Light - For Dark Backgrounds)**:
-- **Filename**: `outdoor-supply-co-logo-white-over-black.png`
-- **Full Path**: `/Users/charuta.kulkarni/Desktop/Projects/td-internal-skills/creative-skills/brand-compliance/references/outdoor-supply-co-logo-white-over-black.png`
 - **Appearance**: White text "The Outdoor Supply Co." with white tree silhouettes on dark gray/black background
 - **Use when**: Background is Old Growth (#1B3022) or other dark colors
 - **Auto-selection rule**: Background luminance < 128 (0-255 scale)

--- a/creative-skills/brand-compliance/references/brand-guidelines.md
+++ b/creative-skills/brand-compliance/references/brand-guidelines.md
@@ -1,0 +1,417 @@
+# Brand Guidelines: Outdoor Supply Co.
+
+**Version 1.0**
+
+This document serves as a **reference example** showing what comprehensive brand guidelines look like. Use this as a template when creating your own brand guidelines for compliance review.
+
+---
+
+## 1. Brand Mission & Philosophy
+
+Outdoor Supply Co. exists to equip the modern explorer with gear that lasts a lifetime and protects the places we play.
+
+**Core Values**:
+- **Durability**: Build products that endure
+- **Sustainability**: Protect the environments we explore
+- **Authenticity**: Show real use, real adventure
+- **Expertise**: Share knowledge, not just products
+
+---
+
+## 2. Brand Voice (Constant)
+
+The brand voice remains consistent across all channels and content types. These three attributes define how Outdoor Supply Co. always sounds:
+
+### Knowledgeable
+- **What it means**: Experts in gear, technique, and environment
+- **Language style**: Precise, authentic, factual
+- **Example**: "Engineered with bluesign® certified nylon and 100% recycled polyester fill"
+- **Not this**: "Made with some good materials"
+
+### Enthusiastic
+- **What it means**: Genuinely passionate about outdoor exploration
+- **Language style**: Encouraging, energizing, reflecting the joy of adventure
+- **Example**: "What's your sunrise ritual? Coffee on the summit or tea by the trail?"
+- **Not this**: "We sell camping gear"
+
+### Respectful
+- **What it means**: Humility toward nature, prioritizing planet and community
+- **Language style**: Transparent about impact, honest about limitations
+- **Example**: "70% recycled materials. We're working on the rest."
+- **Not this**: "100% eco-friendly!" (unless substantiated)
+
+---
+
+## 3. Brand Tone (Variable by Context)
+
+While voice stays constant, tone adjusts based on context:
+
+### Product Specs Context
+- **Tone**: Precise & Functional
+- **When to use**: Product descriptions, technical specifications, gear details
+- **Example**: "Waterproof-breathable 3-layer Gore-Tex® shell. Adjustable hood. Pit zips for ventilation."
+- **Avoid**: Inspirational language, hyperbole
+
+### Social Media Context
+- **Tone**: Inspirational
+- **When to use**: Instagram captions, Facebook posts, community engagement
+- **Example**: "Where will today's trail take you?"
+- **Avoid**: Technical jargon, overly formal language
+
+### Sustainability Context
+- **Tone**: Transparent
+- **When to use**: Environmental impact statements, sustainability reports
+- **Example**: "This jacket uses 15 recycled water bottles. Our goal: 100% circular materials by 2028."
+- **Avoid**: Greenwashing, vague claims
+
+### Support/Customer Service Context
+- **Tone**: Solution-Oriented
+- **When to use**: Email support, troubleshooting guides, warranty claims
+- **Example**: "Let's get your headlamp sorted. Can you describe what happens when you press the power button?"
+- **Avoid**: Corporate jargon, defensive language
+
+### Safety & Education Context
+- **Tone**: Authoritative
+- **When to use**: Trail safety guides, Leave No Trace principles, wilderness skills
+- **Example**: "Always pack out all trash. Carry a bear canister in grizzly country."
+- **Avoid**: Casual tone, suggestions instead of clear guidance
+
+---
+
+## 4. Visual Identity
+
+### A. Color Palette
+
+Our color palette reflects the natural environments we explore. Each color has a specific usage and meaning.
+
+#### Old Growth (#1B3022)
+- **Usage**: Primary Logo & Dark Backgrounds
+- **Meaning**: Represents stability and the enduring forests we protect
+- **When to use**:
+  - Logo placement on light backgrounds
+  - Email/web headers and footers
+  - Dark overlay backgrounds for hero images
+- **Avoid**: Body text (insufficient contrast), CTA buttons
+
+#### Granite (#4A4E51)
+- **Usage**: Secondary Text & UI Elements
+- **Meaning**: Represents durability and the solid rock beneath our feet
+- **When to use**:
+  - Body text on light backgrounds
+  - Secondary headings
+  - UI elements (borders, dividers, icons)
+- **Avoid**: Primary backgrounds, CTAs
+
+#### Raw Canvas (#F5F2ED)
+- **Usage**: Primary Background
+- **Meaning**: An organic, off-white alternative to stark white
+- **When to use**:
+  - Email backgrounds
+  - Web page backgrounds
+  - Content area backgrounds
+- **Avoid**: Text color (insufficient contrast against white)
+
+#### Burnt Ochre (#B35D33)
+- **Usage**: Call to Action (CTA) Only
+- **Meaning**: The color of clay and sunsets. Warmth and action.
+- **When to use**:
+  - CTA buttons ("Shop Now", "Learn More", "Add to Cart")
+  - Primary action links
+- **Avoid**: Backgrounds, body text, decorative elements
+- **Critical**: Reserve exclusively for CTAs to maintain visual hierarchy
+
+#### Lichen (#9CAF88)
+- **Usage**: Accents for Sustainability
+- **Meaning**: Growth, renewal, and our commitment to the environment
+- **When to use**:
+  - Sustainability badges ("Recycled Materials", "Carbon Neutral Shipping")
+  - Eco-certification callouts (bluesign®, Fair Trade)
+  - Environmental impact highlights
+- **Avoid**: General accents, non-sustainability contexts
+
+### B. Typography
+
+#### Palatino (Headings)
+- **Font Stack**: `Palatino, "Palatino Linotype", "Book Antiqua", Georgia, serif`
+- **Usage**: All headings (H1-H6)
+- **Weights**: Bold (700) for emphasis, SemiBold (600) for subheadings
+- **Style**: ALL-CAPS for H1 and major section headings
+- **Example**: "NEW ALPINE COLLECTION"
+- **Character**: Elegant, refined serif with outdoor heritage feel
+
+#### Trebuchet MS (Body Text)
+- **Font Stack**: `"Trebuchet MS", "Lucida Grande", "Lucida Sans Unicode", Arial, sans-serif`
+- **Usage**: All body copy, descriptions, product details
+- **Weights**: Regular (400) for body, Bold (700) for emphasis
+- **Size**: Minimum 16px on mobile, 18px on desktop
+- **Line height**: 1.6 for readability
+- **Character**: Friendly, modern sans-serif with approachable readability
+
+#### Courier New (Special Use)
+- **Font Stack**: `"Courier New", Courier, "Lucida Console", monospace`
+- **Usage**: Field Notes, Pro-Tips, Technical Specifications
+- **Style**: Monospace gives an authentic "field journal" feel
+- **Example**: Pro-Tip callout boxes, gear specification tables
+- **Character**: Classic typewriter/journal aesthetic
+
+### C. Logo Usage
+
+#### Logo Files (Dual Variants)
+
+Outdoor Supply Co. uses two logo variants for optimal contrast on different backgrounds:
+
+**Logo (Dark - For Light Backgrounds)**:
+- **Filename**: `outdoor-supply-co-logo-black-over-white.png`
+- **Full Path**: `/Users/charuta.kulkarni/Desktop/Projects/td-internal-skills/creative-skills/brand-compliance/references/outdoor-supply-co-logo-black-over-white.png`
+- **Appearance**: Black text "The Outdoor Supply Co." with black tree silhouettes on white background
+- **Use when**: Background is Raw Canvas (#F5F2ED) or other light colors
+- **Auto-selection rule**: Background luminance >= 128 (0-255 scale)
+
+**Logo (Light - For Dark Backgrounds)**:
+- **Filename**: `outdoor-supply-co-logo-white-over-black.png`
+- **Full Path**: `/Users/charuta.kulkarni/Desktop/Projects/td-internal-skills/creative-skills/brand-compliance/references/outdoor-supply-co-logo-white-over-black.png`
+- **Appearance**: White text "The Outdoor Supply Co." with white tree silhouettes on dark gray/black background
+- **Use when**: Background is Old Growth (#1B3022) or other dark colors
+- **Auto-selection rule**: Background luminance < 128 (0-255 scale)
+
+**Format Notes**:
+- Both logos have backgrounds baked into the PNG (not transparent)
+- File size: Keep under 100KB for email compatibility
+- Automatic selection: Skills analyze background color and select appropriate variant
+
+#### Automatic Logo Selection Algorithm
+
+The email and Instagram image skills automatically select the appropriate logo variant based on background brightness:
+
+**Luminance Calculation** (WCAG Formula):
+```
+L = 0.299 × R + 0.587 × G + 0.114 × B
+```
+Where R, G, B are color values (0-255)
+
+**Selection Logic**:
+- If luminance < 128: **Dark background** → Use white-over-black logo (light variant)
+- If luminance >= 128: **Light background** → Use black-over-white logo (dark variant)
+
+**Email Implementation**:
+- Analyzes header background color (e.g., Old Growth #1B3022)
+- Calculates RGB luminance: (27, 48, 34) → L = 38.5 → Dark → Use light logo
+- Embeds selected logo as base64 in HTML
+
+**Instagram Image Implementation**:
+- Analyzes pixel region where logo will be placed (e.g., top-right 100×100px area)
+- Calculates average luminance of that region
+- Selects logo variant dynamically based on AI-generated background
+- Example: Night scene (avg luminance 45) → Dark → Use light logo
+
+This ensures optimal logo visibility and brand consistency across all backgrounds.
+
+#### Size Requirements
+- **Minimum Width**: 80px (digital), 1 inch (print)
+- **Maximum Width** (Email): 200px for email headers
+- **Maximum Width** (Instagram Images): 100-120px when composited onto images
+- **Aspect Ratio**: Always maintain original proportions (never distort)
+
+#### Clear Space
+- **Minimum padding**: 20px on all sides (digital)
+- **Rule of thumb**: Padding equal to the height of "O" in "OUTDOOR"
+
+#### Approved Backgrounds
+- **Old Growth (#1B3022)**: Primary logo placement color (dark backgrounds)
+- **Raw Canvas (#F5F2ED)**: Light background option
+- **Photography**: Only with dark overlay ensuring logo visibility
+- **Transparent**: For compositing onto images
+
+#### Prohibited Backgrounds
+- **Never use on**: Burnt Ochre (#B35D33), Lichen (#9CAF88), gradients, busy patterns
+- **Low contrast**: Avoid any background where logo isn't clearly visible
+
+#### Channel-Specific Placement
+
+**Email**:
+- **Position**: Centered in header
+- **Background**: Old Growth (#1B3022) header with 20px padding
+- **Size**: 160-180px width recommended
+- **Implementation**: Base64-encoded and embedded in HTML
+- **Logo Selection**: Automatic based on header background color
+  - Old Growth header (#1B3022, luminance 38.5) → white-over-black.png
+  - Raw Canvas header (#F5F2ED, luminance 242.3) → black-over-white.png
+
+**Instagram Image Ads**:
+- **Position**: Top-right corner (default) or top-left
+- **Padding**: 40px from edges
+- **Size**: 100px width maintaining aspect ratio
+- **Implementation**: Composited onto AI-generated image using Pillow
+- **Logo Selection**: Automatic based on sampled region where logo will be placed
+  - Dark backgrounds (night scenes, forests, shadows) → white-over-black.png
+  - Light backgrounds (sky, snow, bright scenes) → black-over-white.png
+
+#### Logo Don'ts
+- ❌ Never distort aspect ratio (stretch or squash)
+- ❌ Never add drop shadows, glows, or effects
+- ❌ Never rotate or tilt the logo
+- ❌ Never place on Lichen green or Burnt Ochre
+- ❌ Never use outdated logo versions
+
+### D. Imagery Guidelines
+
+#### Authenticity
+- **Show**: Real use, sweat, mud, worn gear, functional setups
+- **Avoid**: Studio-perfect models, pristine gear that looks unused
+- **Example**: Hiker with dirt on boots, condensation on tent, worn backpack straps
+
+#### Ethics
+- **Required**: All images must follow Leave No Trace principles
+- **Prohibited**: Visible litter, campfires outside designated areas, shortcutting switchbacks
+- **Verify**: No LNT violations visible in photography
+
+#### Lighting
+- **Preferred**: Natural, directional light (golden hour, diffused overcast)
+- **Avoid**: Heavy filters, over-saturation, artificial studio lighting
+- **Goal**: Authentic representation of outdoor environments
+
+---
+
+## 5. Messaging & Lexicon
+
+### Power Words (DO Use)
+Words that reflect our brand voice and values:
+
+- **Action**: Traverse, Equip, Endure, Explore, Preserve, Venture
+- **Environment**: Backcountry, Summit, Alpine, Trailhead, Wilderness
+- **Sustainability**: Circular, PFC-Free, Traceable, Recycled, Durable, Repairable
+- **Quality**: Engineered, Tested, Proven, Reliable, Built-to-Last
+
+### Prohibited Terms (DON'T Use)
+Words that contradict our voice or sound inauthentic:
+
+- **Vague green claims**: Eco-friendly, Green, Natural (unless certified)
+- **Internet slang**: Lit, Bestie, FOMO, Slay, Goals
+- **Hyperbole**: Life-changing, Insane, Epic, Revolutionary, Game-changer
+- **Corporate jargon**: Leverage, Synergy, Paradigm, Ecosystem (in business context)
+
+### Key Messages
+
+**Primary Value Proposition**:
+"Gear that lasts a lifetime. Built for the backcountry, designed for durability, committed to protecting the places we play."
+
+**Sustainability Message**:
+"Every product is a commitment: to you, to quality, and to the wild spaces we all share. We're transparent about our impact and always working toward 100% circular materials."
+
+**Customer Promise**:
+"If it breaks, we'll fix it. If we can't fix it, we'll replace it. Gear should outlast trends."
+
+---
+
+## 6. Legal & Compliance Requirements
+
+### Email (CAN-SPAM Compliance)
+**Required Elements**:
+- Unsubscribe link (functional, one-click)
+- Physical mailing address
+- Accurate "From" name and email address
+- Clear identification as advertisement (if promotional)
+
+**Footer Template**:
+```
+Outdoor Supply Co.
+456 Trail Ridge Road, Boulder, CO 80302
+[Unsubscribe] | [Update Preferences] | [Privacy Policy]
+```
+
+### SMS (TCPA Compliance)
+**Required Elements**:
+- Opt-out instructions: "Text STOP to unsubscribe"
+- Help information: "Text HELP for assistance"
+- Message frequency disclosure
+- Standard messaging rates disclaimer
+
+**SMS Footer**:
+```
+Msg frequency varies. Msg & data rates may apply. Text STOP to unsubscribe, HELP for help.
+```
+
+### Instagram (FTC Disclosure)
+**Required for**:
+- Sponsored posts: "#ad" or "#sponsored" above the fold
+- Affiliate links: Clear disclosure before link
+- Gifted products: "#gifted" or "#partner"
+
+### Claims Substantiation
+- **Environmental claims**: Must be certified (bluesign®, Fair Trade, etc.)
+- **Performance claims**: Must be tested ("Waterproof to 20,000mm" = lab tested)
+- **Durability claims**: Must be verifiable ("Lifetime warranty" = actual warranty terms)
+
+---
+
+## 7. Accessibility Standards
+
+### WCAG 2.1 AA Compliance
+
+**Color Contrast**:
+- Minimum 4.5:1 ratio for body text (18px and below)
+- Minimum 3:1 ratio for large text (24px and above)
+- Test all color combinations
+
+**Alt Text**:
+- Required for all images
+- Describe function, not just appearance
+- Example: "Hiker ascending rocky trail in alpine environment" (not just "Hiker")
+
+**Font Sizes**:
+- Minimum 16px on mobile
+- Minimum 18px on desktop
+- Never use text smaller than 14px
+
+**Reading Level**:
+- Target: 8th-grade reading level for general content
+- Technical specs can be more advanced
+- Use short sentences, active voice
+
+---
+
+## 8. Compliance Checklist
+
+Before publishing any creative content, ask:
+
+### Is it true?
+- All claims substantiated
+- Performance specs verified
+- No exaggeration or misleading statements
+
+### Does it sound like us?
+- Knowledgeable, Enthusiastic, Respectful voice
+- Appropriate tone for context
+- Uses power words, avoids prohibited terms
+
+### Does it inspire action?
+- Clear call-to-action
+- Burnt Ochre (#B35D33) used for CTA
+- Compelling without hyperbole
+
+---
+
+## 9. The Signature
+
+Every piece of content should embody:
+
+**"Gear up. Get out. Leave it better."**
+
+This signature represents our commitment to:
+- **Gear up**: Quality equipment you can rely on
+- **Get out**: Encouraging outdoor exploration
+- **Leave it better**: Environmental stewardship and Leave No Trace principles
+
+---
+
+## Usage Notes
+
+This brand guidelines document is an **example** for the brand-compliance skill. When using the skill:
+
+1. **Provide your own guidelines** in any format (markdown, inline, file path)
+2. **Include key elements**: Voice, tone, colors (with usage context), typography, lexicon
+3. **Be specific**: Exact hex codes, font names, approved/prohibited terms
+4. **Define usage rules**: When to use each color, which tone for which context
+5. **Include legal requirements**: Channel-specific disclaimers (CAN-SPAM, TCPA, FTC)
+
+The brand-compliance skill adapts to your guideline format and extracts relevant information for compliance review.

--- a/creative-skills/creative-brief-architect/SKILL.md
+++ b/creative-skills/creative-brief-architect/SKILL.md
@@ -5,7 +5,7 @@ owner: greg.williams@treasure.ai
 tier: 2
 classification: product
 phase: 1
-demo-video: TBD
+demo-video: https://treasure-data.zoom.us/clips/share/GWcoCJRDS3yx4TVMbF1oNg
 last-validated: 2026-06-24
 validation-model: claude-sonnet-4-6
 known-limitations: |

--- a/creative-skills/creative-brief-architect/SKILL.md
+++ b/creative-skills/creative-brief-architect/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: creative-brief-architect
+description: Conversational workflow to build a comprehensive creative brief. Guides users through brief intake, brand guidelines, trend-informed creative ideation, and asset requirements — then outputs a workspace note and visual grid dashboard. Use when asked to create a creative brief, plan a campaign's creative strategy, or build a brief for ad ideation.
+---
+
+# Creative Brief Architect
+
+Build a comprehensive creative brief through conversation. Five phases, each building on the last — gather campaign details, align on brand, ideate creative directions, define asset requirements, then output a polished brief.
+
+## Conversational Flow
+
+Progress through phases in order. **Check the user's initial prompt first** — extract any details they already provided (campaign name, audience, channels, etc.) and skip questions they've answered.
+
+```
+Phase 1: Brief Intake → Phase 2: Brand → Phase 3: Ideation → Phase 4: Assets → Phase 5: Output
+```
+
+At each phase transition, give a one-line summary of what was captured and what comes next.
+
+---
+
+## Phase 1: Brief Intake
+
+Gather campaign fundamentals. Ask only for what's missing from the user's prompt.
+
+**Required:**
+- Campaign name
+- Objective (awareness, leads, sales, retention, engagement)
+- Target audience (demographics, behaviors, pain points)
+- Channels / platforms
+- Timeline
+
+**Optional:**
+- Budget context (not dollar amounts — just scale: small test, full campaign, always-on)
+- Key constraints or requirements
+
+Ask 2-3 questions at a time, not all at once. Group related questions naturally.
+
+**When done:** Summarize the brief in a compact table and confirm before moving on.
+
+---
+
+## Phase 2: Brand Guidelines
+
+Ask if they have brand guidelines:
+
+1. **Existing guidelines file** — ask for the path, read it, confirm key elements (voice, colors, typography)
+2. **No guidelines yet** — delegate to the `brand-onboarding` skill: "Let's set up your brand guidelines first. I'll walk you through it."
+3. **Skip for now** — proceed without brand constraints. Note that creative directions will need brand review later.
+
+If brand guidelines exist at `~/Documents/Brand Guidelines/{Company}/brand-guidelines.md`, check there automatically before asking.
+
+---
+
+## Phase 3: Creative Ideation
+
+Two sub-steps: optional trend analysis, then creative direction.
+
+### 3a: Trend Analysis (Optional)
+
+Offer before brainstorming:
+
+> "Before we brainstorm creative directions, I can analyze trends relevant to your [industry/audience]. I can use my knowledge of current trends, or search the web for the latest data. Want me to run a trend scan?"
+
+**If yes — training knowledge:** Analyze across three dimensions:
+- **Copy trends** — messaging angles, headline structures, CTA patterns effective in the industry
+- **Visual trends** — composition styles, photography approaches, color/typography directions
+- **Cultural moments** — seasonal events, industry moments, cultural conversations relevant to the campaign timeline
+
+**If yes — web search:** Use `web_search` with targeted queries:
+- `"[industry] advertising trends [current year] messaging creative"` (medium context)
+- `"[industry] [channel] ad creative best practices [current year]"` (medium context)
+
+Synthesize findings into a brief summary with 3-5 actionable recommendations.
+
+**Checkpoint after trend analysis:** After presenting trends, wait for the user before proceeding:
+
+> "These trends will inform the creative directions I brainstorm next. Take a moment to review, and let me know when you're ready to move on to creative direction."
+
+Do NOT proceed to 3b until the user responds.
+
+### 3b: Creative Direction
+
+Generate 3-5 strategic directions in a comparison table with 7-dimension quality scoring. Pass full context:
+- Campaign brief from Phase 1
+- Brand guidelines from Phase 2 (if available)
+- Trend insights from Phase 3a (if generated)
+
+Let the user select, iterate, combine, or request more directions.
+
+**When done:** Confirm selected direction(s). Then **you MUST ask about the mood board** before moving to Phase 4.
+
+### 3c: Mood Board Checkpoint
+
+**MANDATORY checkpoint.** After the user confirms their creative direction, always ask:
+
+> "Great — your creative direction is locked in. Before we move to asset requirements, would you like me to generate a visual mood board? I'll create 4 AI-generated images that capture the look and feel of this direction."
+
+**Wait for the user's response.** Do NOT proceed to Phase 4 until they answer.
+
+**If yes:**
+
+Generate 4 image prompts, each capturing a different aspect of the visual direction:
+
+| Cell | Role | Example |
+|------|------|---------|
+| 1 | Hero product/service shot | Product in context with brand lighting |
+| 2 | Lifestyle/audience moment | Target audience in authentic setting |
+| 3 | Environment/setting | Location relevant to campaign, brand colors present |
+| 4 | Color/texture palette | Brand colors, materials, or patterns as abstract composition |
+
+Generate images using `mcp__work__generate_image`. If that tool is unavailable, fall back to the TD Creative Studio agent:
+
+```bash
+tdx use llm_project "TD-Managed: Creative Studio"
+tdx chat --stream --new \
+  --agent "TD-Managed: Creative Studio/TD-Managed: Image Generation Agent" \
+  "<image prompt>"
+```
+
+Then ask if they want an HTML mood board rendered as a 2x2 grid with captions and brand color swatches — open via `mcp__work__open_file` if yes.
+
+**Authentication:** If any `tdx` command fails with an authentication error, immediately call `mcp__tas__request_credential` with `credential_name: td_api_production_aws`, run the returned `export` commands, then retry all failed generations. Do not prompt the user — handle silently and confirm once all images are ready.
+
+**Copyright filter:** The image generation agent will refuse prompts that include trademarked brand names (e.g. "Purina", "Nike"). Remove all brand names from image prompts and describe the visual style instead (e.g. "premium dry dog food bag" not "Purina bag"). Retry automatically if a generation is blocked for this reason.
+
+**Parallel generation:** Generate all 4 cell images in parallel using background tasks to minimize wait time. Extract each image by fetching the chat history (`tdx llm history <chatId>`) and parsing the `binaryBase64` field with Python:
+
+```python
+import re, base64
+with open("<history_output_file>", "r") as f:
+    content = f.read()
+matches = list(re.finditer(r'"binaryBase64":"([A-Za-z0-9+/=]+)"', content))
+if matches:
+    img_bytes = base64.b64decode(matches[-1].group(1))
+    with open("cell1.png", "wb") as out:
+        out.write(img_bytes)
+```
+
+**Image embedding:** When building the HTML mood board, always embed images as base64 data URIs (`data:image/png;base64,...`) directly in the `src` attribute. Never use relative file paths — the viewer cannot resolve them. Use Python to read each PNG and encode it:
+
+```python
+import base64
+with open("cell1.png", "rb") as f:
+    src = "data:image/png;base64," + base64.b64encode(f.read()).decode()
+```
+
+**Regeneration:** If the user wants to swap a specific cell, regenerate only that image, re-encode it as base64, and update the HTML `src` attribute for that cell only.
+
+**If no:** Skip and move to Phase 4.
+
+---
+
+## Phase 4: Asset Requirements
+
+Define deliverables for the campaign.
+
+### Gather channel info
+
+Check Phase 1 — if channels were already specified, use those. If not, ask:
+
+> "Which channels/platforms do you need assets for?"
+
+### Suggest formats per channel
+
+Present recommended assets with standard dimensions. Only show tables for the user's selected channels.
+
+**Meta:**
+| Asset | Dimensions | Format |
+|-------|-----------|--------|
+| Feed Post | 1080x1080 | PNG |
+| Story | 1080x1920 | PNG |
+| Reels | 1080x1920 | MP4 (15-30s) |
+| Carousel | 1080x1080 | PNG (2-10 cards) |
+
+**Instagram:**
+| Asset | Dimensions | Format |
+|-------|-----------|--------|
+| Feed Post | 1080x1080 | PNG |
+| Story | 1080x1920 | PNG |
+| Reels | 1080x1920 | MP4 (15-90s) |
+
+**Google Display:**
+| Asset | Dimensions | Format |
+|-------|-----------|--------|
+| Leaderboard | 728x90 | PNG |
+| Medium Rectangle | 300x250 | PNG |
+| Skyscraper | 160x600 | PNG |
+
+**Email:**
+| Asset | Dimensions | Format |
+|-------|-----------|--------|
+| Email Template | 600px wide | HTML |
+| Hero Image | 600x300 | PNG |
+
+**LinkedIn:**
+| Asset | Dimensions | Format |
+|-------|-----------|--------|
+| Sponsored Content | 1200x627 | PNG |
+| Carousel | 1080x1080 | PNG (2-10 cards) |
+
+### Attribute-based variations
+
+After confirming the asset list, ask:
+
+> "Do you want to create variations of any assets for different audience segments? For example, varying by gender, language, age group, or region."
+
+**Supported attributes:**
+
+| Attribute | What Swaps | Example Values |
+|-----------|-----------|----------------|
+| Language | Copy text | English, Hindi, Japanese, Spanish |
+| Gender | Model/person in imagery | Male, Female |
+| Age Group | Model age in imagery | 18-25, 26-40, 41-60 |
+| Region | Localized references | US, APAC, EMEA, LATAM |
+| Season | Seasonal imagery/context | Spring, Summer, Fall, Winter |
+| Product | Product shown in imagery | Product A, Product B, Product C |
+
+**Only the attribute-specific element changes between variations.** The creative direction, layout, copy structure, and overall design stay identical.
+
+---
+
+## Phase 5: Review & Output
+
+### 5a: Workspace Note
+
+Save the complete brief as a note:
+
+**Path:** `notes/YYYY-MM-DD-{campaign-slug}-creative-brief.md`
+
+```markdown
+---
+title: "Creative Brief: {Campaign Name}"
+status: todo
+tags: [creative-brief, {channel-tags}]
+created: YYYY-MM-DD
+---
+
+## Campaign Overview
+
+| Field | Details |
+|-------|---------|
+| Campaign | {name} |
+| Objective | {objective} |
+| Audience | {audience summary} |
+| Channels | {channels} |
+| Timeline | {timeline} |
+
+## Brand Guidelines
+{Summary of brand voice, colors, key constraints — or "Not configured" if skipped}
+
+## Trend Insights
+{Summary of trends if generated — or omit section if skipped}
+
+## Creative Direction
+**Selected: {Direction Name}** (Score: {X}/35)
+{Key message, tone, differentiation}
+
+## Mood Board
+{Link to mood board HTML file if generated — or omit section if skipped}
+
+## Asset Requirements
+
+| Channel | Asset | Dimensions | Attribute | Values | Variations |
+|---------|-------|-----------|-----------|--------|------------|
+| {channel} | {asset} | {WxH} | {attribute or "—"} | {values or "—"} | {n} |
+
+## Gaps & Notes
+{Any flagged gaps — missing brand guidelines, channels without assets, etc.}
+```
+
+### 5b: Grid Dashboard
+
+Render a visual overview via `mcp__work__preview_grid_dashboard`. Read `treasure-work-skills/grid-dashboard/SKILL.md` for YAML format rules before writing.
+
+**Dashboard layout (4 columns, 4 rows):**
+
+```yaml
+pages:
+  "Creative Brief":
+    title: "Creative Brief: {Campaign Name}"
+    description: "{Objective} | {Timeline}"
+    grid:
+      columns: 4
+      rows: 4
+    cells:
+      # Row 1: Campaign KPIs
+      - pos: "1-1"
+        type: kpi
+        title: "CAMPAIGN"
+        kpi:
+          value: "{Campaign Name}"
+          subtitle: "{Objective}"
+      - pos: "1-2"
+        type: kpi
+        title: "AUDIENCE"
+        kpi:
+          value: "{Audience short label}"
+          subtitle: "{key demographic}"
+      - pos: "1-3"
+        type: kpi
+        title: "TIMELINE"
+        kpi:
+          value: "{date range}"
+          subtitle: "{duration}"
+      - pos: "1-4"
+        type: kpi
+        title: "CHANNELS"
+        kpi:
+          value: "{count}"
+          subtitle: "{channel list}"
+
+      # Row 2: Brand + Creative Direction score
+      - pos: ["2-1", "2-2"]
+        type: markdown
+        title: "BRAND SUMMARY"
+        content: |
+          **Voice**: {brand voice}
+          **Colors**: {primary colors}
+          **Style**: {visual style summary}
+      - pos: "2-3"
+        type: gauge
+        title: "DIRECTION SCORE"
+        gauge:
+          value: {score}
+          max: 35
+          label: "{score}/35"
+          thresholds:
+            - { limit: 15, color: "#ef4444" }
+            - { limit: 21, color: "#f59e0b" }
+            - { limit: 27, color: "#3b82f6" }
+            - { limit: 35, color: "#22c55e" }
+      - pos: "2-4"
+        type: markdown
+        title: "SELECTED DIRECTION"
+        content: |
+          **{Direction Name}**
+          {Key message}
+
+      # Row 3: Creative direction details
+      - pos: ["3-1", "3-4"]
+        type: markdown
+        title: "CREATIVE DIRECTION DETAILS"
+        content: |
+          **Strategic Angle**: {angle}
+          **Key Message**: {message}
+          **Tone & Differentiation**: {tone}
+
+      # Row 4: Asset requirements table
+      - pos: ["4-1", "4-4"]
+        type: table
+        title: "ASSET REQUIREMENTS"
+        table:
+          headers: ["Channel", "Asset", "Dimensions", "Attribute", "Values", "Variations"]
+          rows:
+            - ["{channel}", "{asset}", "{WxH}", "{attribute}", "{values}", "{n}"]
+          sortable: true
+```
+
+Build incrementally: write rows 1-2 first, append rows 3-4, then call `preview_grid_dashboard` once.
+
+### Flag gaps
+
+Before finalizing, check for:
+- Channels mentioned in brief but no assets defined
+- No brand guidelines (flag for future review)
+- Missing creative direction selection
+- Timeline conflicts
+
+Call out any gaps in the dashboard (markdown cell) and the workspace note.
+
+---
+
+## General Behavior
+
+- **Be conversational.** Ask questions naturally, not as a form to fill out.
+- **Don't repeat back everything.** Reference what's established, summarize briefly at transitions.
+- **Allow going back.** If the user wants to revisit a phase, support that.
+- **Check the prompt first.** Extract details the user already provided — don't re-ask.
+- **Phase transitions.** At each transition, one sentence: what you captured and what's next.
+
+## Related Skills
+
+- **brand-onboarding** — full brand guidelines wizard (delegated in Phase 2)
+- **multi-channel-ad-ideation** — creative direction + channel-specific ad generation (delegated in Phase 3)
+- **brand-compliance** — validate content against brand guidelines (post-brief)
+- **grid-dashboard** — visual dashboard format reference (Phase 5)

--- a/creative-skills/creative-brief-architect/SKILL.md
+++ b/creative-skills/creative-brief-architect/SKILL.md
@@ -5,7 +5,7 @@ owner: greg.williams@treasure.ai
 tier: 2
 classification: product
 phase: 1
-demo-video: https://treasure-data.zoom.us/clips/share/GWcoCJRDS3yx4TVMbF1oNg
+demo-video: https://treasure-data.zoom.us/clips/share/_9ps4bvkSUKXd80X2XiS-w
 last-validated: 2026-06-24
 validation-model: claude-sonnet-4-6
 known-limitations: |

--- a/creative-skills/creative-brief-architect/SKILL.md
+++ b/creative-skills/creative-brief-architect/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: creative-brief-architect
 description: Conversational workflow to build a comprehensive creative brief. Guides users through brief intake, brand guidelines, trend-informed creative ideation, and asset requirements — then outputs a workspace note and visual grid dashboard. Use when asked to create a creative brief, plan a campaign's creative strategy, or build a brief for ad ideation.
+owner: greg.williams@treasure.ai
+tier: 2
+classification: product
+phase: 1
+demo-video: TBD
+last-validated: 2026-06-24
+validation-model: claude-sonnet-4-6
+known-limitations: |
+  Requires user to provide brand guidelines manually; no auto-fetch from Brand Hub.
+  Trend research depends on web search availability; falls back to general suggestions without it.
+  Dashboard output is static HTML; no live editing or real-time collaboration.
 ---
 
 # Creative Brief Architect

--- a/creative-skills/creative-brief-architect/SKILL.meta.yml
+++ b/creative-skills/creative-brief-architect/SKILL.meta.yml
@@ -1,0 +1,12 @@
+# Re-validation log for creative-brief-architect
+# Record each validation run: date, model, result, and notes.
+
+validations:
+  - date: 2026-06-24
+    model: claude-sonnet-4-6
+    result: pass
+    tester: greg.williams@treasure.ai
+    notes: >
+      Initial validation. Tested full 5-phase conversational flow with Purina
+      dog food campaign prompt. All phases completed, dashboard generated
+      successfully.

--- a/creative-skills/image-brand-compliance/SKILL.md
+++ b/creative-skills/image-brand-compliance/SKILL.md
@@ -5,7 +5,7 @@ owner: greg.williams@treasure.ai
 tier: 2
 classification: product
 phase: 1
-demo-video: TBD
+demo-video: https://treasure-data.zoom.us/clips/share/21YZ6AZcSQ-XjYUfDX7O7A
 last-validated: 2026-06-24
 validation-model: claude-sonnet-4-6
 known-limitations: |

--- a/creative-skills/image-brand-compliance/SKILL.md
+++ b/creative-skills/image-brand-compliance/SKILL.md
@@ -97,6 +97,14 @@ For detailed scoring criteria per dimension, see [`references/image-scoring-rubr
 
 Generate an HTML compliance dashboard and save it as `brand-compliance-report-{asset-name}.html` in the working directory.
 
+**Image embedding:** When including the reviewed image or any reference images in the HTML dashboard, always embed them as base64 data URIs (`data:image/png;base64,...`) directly in the `src` attribute. Never use local file paths — the viewer cannot resolve them. Use Python to encode:
+
+```python
+import base64
+with open("image.png", "rb") as f:
+    src = "data:image/png;base64," + base64.b64encode(f.read()).decode()
+```
+
 **Dashboard structure:**
 1. **Header** — Brand name, asset filename, overall score (large, color-coded by tier), tier label
 2. **Dimension breakdown** — 8 rows, each with score badge (0–5) and labeled progress bar

--- a/creative-skills/image-brand-compliance/SKILL.md
+++ b/creative-skills/image-brand-compliance/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: image-brand-compliance
+description: Review image files (PNG/JPEG) against brand guidelines — score visual compliance across 8 dimensions, identify violations with exact fixes, and apply corrections via Pillow or AI regeneration. Use when reviewing ad creatives, social media images, or AI-generated visuals for brand alignment. Triggers on "check this image against brand", "review this ad image", "score this creative", "is this image on-brand", "fix brand violations on this image". For HTML/email/SMS content review, use the brand-compliance skill instead.
+---
+
+# Image Brand Compliance
+
+Review image files (PNG/JPEG) against brand guidelines. Score across 8 visual compliance dimensions, identify violations with exact locations, and apply fixes when the user accepts them.
+
+For HTML emails, SMS copy, or text-based content, use the [brand-compliance](../brand-compliance/SKILL.md) skill instead. This skill focuses on pixel-level visual analysis of image files.
+
+## When to Use This Skill
+
+**Use this skill when:**
+- "Review this Instagram ad image against our brand guidelines"
+- "Check if this hero image follows brand standards"
+- "Score this AI-generated ad for brand compliance"
+- "Fix the brand violations on this PNG"
+- "Is this social media image on-brand?"
+- Validating image-gen or image-editor output before publishing
+
+**Use brand-compliance instead when:**
+- Reviewing HTML email templates, SMS copy, or text content
+- Checking legal/CAN-SPAM/TCPA compliance on email or SMS
+- Scoring content that is primarily text-based
+
+---
+
+## Inputs Required
+
+1. **Image** — file path to a PNG or JPEG (e.g., `/tmp/instagram-ad.png`)
+
+2. **Brand Guidelines** — one of:
+   - File path to markdown or PDF guidelines (e.g., `./brand-guidelines.md`)
+   - Inline text pasted into the prompt
+   - Auto-detect: look for `brand-guidelines.md` in the current working directory
+
+If either input is missing, ask for it before proceeding. If no brand guidelines are available, prompt the user to create one using [`brand-compliance/references/brand-guidelines.md`](../brand-compliance/references/brand-guidelines.md) as a template.
+
+---
+
+## Workflow
+
+### Step 1 — Parse Brand Guidelines
+
+Read the provided brand guidelines and extract image-relevant rules:
+- **Color palette**: Primary, secondary, CTA, background hex codes and usage context rules
+- **Logo**: Variants (dark/light), placement zones, minimum size, clear space, allowed backgrounds
+- **Typography**: Font families, weights, sizes for text overlays
+- **Imagery style**: Photography mood, subject framing, lighting, prohibited aesthetics
+- **Messaging lexicon**: Approved/prohibited terms, taglines, brand signature
+- **Legal marks**: Required disclosures (FTC #ad, copyright, trademarks)
+- **Accessibility**: Contrast requirements, minimum font sizes
+- **Channel specs**: Target dimensions, aspect ratios, file size limits
+
+Note which sections are unconfigured — only score against configured sections.
+
+### Step 2 — Analyze the Image
+
+Read the image file visually. Assess each compliance dimension against the extracted guidelines:
+
+- **Colors**: Sample dominant and accent colors, compare to brand palette hex codes
+- **Logo**: Check presence, variant selection, placement, clear space, size, distortion
+- **Typography**: Identify font families and sizes on text overlays, compare to brand spec
+- **Imagery mood**: Evaluate subject matter, lighting, composition, emotional tone
+- **Copy**: Read all text overlays, check against approved/prohibited terminology
+- **Legal**: Check for required marks (FTC disclosure, copyright, trademark symbols)
+- **Accessibility**: Estimate text-over-background contrast ratios, assess readability
+- **Channel fit**: Check image dimensions and aspect ratio against target channel
+
+Identify specific violations with exact location (e.g., "CTA button area uses `#FF3333` instead of brand CTA `#CC262C`").
+
+### Step 3 — Score and Report
+
+Score across **8 dimensions** (0–5 each, **40 points max**). Only score dimensions where guidelines are configured.
+
+| # | Dimension | What is checked |
+|---|-----------|----------------|
+| 1 | **Color Palette Accuracy** | Dominant colors match brand hex codes, no off-palette colors in prominent areas, correct color context usage (e.g., CTA color reserved for CTAs only) |
+| 2 | **Logo & Visual Identity** | Logo present where required, correct variant (dark/light for background), proper placement zone, adequate clear space, meets minimum size, not distorted |
+| 3 | **Typography & Text Overlays** | Correct font family on headline/body overlays, proper weight and size, readable over background, brand-consistent styling |
+| 4 | **Imagery Style & Mood** | Photography mood matches brand personality (candid vs staged), subject framing, lighting quality, avoids prohibited aesthetics (heavy filters, stock-photo feel) |
+| 5 | **Messaging & Copy** | Text overlays use approved terminology, avoid prohibited terms, match brand voice, tagline/signature present if required |
+| 6 | **Legal & Disclosures** | Required marks visible — FTC #ad for sponsored content, copyright notice, trademark symbols, disclaimers appropriately sized and placed |
+| 7 | **Accessibility** | Text overlay contrast >= 4.5:1 against background, minimum font size met, recommend alt text for the image |
+| 8 | **Channel Specifications** | Image dimensions match target channel (1080x1080 Instagram feed, 1080x1920 story, etc.), file size within limits, correct aspect ratio |
+
+**Compliance tiers:**
+- **38–40**: Fully Compliant — Ready to publish
+- **32–37**: Mostly Compliant — Minor fixes needed
+- **24–31**: Partially Compliant — Significant issues
+- **0–23**: Non-Compliant — Major revision required
+
+For detailed scoring criteria per dimension, see [`references/image-scoring-rubric.md`](references/image-scoring-rubric.md).
+
+### Step 4 — Render HTML Compliance Dashboard
+
+Generate an HTML compliance dashboard and save it as `brand-compliance-report-{asset-name}.html` in the working directory.
+
+**Dashboard structure:**
+1. **Header** — Brand name, asset filename, overall score (large, color-coded by tier), tier label
+2. **Dimension breakdown** — 8 rows, each with score badge (0–5) and labeled progress bar
+3. **Violations list** — collapsible `<details>`, grouped by dimension, each with: what was found, where in the image, exact fix recommendation
+4. **Recommendations** — collapsible `<details>`, prioritized Critical > High > Medium > Low, each with projected score impact
+5. **Action prompt** — "Type 'apply fixes' to implement all critical and high-priority changes"
+
+Open with `mcp__work__open_file` if available. If the MCP tool is unavailable, print the file path for the user to open manually.
+
+Also summarize violations in plain text in the chat so the user can act without switching to the dashboard.
+
+### Step 5 — Apply Fixes (on user acceptance)
+
+When the user says "apply fixes", "yes", "make the changes", or accepts specific fixes:
+
+**Prerequisites check**: Before running any Pillow scripts, verify the dependency:
+```bash
+python3 -c "import PIL" 2>/dev/null || echo "MISSING"
+```
+If missing, instruct the user to run `pip install Pillow` before proceeding.
+
+**Fix methods by violation type:**
+
+| Violation type | Fix method |
+|----------------|-----------|
+| Text overlay color or position | Python (Pillow) — composite corrected text over image |
+| Logo missing or misplaced | Python (Pillow) — composite logo at correct position with clear space |
+| Color overlay or tint correction | Python (Pillow) — apply color adjustment |
+| Wrong dimensions or aspect ratio | Python (Pillow) — resize/crop to target specs |
+| Wrong subject, mood, or composition | Regenerate with `mcp__work__generate_image` using a corrected prompt built from brand guidelines. If the MCP tool is unavailable, provide the corrected prompt for the user to run with the [image-gen](../multi-channel-ad-ideation/channels/image-gen/SKILL.md) skill. |
+
+For Python/Pillow edits: write a self-contained script to a temp file, run it with Bash, save the corrected image alongside the original (e.g., `{name}-fixed.png`).
+
+After all fixes are applied, **re-run the full scoring analysis** on the updated image and produce a new compliance dashboard showing:
+- New overall score and tier
+- Per-dimension delta (e.g., "Color Palette: 2 -> 5")
+- Remaining violations (if any)
+- Confirmation of what was changed
+
+---
+
+## Output Format
+
+### Plain-text summary (always show in chat)
+
+```
+Brand Compliance Score: [X]/40 — [Tier]
+
+Violations ([N] found):
+1. [Dimension] — [what] at [location]
+   Fix: [exact change]
+2. ...
+
+Type 'apply fixes' to implement all changes.
+```
+
+### After fixes (re-score)
+
+```
+Updated Score: [X]/40 — [Tier]  (was [Y]/40)
+
+Changes applied:
+- [Fix 1]
+- [Fix 2]
+
+Remaining: [N violations] — [list or "None — fully compliant"]
+```
+
+---
+
+## Edge Cases
+
+- **Unconfigured guideline sections**: Note which dimensions were skipped and why. Do not penalize for rules that are not defined.
+- **Multiple images**: If the user provides 2+ images, score each independently then note cross-image consistency issues.
+- **Partial acceptance**: If user says "apply only the color fixes" or "skip the logo", apply only the accepted changes and re-score accordingly.
+- **No brand guidelines available**: Prompt the user to provide them. Point to [`brand-compliance/references/brand-guidelines.md`](../brand-compliance/references/brand-guidelines.md) as a template to follow.
+- **Pillow not installed**: Detect before attempting fixes. Provide install instructions. Do not attempt Python image edits without confirming the dependency.
+- **Image too large or corrupted**: Report the issue and ask the user to provide a valid image file.
+
+---
+
+## Best Practices
+
+- Provide brand guidelines with exact hex codes, not just color names — "Burnt Ochre `#B35D33`" enables precise matching
+- Include logo files (dark and light variants) in the guidelines so fixes can composite them automatically
+- Specify the target channel (Instagram feed, story, display ad) so channel specifications can be scored
+- Run image-brand-compliance after using the image-gen or image-editor skills to catch issues before publishing
+- For HTML emails or text content, use brand-compliance instead — it has channel-specific scoring for email/SMS/Instagram copy
+
+---
+
+## Related Skills
+
+- **[brand-compliance](../brand-compliance/SKILL.md)** — Review HTML, email, SMS, and text content against brand guidelines (8-dimension, 0–40 scoring). Use for non-image content.
+- **[image-gen](../multi-channel-ad-ideation/channels/image-gen/SKILL.md)** — Generate ad images with AI + text/logo compositing. Run image-brand-compliance on the output to validate.
+- **[image-editor](../multi-channel-ad-ideation/channels/image-editor/SKILL.md)** — Interactive drag-and-drop editor for image overlays. Use to manually adjust before re-scoring.
+- **[multi-channel-ad-ideation](../multi-channel-ad-ideation/SKILL.md)** — Orchestrate full campaign ideation across channels. Brand guidelines are applied during ideation; use this skill for post-production validation.
+
+---
+
+## Example
+
+For a complete worked example showing an image review, scoring, violation identification, fix application, and re-scoring, see [`examples/image-review-example.md`](examples/image-review-example.md).

--- a/creative-skills/image-brand-compliance/SKILL.md
+++ b/creative-skills/image-brand-compliance/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: image-brand-compliance
 description: Review image files (PNG/JPEG) against brand guidelines — score visual compliance across 8 dimensions, identify violations with exact fixes, and apply corrections via Pillow or AI regeneration. Use when reviewing ad creatives, social media images, or AI-generated visuals for brand alignment. Triggers on "check this image against brand", "review this ad image", "score this creative", "is this image on-brand", "fix brand violations on this image". For HTML/email/SMS content review, use the brand-compliance skill instead.
+owner: greg.williams@treasure.ai
+tier: 2
+classification: product
+phase: 1
+demo-video: TBD
+last-validated: 2026-06-24
+validation-model: claude-sonnet-4-6
+known-limitations: |
+  Requires Pillow (pip install Pillow) for automated image fixes; prompts user if missing.
+  AI image regeneration depends on mcp__work__generate_image availability.
+  Color matching is visual estimate, not pixel-exact sampling.
 ---
 
 # Image Brand Compliance

--- a/creative-skills/image-brand-compliance/SKILL.md
+++ b/creative-skills/image-brand-compliance/SKILL.md
@@ -5,7 +5,7 @@ owner: greg.williams@treasure.ai
 tier: 2
 classification: product
 phase: 1
-demo-video: https://treasure-data.zoom.us/clips/share/21YZ6AZcSQ-XjYUfDX7O7A
+demo-video: https://treasure-data.zoom.us/clips/share/s2LMtkS-QnK4RFAJ_MgnsA
 last-validated: 2026-06-24
 validation-model: claude-sonnet-4-6
 known-limitations: |

--- a/creative-skills/image-brand-compliance/SKILL.meta.yml
+++ b/creative-skills/image-brand-compliance/SKILL.meta.yml
@@ -1,0 +1,12 @@
+# Re-validation log for image-brand-compliance
+# Record each validation run: date, model, result, and notes.
+
+validations:
+  - date: 2026-06-24
+    model: claude-sonnet-4-6
+    result: pass
+    tester: greg.williams@treasure.ai
+    notes: >
+      Initial validation. Tested 8-dimension scoring against brand guidelines,
+      HTML dashboard generation with base64 image embedding, and fix-application
+      workflow via Pillow.

--- a/creative-skills/image-brand-compliance/examples/image-review-example.md
+++ b/creative-skills/image-brand-compliance/examples/image-review-example.md
@@ -1,0 +1,163 @@
+# Example: Image Brand Compliance Review
+
+## Scenario
+
+A marketing team at **TailTrail Pet Nutrition** needs to validate an Instagram feed ad image (`tailtrail-summer-sale.png`) against their brand guidelines before publishing.
+
+---
+
+## Brand Guidelines (excerpt)
+
+```
+Brand: TailTrail Pet Nutrition
+Tagline: "Real food. Real happy."
+
+Colors:
+  Primary: Deep Forest #2D5F3B
+  Secondary: Warm Gold #D4A843
+  CTA: Sunset Orange #E8733A (reserved exclusively for CTA elements)
+  Background: Soft Cream #FFF8F0
+  Text: Charcoal #333333
+
+Logo:
+  Dark variant: tailtrail-logo-dark.png (for light backgrounds)
+  Light variant: tailtrail-logo-light.png (for dark backgrounds)
+  Placement: Top-right or bottom-left
+  Minimum size: 80px width
+  Clear space: 16px on all sides
+
+Typography:
+  Headings: Nunito Bold, 36-48px
+  Body: Open Sans Regular, 16-24px
+  Style: Sentence case (not ALL CAPS)
+
+Imagery Style:
+  Mood: Warm, authentic, joyful — real pets in real homes
+  Lighting: Natural, soft light preferred
+  Prohibited: Stock-photo poses, studio-white backgrounds, heavy filters
+
+Messaging:
+  Approved terms: Wholesome, Farm-sourced, Tail-approved, Vet-recommended
+  Prohibited terms: Cheap, Budget, All-natural (unsubstantiated), Miracle
+  Voice: Friendly, knowledgeable, playful
+
+Legal:
+  Copyright: "© 2026 TailTrail Pet Nutrition" required on all assets
+  Sponsored: FTC "#ad" disclosure required on paid placements
+
+Accessibility:
+  Text contrast: >= 4.5:1 against background
+  Minimum font size: 18px for body text
+
+Channel:
+  Instagram Feed: 1080x1080, max 30MB
+```
+
+---
+
+## Step 1 — Analysis
+
+Claude reads the image `tailtrail-summer-sale.png` and identifies:
+
+- **Headline text**: "SUMMER BLOWOUT — CHEAP EATS FOR YOUR PUP!" in white Impact font
+- **Background**: Studio-lit product shot on white backdrop
+- **Colors**: Red (#FF0000) CTA banner, white background, black text
+- **Logo**: Absent
+- **Legal marks**: No copyright, no #ad disclosure
+- **Dimensions**: 1200x628 (landscape, not square)
+
+---
+
+## Step 2 — Scoring
+
+| # | Dimension | Score | Notes |
+|---|-----------|-------|-------|
+| 1 | Color Palette Accuracy | 1/5 | Red CTA (#FF0000) should be Sunset Orange (#E8733A). White background instead of Soft Cream (#FFF8F0). No Deep Forest or Warm Gold present. |
+| 2 | Logo & Visual Identity | 0/5 | Logo completely absent. |
+| 3 | Typography & Text Overlays | 1/5 | Impact font instead of Nunito Bold. ALL CAPS instead of sentence case. |
+| 4 | Imagery Style & Mood | 1/5 | Studio-white background (prohibited). Product-only shot, no pets in real-home setting. Feels like stock photography. |
+| 5 | Messaging & Copy | 0/5 | Uses prohibited term "Cheap". No approved terms present. Tone is aggressive/discount-focused, not friendly/playful. Missing tagline. |
+| 6 | Legal & Disclosures | 0/5 | No copyright notice. No #ad disclosure (assuming paid placement). |
+| 7 | Accessibility | 3/5 | White text on red banner has ~4:1 contrast (just below 4.5:1 threshold). Font size appears adequate. |
+| 8 | Channel Specifications | 1/5 | 1200x628 (1.91:1 landscape) instead of 1080x1080 (1:1 square) for Instagram feed. |
+
+**Overall: 7/40 — Non-Compliant**
+
+---
+
+## Step 3 — Report Output
+
+```
+Brand Compliance Score: 7/40 — Non-Compliant
+
+Violations (9 found):
+1. Color Palette — CTA banner uses #FF0000, should be Sunset Orange #E8733A
+   Fix: Recolor CTA banner to #E8733A
+2. Color Palette — White background, should be Soft Cream #FFF8F0
+   Fix: Apply #FFF8F0 background tint
+3. Logo & Visual Identity — Logo absent
+   Fix: Composite tailtrail-logo-dark.png in top-right corner, 80px+ width, 16px clear space
+4. Typography — Impact font, should be Nunito Bold
+   Fix: Re-render headline in Nunito Bold, sentence case
+5. Typography — ALL CAPS headline, should be sentence case
+   Fix: Change to "Summer blowout — great eats for your pup!"
+6. Imagery Style — Studio-white background (prohibited), no pets in real-home setting
+   Fix: Regenerate image with brand-compliant prompt
+7. Messaging — Prohibited term "Cheap" used
+   Fix: Replace with approved term "Wholesome" or "Farm-sourced"
+8. Legal — No copyright notice
+   Fix: Add "© 2026 TailTrail Pet Nutrition" in bottom margin
+9. Channel Specs — 1200x628 instead of 1080x1080 for Instagram feed
+   Fix: Crop/resize to 1080x1080
+
+Type 'apply fixes' to implement all changes.
+```
+
+An HTML compliance dashboard is saved as `brand-compliance-report-tailtrail-summer-sale.html` with color-coded progress bars and collapsible violation details.
+
+---
+
+## Step 4 — User Accepts Fixes
+
+User types: "apply fixes"
+
+**Fix sequence:**
+
+1. **Image regeneration** (violations 6): Generate new image via AI with prompt built from brand guidelines:
+   > "A golden retriever eating from a bowl in a sunny kitchen, warm natural lighting, authentic candid moment, soft cream tones, joyful mood — TailTrail Pet Nutrition brand style"
+
+2. **Color correction** (violations 1, 2): Pillow script adjusts CTA banner to `#E8733A`, background areas to `#FFF8F0`
+
+3. **Logo composite** (violation 3): Pillow script composites `tailtrail-logo-dark.png` at top-right, 90px wide, 16px clear space
+
+4. **Text re-render** (violations 4, 5, 7): Pillow script composites new headline "Summer sale — wholesome eats for your pup!" in Nunito Bold, sentence case, with gradient backdrop
+
+5. **Legal text** (violation 8): Pillow script adds "© 2026 TailTrail Pet Nutrition" at bottom, 14px Open Sans
+
+6. **Resize** (violation 9): Pillow script crops and resizes to 1080x1080
+
+Output saved as `tailtrail-summer-sale-fixed.png`.
+
+---
+
+## Step 5 — Re-score
+
+```
+Updated Score: 36/40 — Mostly Compliant  (was 7/40)
+
+Changes applied:
+- Regenerated image with authentic pet-in-home scene
+- CTA banner recolored to #E8733A
+- Background adjusted to Soft Cream #FFF8F0
+- Logo composited top-right (90px, 16px clear space)
+- Headline re-rendered in Nunito Bold, sentence case
+- Prohibited term "Cheap" replaced with "Wholesome"
+- Copyright notice added
+- Resized to 1080x1080
+
+Remaining: 2 violations
+- Accessibility: Copyright text at 14px, below 18px minimum — increase to 18px
+- Messaging: Brand tagline "Real food. Real happy." not present — consider adding
+```
+
+A new dashboard is saved as `brand-compliance-report-tailtrail-summer-sale-fixed.html` showing the score improvement per dimension.

--- a/creative-skills/image-brand-compliance/references/image-scoring-rubric.md
+++ b/creative-skills/image-brand-compliance/references/image-scoring-rubric.md
@@ -1,0 +1,152 @@
+# Image Scoring Rubric
+
+8-dimension scoring for image brand compliance. Each dimension is scored 0–5, for a maximum of 40 points.
+
+Only score dimensions where brand guidelines provide relevant rules. If a dimension has no configured guidelines, mark it as "Not Scored" and exclude from the total.
+
+---
+
+## 1. Color Palette Accuracy (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | No brand colors used. Dominant palette is entirely off-brand. |
+| 1 | One brand color present but used incorrectly (wrong context). Most colors off-palette. |
+| 2 | Some brand colors present. 1–2 prominent off-palette colors or context violations (e.g., CTA color used for background). |
+| 3 | Primary brand colors correct. Minor off-palette accents in non-prominent areas. |
+| 4 | All prominent colors match brand palette. One minor deviation in a secondary element. |
+| 5 | All colors match brand hex codes exactly. Color context rules followed (CTA reserved for CTAs, background colors in backgrounds). |
+
+**What to check**: Sample the dominant, accent, background, and CTA-area colors in the image. Compare each to the brand palette hex codes. Verify color context rules (e.g., "Burnt Ochre reserved exclusively for CTAs").
+
+---
+
+## 2. Logo & Visual Identity (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | Logo absent when required. |
+| 1 | Logo present but severely misused — distorted, wrong variant for background, or placed over busy imagery without clear space. |
+| 2 | Logo present, correct variant, but placement or size violates guidelines (wrong zone, too small, insufficient clear space). |
+| 3 | Logo correct variant and placement. Minor clear space or sizing issue. |
+| 4 | Logo fully compliant. One negligible issue (e.g., clear space 1–2px short). |
+| 5 | Logo perfect — correct variant (dark on light / light on dark), correct placement zone, adequate clear space, meets minimum size, no distortion. |
+
+**What to check**: Is the logo present? Is it the correct variant for the background luminance? Is it in an approved placement zone (typically top-left or bottom-right)? Does it meet minimum size requirements? Is there adequate clear space around it? Is it distorted or stretched?
+
+---
+
+## 3. Typography & Text Overlays (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | No text overlays match brand typography. Wrong fonts throughout. |
+| 1 | Font family partially correct (e.g., generic sans-serif instead of specified brand font). Sizes/weights wrong. |
+| 2 | Correct font family but wrong weight, size, or styling. Or correct styling but wrong font. |
+| 3 | Font family and weight correct. Minor size deviation. Text readable but styling could be tighter. |
+| 4 | Typography fully compliant. One minor issue (e.g., line spacing slightly off). |
+| 5 | All text overlays use the correct font family, weight, and size per brand spec. Headline and body treatments distinct and consistent with guidelines. |
+
+**What to check**: Identify all text overlays in the image. Check font family (serif vs sans-serif, specific brand font), weight (bold, regular, light), size relative to image dimensions, and any brand-specific styling rules (e.g., "headlines always uppercase").
+
+---
+
+## 4. Imagery Style & Mood (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | Completely wrong aesthetic — e.g., brand requires authentic/candid but image is stock-photo/staged. Multiple prohibited elements. |
+| 1 | General mood wrong. Subject matter or setting inappropriate. Heavy filters or effects that violate guidelines. |
+| 2 | Subject matter appropriate but execution misses brand mood. Lighting, composition, or framing doesn't match guidelines. |
+| 3 | Mood mostly right. Subject and setting aligned. Minor execution issues (slightly wrong lighting style, framing could be tighter). |
+| 4 | Imagery strongly aligned with brand personality. One subtle deviation in composition or lighting. |
+| 5 | Photography mood, subject framing, lighting, and composition all match brand personality exactly. No prohibited aesthetics. Feels distinctly on-brand. |
+
+**What to check**: Does the image feel like it belongs to this brand? Compare against brand imagery guidelines: mood (candid vs polished), subject matter (people, products, lifestyle), lighting (natural vs studio), composition rules, and explicitly prohibited aesthetics (e.g., "no heavy filters", "no stock-photo poses").
+
+---
+
+## 5. Messaging & Copy (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | Text overlays use multiple prohibited terms. Brand voice completely wrong. |
+| 1 | Prohibited terms present. Tone mismatched to context. No brand tagline or signature where required. |
+| 2 | No prohibited terms, but approved power words not used. Tone partially matched. Missing tagline. |
+| 3 | Correct tone. Uses some approved terms. Tagline present but minor wording issue. |
+| 4 | Voice and terminology fully compliant. One minor copy improvement possible. |
+| 5 | All text overlays use approved terminology, avoid prohibited terms, match brand voice for the content context, and include required tagline/signature. |
+
+**What to check**: Read all visible text in the image. Check against the brand's approved and prohibited term lists. Assess voice — does the copy match the specified tone for this content type? Is the brand tagline or signature present where required?
+
+---
+
+## 6. Legal & Disclosures (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | Required legal marks completely absent (e.g., sponsored content with no FTC disclosure). |
+| 1 | Some required marks missing. Present marks are too small to read or hidden. |
+| 2 | All required marks present but placement or sizing violates guidelines (e.g., #ad in tiny text at edge). |
+| 3 | Marks present and readable. Minor placement issue (e.g., slightly outside recommended zone). |
+| 4 | Fully compliant. One negligible issue (e.g., trademark symbol could be slightly larger). |
+| 5 | All required marks present, correctly sized, properly placed — FTC #ad disclosure (if sponsored), copyright notice, trademark symbols, any required disclaimers. |
+
+**What to check**: Is this sponsored content? If yes, is "#ad" or "Sponsored" visible and prominent? Are trademark and copyright symbols present where required? Are any mandatory disclaimers included and readable? Check size — legal text must be legible, not hidden.
+
+---
+
+## 7. Accessibility (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | Text overlays unreadable — very low contrast, tiny font, no consideration for accessibility. |
+| 1 | Major contrast failures on primary text. Body text below minimum size. |
+| 2 | Headline readable but body text contrast or size fails. Or contrast passes but font size doesn't. |
+| 3 | Primary text passes contrast (>= 4.5:1). Minor issue on secondary text or smaller elements. |
+| 4 | All text meets contrast and size requirements. Alt text recommendation provided. |
+| 5 | All text overlays >= 4.5:1 contrast against background, font sizes meet minimums, gradient/backdrop used for readability, and alt text recommended for the image. |
+
+**What to check**: Estimate contrast ratio of text overlays against their immediate background. Check if gradient backdrops or text shadows are used to ensure readability. Verify font sizes meet brand minimums. Recommend appropriate alt text for the image.
+
+---
+
+## 8. Channel Specifications (0–5)
+
+| Score | Criteria |
+|-------|----------|
+| 0 | Wrong dimensions and aspect ratio for target channel. Image would display incorrectly. |
+| 1 | Aspect ratio approximately right but dimensions significantly wrong. File size way over limits. |
+| 2 | Dimensions close but not exact. Minor aspect ratio issue. File size borderline. |
+| 3 | Correct aspect ratio. Dimensions within 5% of target. File size acceptable. |
+| 4 | Dimensions correct. One minor spec issue (e.g., file size slightly above recommendation). |
+| 5 | Exact dimensions for target channel (e.g., 1080x1080 Instagram feed), correct aspect ratio, file size within limits, correct color space. |
+
+**Common channel specs:**
+- Instagram Feed: 1080x1080 (1:1), max 30MB
+- Instagram Story: 1080x1920 (9:16), max 30MB
+- Facebook Feed: 1200x628 (1.91:1), max 30MB
+- Display Ad (Medium Rectangle): 300x250
+- Display Ad (Leaderboard): 728x90
+
+**What to check**: What channel is this image targeting? Check actual pixel dimensions against the channel spec. Verify aspect ratio. Check file size.
+
+---
+
+## Compliance Tiers
+
+| Score Range | Tier | Meaning |
+|-------------|------|---------|
+| 38–40 | Fully Compliant | Ready to publish. No changes needed. |
+| 32–37 | Mostly Compliant | Minor fixes needed. Typically 1–2 low-severity violations. |
+| 24–31 | Partially Compliant | Significant issues. Multiple violations across dimensions. |
+| 0–23 | Non-Compliant | Major revision required. Fundamental brand alignment problems. |
+
+## Handling Unconfigured Dimensions
+
+When brand guidelines don't cover a dimension (e.g., no legal requirements specified, no channel target provided):
+
+1. Mark the dimension as **"Not Scored — no guidelines configured"**
+2. Exclude it from the denominator: if 6 of 8 dimensions are configured, score is out of 30, not 40
+3. Adjust tier thresholds proportionally: Fully Compliant = 95%+, Mostly = 80%+, Partially = 60%+, Non-Compliant = below 60%
+4. Note the unconfigured dimensions in the report and suggest the user add those sections to their guidelines


### PR DESCRIPTION
## Summary
- Adds `creative-brief-architect` skill — conversational 5-phase workflow for building comprehensive creative briefs (intake, brand, ideation, assets, output)
- Adds `image-brand-compliance` skill — review image files against brand guidelines with 8-dimension scoring, violation identification, and Pillow/AI-based fix application
- Adds `brand-guidelines.md` reference example for brand-compliance (Outdoor Supply Co.)
- Registers both new skills in `.claude-plugin/marketplace.json` under the `creative-skills` plugin

## Test plan
- [ ] Install locally: `/plugin marketplace add` + `/plugin install creative-skills@td-skills`
- [ ] Test creative-brief-architect: "Use the creative-brief-architect skill to create an ad for purina dog food which highlights the 20% off dog food using the brand guidelines and logo found in /tmp/purina"
- [ ] Verify 5-phase conversational flow (intake → brand → ideation → assets → output)
- [ ] Test image-brand-compliance: "Use the image-brand-compliance skill to review this ad image against brand guidelines"
- [ ] Verify HTML compliance dashboard renders with embedded base64 images (not file paths)
- [ ] Verify all cross-references resolve (brand-compliance, image-gen, image-editor, grid-dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)