### PR TITLE
image-gen: use tas-imggen (gpt2 image model) as primary generator

### DIFF
--- a/creative-skills/multi-channel-ad-ideation/channels/image-gen/SKILL.md
+++ b/creative-skills/multi-channel-ad-ideation/channels/image-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-gen
-description: Generate real Instagram image ads with AI-generated visuals and text overlays. Combines TD Creative Studio image generation with headline compositing via Pillow. Use when user wants to create Instagram ad images, generate ad visuals with text, or produce shareable ad PNGs. Trigger keywords: instagram ad image, generate ad image, image ad with text, ad visual, create instagram ad.
+description: Generate real Instagram image ads with AI-generated visuals and text overlays. Combines tas-imggen AI image generation (TD Creative Studio as backup) with headline compositing via Pillow. Use when user wants to create Instagram ad images, generate ad visuals with text, or produce shareable ad PNGs. Trigger keywords: instagram ad image, generate ad image, image ad with text, ad visual, create instagram ad.
 ---
 
 # Instagram Image Ad Generation
@@ -14,7 +14,7 @@ This skill chains three systems together:
 ```
 Creative Ideation (concept + copy)
     ↓
-TD Creative Studio Agent (AI image generation from concept description)
+tas-imggen CLI (AI image generation — TD Creative Studio agent as backup)
     ↓
 Pillow Text Compositor (headline overlay on generated image)
     ↓
@@ -45,10 +45,10 @@ Generate **3-5 Instagram image ad concepts** in this text-only format:
 [Combine the visual concept description with the primary text theme into a rich,
 detailed prompt for AI image generation. **If Description text is provided, incorporate
 it into the prompt context.** Include composition, lighting, color palette, mood, style,
-and any specific visual elements. This is what gets sent to the TD Creative Studio
-Image Generation Agent.]
+and any specific visual elements. This is what gets sent to the image generator
+(`tas-imggen`, or the TD Creative Studio agent as backup).]
 
-- **Dimensions**: 1024x1024 (will be generated at this size)
+- **Dimensions**: 1080x1080 (Instagram feed; generated at this size — use 1080x1920 for stories/reels)
 - **Style**: [Photorealistic, illustration, flat design, etc.]
 - **Mood/Tone**: [Energetic, calm, luxurious, urgent, etc.]
 - **Key Visual Elements**: [Specific objects, scenes, or compositions to include]
@@ -87,17 +87,22 @@ When triggered, execute the full pipeline for each confirmed concept.
 
 ## Execution Pipeline
 
-### Step 1: Set Project Context
+### Step 1: Generate the Base Image (Primary — `tas-imggen` CLI)
+
+Send the **Image Generation Prompt** from the confirmed concept to the `tas-imggen` tool, which writes the PNG directly to the output path — no project context, chat session, or extraction step required:
+
+```bash
+tas-imggen generate --prompt "<Image Generation Prompt from confirmed concept>" --size 1080x1080 --quality high -o <concept_name>_base.png
+```
+
+Set `--size` to the exact target Instagram placement — `1080x1080` for feed (default here), `1080x1920` for stories/reels. Generate multiple confirmed concepts in parallel (background tasks), each with its own `-o <concept_name>_base.png`. Once the base image exists, skip Steps 2–3 and proceed to Step 3.5.
+
+### Step 2: Generate the Base Image (Backup — TD Creative Studio Agent)
+
+**Only if `tas-imggen` is unavailable or errors.** Set the project context, then send the prompt to the TD agent:
 
 ```bash
 tdx use llm_project "TD-Managed: Creative Studio"
-```
-
-### Step 2: Generate the Base Image
-
-Send the **Image Generation Prompt** from the confirmed concept to the TD agent:
-
-```bash
 tdx chat --stream \
   --new \
   --agent "TD-Managed: Creative Studio/TD-Managed: Image Generation Agent" \
@@ -111,7 +116,7 @@ Parse the `chatId` from the metadata event in the stream output:
 {"type":"metadata","data":{"chatId":"<CHAT_ID>"}}
 ```
 
-### Step 3: Extract Image from Chat History
+### Step 3: Extract Image from Chat History (Backup only)
 
 ```bash
 tdx llm history "<CHAT_ID>"
@@ -370,7 +375,7 @@ Optional additional context, often hidden in feed.
 
 ## Image Generation Prompt Tips
 
-The TD Creative Studio Image Generation Agent uses Amazon Bedrock Nova Canvas (default 1024x1024).
+The primary generator is the `tas-imggen` CLI; set `--size` to the exact target placement (1080x1080 for Instagram feed, 1080x1920 for stories/reels). The TD Creative Studio backup uses Amazon Bedrock Nova Canvas (fixed 1024x1024).
 
 - **Do**: Be descriptive (composition, lighting, colors, mood, textures), specify style explicitly ("photorealistic", "digital illustration"), include negative prompts, leave visual breathing room where headline will go
 - **Don't**: Request copyrighted characters/brand logos, use vague descriptions, forget to leave clean space in the text position area
