### PR TITLE
tdx-skills/segment: name matching is case-insensitive + parent-relative path guidance

### DIFF
--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -75,6 +75,7 @@ tdx sg move "Marketing/VIP Customers" --folder "Marketing/Archive"   # nested pa
 - Names are **relative to the parent segment** — do not prefix the parent segment name.
 - **A bare name only matches a segment at the parent's top level — it never searches inside folders.** If the segment is nested, or you are not sure where it lives, first run `tdx sg list -r --json`, find the segment's **folder path**, and move by that path (`Folder/Sub/Segment Name`). A bare name that isn't at the top level returns `segment not found` — read that as "it's inside a folder, go find the path", not "it doesn't exist".
 - **Footgun:** the same name can exist both at the top level and inside a folder (names are unique only within a folder). A bare name then silently resolves the **top-level** one. When a name may not be unique, use the full folder path so you move the intended segment.
+- **The same name can appear in several different folders.** If `tdx sg list -r --json` returns more than one segment with the requested name, do **not** pick one — show the user each match with its full folder path and id, and ask which they mean. Only move once you have a single unambiguous path. Never move "the first one you found".
 
 ## YAML Configuration
 

--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -72,7 +72,9 @@ tdx sg move "Marketing/VIP Customers" --folder "Marketing/Archive"   # nested pa
 - Segments and the target folder can be given by **numeric ID or by name/path** (names resolve within the current parent segment context).
 - **Get IDs/names from `tdx sg list -r --json`** (use `-r` so segments nested in folders are included; read the `id`/`name` field — or the Console URL) — not from the IDs returned by `tdx sg create`.
 - Name matching is **case-insensitive**; an ambiguous name errors and lists the matches with their IDs so you can pass the ID instead.
-- Names are **relative to the parent segment** — do not prefix the parent segment name. A nested segment needs its **folder path** (`Folder/Sub/Segment Name`); a bare name matches only segments at the parent's top level (those not inside any folder under it).
+- Names are **relative to the parent segment** — do not prefix the parent segment name.
+- **A bare name only matches a segment at the parent's top level — it never searches inside folders.** If the segment is nested, or you are not sure where it lives, first run `tdx sg list -r --json`, find the segment's **folder path**, and move by that path (`Folder/Sub/Segment Name`). A bare name that isn't at the top level returns `segment not found` — read that as "it's inside a folder, go find the path", not "it doesn't exist".
+- **Footgun:** the same name can exist both at the top level and inside a folder (names are unique only within a folder). A bare name then silently resolves the **top-level** one. When a name may not be unique, use the full folder path so you move the intended segment.
 
 ## YAML Configuration
 

--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -71,7 +71,8 @@ tdx sg move "Marketing/VIP Customers" --folder "Marketing/Archive"   # nested pa
 
 - Segments and the target folder can be given by **numeric ID or by name/path** (names resolve within the current parent segment context).
 - **Get IDs/names from `tdx sg list -r --json`** (use `-r` so segments nested in folders are included; read the `id`/`name` field — or the Console URL) — not from the IDs returned by `tdx sg create`.
-- Name matching is **exact and case-sensitive**; an ambiguous name errors and lists the matches with their IDs so you can pass the ID instead.
+- Name matching is **case-insensitive**; an ambiguous name errors and lists the matches with their IDs so you can pass the ID instead.
+- Names are **relative to the parent segment** — do not prefix the parent segment name. A nested segment needs its **folder path** (`Folder/Sub/Segment Name`); a bare name matches only top-level segments.
 
 ## YAML Configuration
 

--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -72,7 +72,7 @@ tdx sg move "Marketing/VIP Customers" --folder "Marketing/Archive"   # nested pa
 - Segments and the target folder can be given by **numeric ID or by name/path** (names resolve within the current parent segment context).
 - **Get IDs/names from `tdx sg list -r --json`** (use `-r` so segments nested in folders are included; read the `id`/`name` field — or the Console URL) — not from the IDs returned by `tdx sg create`.
 - Name matching is **case-insensitive**; an ambiguous name errors and lists the matches with their IDs so you can pass the ID instead.
-- Names are **relative to the parent segment** — do not prefix the parent segment name. A nested segment needs its **folder path** (`Folder/Sub/Segment Name`); a bare name matches only top-level segments.
+- Names are **relative to the parent segment** — do not prefix the parent segment name. A nested segment needs its **folder path** (`Folder/Sub/Segment Name`); a bare name matches only segments at the parent's top level (those not inside any folder under it).
 
 ## YAML Configuration
 


### PR DESCRIPTION
## Summary

Update the segment skill to match how `tdx sg move` actually resolves names:

- **Case-insensitive** matching (was documented as case-sensitive).
- **Parent-relative names** — don't prefix the parent segment name. A nested segment needs its **folder path** (`Folder/Sub/Segment Name`); a bare name matches only top-level segments.

Keeps the skill accurate so assistants move by name on the first try instead of falling back to listing/IDs. Pairs with the tdx CLI change that makes matching case-insensitive and advertises name/path support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