@@ -384,7 +389,7 @@ The TD Creative Studio Image Generation Agent uses Amazon Bedrock Nova Canvas (d
 | Primary Text | Instagram caption + informs image generation theme |
 | Headline | Text composited onto the generated image |
 | Description | Instagram ad description field + enriches image generation prompt when available |
-| Image Generation Prompt | Sent to TD Creative Studio Image Gen Agent |
+| Image Generation Prompt | Sent to the image generator (`tas-imggen`, Creative Studio backup) |
 | Headline Overlay Style | Controls Pillow text compositing parameters |
 
 ---

--- a/creative-skills/multi-channel-ad-ideation/channels/image-gen/SKILL.md
+++ b/creative-skills/multi-channel-ad-ideation/channels/image-gen/SKILL.md
@@ -87,6 +87,8 @@ When triggered, execute the full pipeline for each confirmed concept.
 
 ## Execution Pipeline
 
+**Output filename contract:** Save the **final** composited image as `<placement>-ad-<concept-slug>-<timestamp>.png` — e.g. `instagram-feed-ad-summer-sale-20260708-143022.png`. `<placement>` is derived from the target size (`instagram-feed` for 1080×1080, `instagram-story` for 1080×1920 stories/reels), `<concept-slug>` is the kebab-cased concept name, and `<timestamp>` is `YYYYMMDD-HHMMSS`. Downstream skills auto-detect this output by globbing `instagram-*-ad-*.png` and picking the most recent by modification time — the placement prefix keeps Instagram assets distinct from other channels' images. Intermediate working files (`_base.png`, `_with_logo.png`) are transient and keep the concept slug.
+
 ### Step 1: Generate the Base Image (Primary — `tas-imggen` CLI)
 
 Send the **Image Generation Prompt** from the confirmed concept to the `tas-imggen` tool, which writes the PNG directly to the output path — no project context, chat session, or extraction step required:
@@ -278,13 +280,13 @@ if SUBTITLE_TEXT:
         draw.text((sx+ox, sy+oy), SUBTITLE_TEXT, fill=(0,0,0,180), font=subtitle_font)
     draw.text((sx, sy), SUBTITLE_TEXT, fill=SUBTITLE_COLOR, font=subtitle_font)
 
-img.convert("RGB").save("<concept_name>_final.png", "PNG", quality=95)
+img.convert("RGB").save("<placement>-ad-<concept-slug>-<timestamp>.png", "PNG", quality=95)  # e.g. instagram-feed-ad-summer-sale-20260708-143022.png
 ```
 
 ### Step 5: Display the Final Image
 
 ```
-open_file(path: "<concept_name>_final.png")
+open_file(path: "<placement>-ad-<concept-slug>-<timestamp>.png")
 ```
 
 ### Step 5b: HTML Ad — Embed Image as Base64 (Required)
@@ -296,7 +298,7 @@ Always embed the final PNG as a base64 data URI:
 ```python
 import base64
 
-with open("<concept_name>_final.png", "rb") as f:
+with open("<placement>-ad-<concept-slug>-<timestamp>.png", "rb") as f:
     b64 = base64.b64encode(f.read()).decode()
 
 data_uri = f"data:image/png;base64,{b64}"

--- a/creative-skills/multi-channel-ad-ideation/channels/image-gen/SKILL.md
+++ b/creative-skills/multi-channel-ad-ideation/channels/image-gen/SKILL.md
@@ -287,6 +287,29 @@ img.convert("RGB").save("<concept_name>_final.png", "PNG", quality=95)
 open_file(path: "<concept_name>_final.png")
 ```
 
+### Step 5b: HTML Ad — Embed Image as Base64 (Required)
+
+When generating an HTML ad mockup, **never reference the PNG via a relative file path**. The HTML must be fully self-contained so it renders correctly regardless of where it is opened.
+
+Always embed the final PNG as a base64 data URI:
+
+```python
+import base64
+
+with open("<concept_name>_final.png", "rb") as f:
+    b64 = base64.b64encode(f.read()).decode()
+
+data_uri = f"data:image/png;base64,{b64}"
+```
+
+Then write the HTML with the data URI inline:
+
+```html
+<img src="data:image/png;base64,{{ b64 }}" alt="..." />
+```
+
+**Why**: A relative `src="image.png"` breaks whenever the HTML file is opened from a different directory, sent via email, or viewed in an artifact panel. A self-contained data URI works everywhere, first time, every time.
+
 ### Step 6: Iteration Support
 
 After displaying, offer the user iteration options:

--- a/creative-skills/multi-channel-ad-ideation/channels/instagram/SKILL.md
+++ b/creative-skills/multi-channel-ad-ideation/channels/instagram/SKILL.md
@@ -99,7 +99,7 @@ Generate **3-5 Instagram image ad concepts** using **table format** for easy sid
 **HTML Generation and Preview Workflow** (complete all steps):
 1. Read `../references/html-preview-templates.md`
 2. **Check for generated image** (auto-background enhancement):
-   - Use Glob to find `instagram-ad-*.png` files in working directory
+   - Use Glob to find `instagram-*-ad-*.png` files in working directory
    - Sort by modification time (most recent first)
    - If found: Read PNG as binary and convert to base64 string
    - If not found: Use placeholder/emoji approach (current behavior)
@@ -112,7 +112,7 @@ Generate **3-5 Instagram image ad concepts** using **table format** for easy sid
 
 **Important workflow requirement**: After generating HTML for Instagram, always complete steps 4 and 5 automatically. Write the HTML to a file and immediately open it with `mcp__tdx-studio__open_file`. This ensures the user sees the preview without needing to ask for it.
 
-**Image Integration Note**: If you previously generated an image using the image-gen skill, this workflow will automatically detect the most recent `instagram-ad-*.png` file and use it as the background image in the HTML preview. This creates a more realistic preview with actual AI-generated visuals instead of placeholders.
+**Image Integration Note**: If you previously generated an image using the image-gen skill, this workflow will automatically detect the most recent `instagram-*-ad-*.png` file and use it as the background image in the HTML preview. This creates a more realistic preview with actual AI-generated visuals instead of placeholders.
 
 Example:
 ```markdown
@@ -143,7 +143,7 @@ This skill automatically integrates with the `image-gen` skill to create more re
 **How it works**:
 1. If you generate an actual Instagram ad image using the `image-gen` skill first
 2. When you then generate HTML mockups with this skill, it will:
-   - Auto-detect the most recent `instagram-ad-*.png` file in the working directory
+   - Auto-detect the most recent `instagram-*-ad-*.png` file in the working directory
    - Convert the PNG to base64 format
    - Embed it as the background image in the HTML preview
    - Result: HTML mockup shows the actual AI-generated image instead of placeholder
@@ -151,14 +151,14 @@ This skill automatically integrates with the `image-gen` skill to create more re
 **Example workflow**:
 ```
 User: "Generate an Instagram ad image for hiking boots"
-[image-gen skill creates instagram-ad-20250316-143022.png]
+[image-gen skill creates instagram-feed-ad-hiking-boots-20260708-143022.png]
 
 User: "Now show me the HTML mockup"
 [This skill detects the PNG, converts to base64, embeds in HTML]
 Result: HTML preview displays with the actual generated hiking boots image as background
 ```
 
-**Fallback**: If no `instagram-ad-*.png` file is found, the HTML mockup uses the standard placeholder/emoji approach.
+**Fallback**: If no `instagram-*-ad-*.png` file is found, the HTML mockup uses the standard placeholder/emoji approach.
 
 ## Copy Constraints
 

--- a/creative-skills/multi-channel-ad-ideation/references/delegation-examples.md
+++ b/creative-skills/multi-channel-ad-ideation/references/delegation-examples.md
@@ -186,7 +186,7 @@ After user confirms text concepts, delegate Phase 2 to channel skills:
 [Read channels/instagram/SKILL.md Phase 2 section]
 [Follow HTML Generation and Preview Workflow]
 [MANDATORY: Write HTML file + call mcp__tdx-studio__open_file]
-[Auto-detect instagram-ad-*.png if using image-gen skill]
+[Auto-detect instagram-*-ad-*.png if using image-gen skill]
 ```
 
 ## Maintaining Context Across Delegations


### PR DESCRIPTION
## Summary
Migrates the `image-gen` skill to generate images through the **`tas-imggen` CLI** (which unlocks the **gpt2 image model**) as the **primary** path, with the TD Creative Studio agent retained as a **backup**.

- **Primary — `tas-imggen`:** writes the PNG directly to the output path, removing the `tdx chat` → `tdx llm history` → `binaryBase64` extraction flow from the happy path.
- **Backup — TD Creative Studio:** the full `tdx` flow is preserved as Steps 2–3, used only when `tas-imggen` is unavailable or errors.
- **True channel sizing:** generates at `1080x1080` (Instagram feed) / `1080x1920` (stories/reels) via `--size`, instead of the inherited Nova Canvas `1024x1024` default. Backup (Nova Canvas) stays fixed at `1024x1024`.
- **Step 5b (new):** HTML ad mockups must embed the final PNG as a base64 data URI rather than a relative file path, so output is self-contained and renders anywhere.
- Updated description, How-It-Works diagram, Phase 1 concept dimensions, execution pipeline, prompt tips, and field-mapping table to match.

Markdown-only; no code/parser changes. Downstream compositing steps (logo, headline, display, iteration) read `img.size` dynamically, so they handle the new size and the backup's 1024x1024 unchanged.

## Context
Companion to #190 (creative-brief-architect + image-brand-compliance), which adopt the same `tas-imggen` primary / Creative Studio backup pattern for their image generation. This PR migrates the canonical `image-gen` skill those two reference.

## Test plan
- [ ] `tas-imggen generate --prompt "…" --size 1080x1080 --quality high -o out.png` produces a valid PNG where the CLI is installed
- [ ] Backup path (Creative Studio) still works when `tas-imggen` is unavailable
- [ ] Full pipeline runs end-to-end: base image → logo overlay → headline composite → display
- [ ] HTML ad mockup renders with an embedded base64 image (no relative path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)