### PR TITLE
feat: add cas skill for Composable Audience Studio (tdx cas)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,7 +92,7 @@
     },
     {
       "name": "tdx-skills",
-      "description": "tdx CLI for managing Treasure Data from the command line including database management, table operations, queries, context configuration, CDP parent segments, child segments with activations, segment validation, journey orchestration, and workflow management",
+      "description": "tdx CLI for managing Treasure Data from the command line including database management, table operations, queries, context configuration, CDP parent segments, child segments with activations, segment validation, journey orchestration, workflow management, and Composable Audience Studio (zero-copy Snowflake/Databricks/BigQuery audiences)",
       "source": "./",
       "strict": false,
       "skills": [
@@ -100,6 +100,7 @@
         "./tdx-skills/parent-segment",
         "./tdx-skills/segment",
         "./tdx-skills/validate-segment",
+        "./tdx-skills/cas",
         "./tdx-skills/journey",
         "./tdx-skills/validate-journey",
         "./tdx-skills/connector-config",

--- a/tdx-skills/cas/SKILL.md
+++ b/tdx-skills/cas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cas
-description: Manages Composable Audience Studio (CAS) zero-copy audiences using `tdx cas` commands — audiences that query customer Cloud Data Warehouses (Snowflake, Databricks, BigQuery) directly instead of copying data into Treasure Data. Covers audience/attribute/behavior YAML, the composable segment rule DSL (distinct from standard `tdx sg` rules), connection resolution per CDW platform, and push safety (idempotent create/update, drift detection, `--delete`). Use when creating or updating composable parent segments, composable child segments, or composable activations, or when a task mentions zero-copy, Snowflake/Databricks/BigQuery audiences, or Composable Audience Studio.
+description: Manages Composable Audience Studio (CAS) zero-copy audiences using `tdx cas` commands — audiences that query customer Cloud Data Warehouses (Snowflake, Databricks, BigQuery) directly instead of copying data into Treasure Data. Covers audience/attribute/behavior YAML, the composable segment rule DSL (distinct from standard `tdx sg` rules), connection resolution per CDW platform, and push safety (idempotent create/update, drift detection, `--delete` for both audience attribute/behavior drift and single-named-target child segment deletion). Use when creating, updating, or deleting composable parent segments, composable child segments, or composable activations, or when a task mentions zero-copy, Snowflake/Databricks/BigQuery audiences, or Composable Audience Studio.
 owner: william.gonzalez@treasure.ai
 tier: 1
 classification: product
@@ -45,6 +45,7 @@ tdx cas push <file_or_dir> --dry-run      # Preview only, no writes
 tdx cas push <file_or_dir> -y             # Skip confirmation (CI/CD)
 tdx cas push <file_or_dir> --delete       # Also apply a detected attribute/behavior removal
 tdx cas sg push <segment_file> --audience <name>  # Push one child segment standalone
+tdx cas sg push <segment_file> --audience <name> --delete  # Delete that one named segment
 tdx cas preview <segment_name> --audience <name>  # Preview a segment query on the CDW
 ```
 
@@ -143,6 +144,18 @@ tdx cas sg push high-value-customers.yml --audience "Customer360 Snowflake" -y
 
 Use this instead of `tdx cas push <dir>` when you only need to manage one segment file independently — e.g. a CI/CD pipeline that touches one segment at a time, or when the parent audience is managed elsewhere and shouldn't be re-pushed alongside every segment change.
 
+### Deleting a single child segment
+
+`tdx cas sg push <segment_file> --audience <name> --delete` deletes **exactly the one segment** named in that file's `name:` field. This is **single-named-target delete only** — not a directory/bulk prune. Passing a directory with `--delete` is rejected outright, not silently interpreted as "delete everything not in this directory."
+
+```bash
+tdx cas sg push high-value-customers.yml --audience "Customer360 Snowflake" --delete
+tdx cas sg push high-value-customers.yml --audience "Customer360 Snowflake" --delete --dry-run
+tdx cas sg push high-value-customers.yml --audience "Customer360 Snowflake" --delete -y
+```
+
+This `--delete` means something different from `tdx cas push`'s own `--delete` (which authorizes removing audience attributes/behaviors detected as drift) — each is scoped to its own command's domain. Don't assume `--delete` always means the same thing across `cas push` and `cas sg push`. The confirmation prompt names the segment and audience explicitly since this is destructive and irreversible — never skip the confirmation (`-y`) on a segment you didn't write the YAML for yourself without confirming with the user first.
+
 ## Legacy endpoint toggle
 
 `tdx cas` requests go to the current default CAS backend host. If a composable audience only exists on the older, standalone legacy host (rare — most accounts are fully migrated), set `TDX_CAS_LEGACY_ENDPOINT=1` before running the command. The two hosts do **not** share data — an audience visible on one is invisible on the other, so only toggle this if `tdx cas list` genuinely doesn't show an audience you expect to find.
@@ -158,6 +171,7 @@ Use this instead of `tdx cas push <dir>` when you only need to manage one segmen
 | `catalog is required` | Databricks/BigQuery connections need `catalog:` set alongside `connection:` in the same block. |
 | Segment rule 400 naming `leftValue`/`rightValue`/`operator` | Composable segment rules use a different shape than standard `tdx sg` — see "Child segment YAML" above, don't reuse a standard segment's rule YAML as-is. |
 | `cas sg push` fails naming `master` or another audience-only field | The file is missing `type: composable_segment` at the top level and got validated as an audience file instead. Add the field — this isn't about the field the error names. |
+| `cas sg push --delete` against a directory is rejected | Single-named-target delete only — point it at the one segment file to delete, not a directory. |
 | Unfamiliar low-level/database error pushing a segment | Composable segment YAML has no schema validation ahead of push — check for a missing or malformed `rule:` block first. |
 | Non-interactive mode error | Add `-y`: `tdx cas push -y <path>` |
 | An audience you expect isn't in `tdx cas list` | It may only exist on the other host — try again with `TDX_CAS_LEGACY_ENDPOINT=1`. |

--- a/tdx-skills/cas/SKILL.md
+++ b/tdx-skills/cas/SKILL.md
@@ -98,7 +98,7 @@ The `connection:` field is a single generic value in the YAML, but what it means
 
 ## Child segment YAML — different rule DSL from `tdx sg`
 
-Composable segment conditions use `leftValue`/`rightValue`/`operator` — **not** the `attribute`/`operator: {type, value}` shape standard `tdx sg` segments use. Get this wrong and the API returns a 400 naming exactly which field is missing/invalid.
+Composable segment conditions use `leftValue` (the attribute) and `operator` (the comparison, which itself nests `type`, `not`, and `rightValue`) — **not** the `attribute`/`operator: {type, value}` shape standard `tdx sg` segments use. `rightValue` is not a sibling of `leftValue`/`operator`; it nests inside `operator`, as shown below. Get this wrong and the API returns a 400 naming exactly which field is missing/invalid.
 
 ```yaml
 type: composable_segment

--- a/tdx-skills/cas/SKILL.md
+++ b/tdx-skills/cas/SKILL.md
@@ -87,7 +87,7 @@ behaviors:
 
 The `connection:` field is a single generic value in the YAML, but what it means depends on the platform:
 
-- **Snowflake**: a federated query config (zero-copy config) **ID**, e.g. `'204'` — never a connector name. This resource is never listed by `tdx connections`, so there's no name to look up; `tdx cas pull` on an existing Snowflake audience shows the exact ID in use. Passing a value that happens to match a registered connector name on a Snowflake field is always a mistake — `tdx cas validate`/`push` catch this and fail fast rather than silently misrouting the ID.
+- **Snowflake**: a federated query config (zero-copy config) **ID** — a raw numeric ID, never a connector name. This resource is never listed by `tdx connections`, so there's no name to look up; `tdx cas pull` on an existing Snowflake audience shows the exact ID in use. Passing a value that happens to match a registered connector name on a Snowflake field is always a mistake — `tdx cas validate`/`push` catch this and fail fast rather than silently misrouting the ID.
 - **Databricks/BigQuery**: a connector name or ID from `tdx connections`, plus a required `catalog:` field alongside `connection:` in the same block (master, or per-attribute/behavior).
 
 ## Child segment YAML — different rule DSL from `tdx sg`

--- a/tdx-skills/cas/SKILL.md
+++ b/tdx-skills/cas/SKILL.md
@@ -5,7 +5,7 @@ owner: william.gonzalez@treasure.ai
 tier: 1
 classification: product
 phase: 1
-last-validated: 2026-07-23
+last-validated: 2026-07-29
 validation-model: claude-sonnet-5
 known-limitations: |
   A push target can only contain one composable audience YAML file — every segment/activation
@@ -29,6 +29,7 @@ known-limitations: |
 All CAS writes go through the typed `tdx cas` commands. **Never** create or update a composable audience/segment/activation with raw `tdx api` HTTP calls — the request shapes below have real footguns that the typed command handles for you.
 
 - **Audience updates are a full replace of `attributes`/`behaviors`, not a merge.** If you push a YAML that's missing an attribute/behavior the server currently has, `tdx cas push` **refuses before writing anything** and names exactly what would be removed. This is intentional — it is not a bug to work around. Either update the local YAML to include the missing field (pull first if it might be stale: `tdx cas pull`), or, if removing it is genuinely intended, re-run with `--delete`. Never assume `--delete` is safe to add reflexively just to make the refusal go away — confirm with the user first if you didn't write the YAML yourself.
+- **Renaming an attribute/behavior (same source `schema`/`table`/`column`, new `name`) does NOT need `--delete`.** `tdx cas push` detects this as a rename, not a removal, and applies it directly. Under the hood the backend recreates the attribute/behavior with a new server-side id every time (it can't rename in place) — push output reports this explicitly, e.g. `Renamed attribute: "email" → "email_updated" (server id changed 10095 → 10096)`. If anything else is keyed on that id (an activation, an external system), it needs to be updated separately; `tdx cas push` has no way to know about or update such references.
 - **Repeat pushes are idempotent by name.** Pushing the same audience/segment/activation name again updates the existing one — it does not create a duplicate. There's no need to check existence yourself before pushing.
 - **No confirmation prompt on drift or errors.** Both the drift refusal above and any other push failure exit non-zero with a specific message (never a generic "push failed"). Read the message — it names the exact field/attribute/behavior involved.
 - If a typed command seems not to exist for what you need, ask the user — do not fall back to raw `tdx api`.
@@ -87,7 +88,11 @@ behaviors:
         column: AMOUNT
 ```
 
-**Attribute/behavior `type` must match the real CDW column type** (`string`, `number`, `timestamp`, `string_array`, `number_array`) — a string-typed attribute over a numeric CDW column is rejected by the API (400) even though it's syntactically valid YAML. If unsure, pull an existing audience over the same table and copy its types.
+**Attribute/behavior `type` must match the real CDW column type** (`string`, `number`, `boolean`, `date`, `timestamp`, `string_array`, `number_array`) — a string-typed attribute over a numeric CDW column is rejected by the API (400) even though it's syntactically valid YAML. If unsure, pull an existing audience over the same table and copy its types.
+
+**Every audience needs at least one attribute.** `tdx cas validate`/`push` reject an audience with an empty or missing `attributes:` list — the backend requires at least one.
+
+**`all_columns: true` for a behavior only works if that behavior already has it set server-side.** The backend rejects `all_columns: true` for a brand-new behavior, or when flipping an existing behavior from explicit `columns:` to `all_columns: true` — this only succeeds on a behavior that was already created with it (e.g. an older audience predating this restriction). For any new or changed behavior, use an explicit `columns:` list instead; don't reach for `all_columns: true` as a shortcut. (Note: this is different from segment activations below, which do support `all_columns: true` freely.)
 
 ## Connection resolution — differs by CDW platform
 
@@ -173,6 +178,7 @@ This `--delete` means something different from `tdx cas push`'s own `--delete` (
 | `cas sg push` fails naming `master` or another audience-only field | The file is missing `type: composable_segment` at the top level and got validated as an audience file instead. Add the field — this isn't about the field the error names. |
 | `cas sg push --delete` against a directory is rejected | Single-named-target delete only — point it at the one segment file to delete, not a directory. |
 | Unfamiliar low-level/database error pushing a segment | Composable segment YAML has no schema validation ahead of push — check for a missing or malformed `rule:` block first. |
+| `all_columns: true` rejected for a behavior | Only works on a behavior that already has it set server-side — use an explicit `columns:` list for any new or changed behavior instead. |
 | Non-interactive mode error | Add `-y`: `tdx cas push -y <path>` |
 | An audience you expect isn't in `tdx cas list` | It may only exist on the other host — try again with `TDX_CAS_LEGACY_ENDPOINT=1`. |
 

--- a/tdx-skills/cas/SKILL.md
+++ b/tdx-skills/cas/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: cas
+description: Manages Composable Audience Studio (CAS) zero-copy audiences using `tdx cas` commands — audiences that query customer Cloud Data Warehouses (Snowflake, Databricks, BigQuery) directly instead of copying data into Treasure Data. Covers audience/attribute/behavior YAML, the composable segment rule DSL (distinct from standard `tdx sg` rules), connection resolution per CDW platform, and push safety (idempotent create/update, drift detection, `--delete`). Use when creating or updating composable parent segments, composable child segments, or composable activations, or when a task mentions zero-copy, Snowflake/Databricks/BigQuery audiences, or Composable Audience Studio.
+owner: william.gonzalez@treasure.ai
+tier: 1
+classification: product
+phase: 1
+last-validated: 2026-07-21
+validation-model: claude-sonnet-5
+known-limitations: |
+  A push target can only contain one composable audience YAML file — every segment/activation
+  file in the target attaches to that one audience. Activation `connector_config` fields are
+  connector-specific and not validated by `tdx cas validate`/`push` ahead of the API call; always
+  run `tdx connection schema <type>` first (see the connector-config skill) rather than guessing
+  field names. Snowflake schema/table name matching is case-sensitive; a lowercase `schema`/`table`
+  pulled from an older audience may not match the CDW's actual (often uppercase) names.
+---
+
+# tdx CAS - Composable Audience Studio Management
+
+**Composable audiences never copy data into Treasure Data** — they query the customer's own Snowflake/Databricks/BigQuery directly. This is the main reason CAS YAML differs from standard `tdx ps`/`tdx sg` YAML: every table reference needs a `connection`, and child segment rules use a different condition shape.
+
+## Pushing composable audiences safely — read this first
+
+All CAS writes go through the typed `tdx cas` commands. **Never** create or update a composable audience/segment/activation with raw `tdx api` HTTP calls — the request shapes below have real footguns that the typed command handles for you.
+
+- **Audience updates are a full replace of `attributes`/`behaviors`, not a merge.** If you push a YAML that's missing an attribute/behavior the server currently has, `tdx cas push` **refuses before writing anything** and names exactly what would be removed. This is intentional — it is not a bug to work around. Either update the local YAML to include the missing field (pull first if it might be stale: `tdx cas pull`), or, if removing it is genuinely intended, re-run with `--delete`. Never assume `--delete` is safe to add reflexively just to make the refusal go away — confirm with the user first if you didn't write the YAML yourself.
+- **Repeat pushes are idempotent by name.** Pushing the same audience/segment/activation name again updates the existing one — it does not create a duplicate. There's no need to check existence yourself before pushing.
+- **No confirmation prompt on drift or errors.** Both the drift refusal above and any other push failure exit non-zero with a specific message (never a generic "push failed"). Read the message — it names the exact field/attribute/behavior involved.
+- If a typed command seems not to exist for what you need, ask the user — do not fall back to raw `tdx api`.
+
+## Core Commands
+
+```bash
+tdx cas list                              # List composable audiences
+tdx cas desc <name>                       # Describe a composable audience
+tdx cas pull <name> [--dir <dir>]         # Pull audience + segments to YAML
+tdx cas validate <file_or_dir>            # Validate YAML locally (no API calls)
+tdx cas push <file_or_dir>                # Preview, confirm, then push
+tdx cas push <file_or_dir> --dry-run      # Preview only, no writes
+tdx cas push <file_or_dir> -y             # Skip confirmation (CI/CD)
+tdx cas push <file_or_dir> --delete       # Also apply a detected attribute/behavior removal
+tdx cas preview <segment_name> --audience <name>  # Preview a segment query on the CDW
+```
+
+`tdx cas push` always previews first (dry-run pass showing create/update counts and any drift), prompts for confirmation on a real write unless `-y`, and refuses outright in non-interactive mode without `-y`.
+
+## Audience YAML
+
+```yaml
+name: Customer360 Snowflake
+description: Customer data from Snowflake
+timezone: UTC
+master:
+  connection: '<federated_query_config_id>'   # Snowflake: raw zero-copy config ID, not a connector name
+  schema: PUBLIC
+  table: CUSTOMERS
+  key_column: CDP_CUSTOMER_ID
+attributes:
+  - name: email
+    connection: '<federated_query_config_id>'
+    schema: PUBLIC
+    table: CUSTOMERS
+    join:
+      table_key: CDP_CUSTOMER_ID
+      master_key: CDP_CUSTOMER_ID
+    column: EMAIL
+    type: string          # Must match the real CDW column type — see Connection resolution below
+behaviors:
+  - name: purchases
+    connection: '<federated_query_config_id>'
+    schema: PUBLIC
+    table: PURCHASE_HISTORY
+    join:
+      table_key: CDP_CUSTOMER_ID
+      master_key: CDP_CUSTOMER_ID
+    time_column: TIMESTAMP
+    columns:                # required: this OR `all_columns: true`
+      - name: amount
+        type: number
+        column: AMOUNT
+```
+
+**Attribute/behavior `type` must match the real CDW column type** (`string`, `number`, `timestamp`, `string_array`, `number_array`) — a string-typed attribute over a numeric CDW column is rejected by the API (400) even though it's syntactically valid YAML. If unsure, pull an existing audience over the same table and copy its types.
+
+## Connection resolution — differs by CDW platform
+
+The `connection:` field is a single generic value in the YAML, but what it means depends on the platform:
+
+- **Snowflake**: a federated query config (zero-copy config) **ID**, e.g. `'204'` — never a connector name. This resource is never listed by `tdx connections`, so there's no name to look up; `tdx cas pull` on an existing Snowflake audience shows the exact ID in use. Passing a value that happens to match a registered connector name on a Snowflake field is always a mistake — `tdx cas validate`/`push` catch this and fail fast rather than silently misrouting the ID.
+- **Databricks/BigQuery**: a connector name or ID from `tdx connections`, plus a required `catalog:` field alongside `connection:` in the same block (master, or per-attribute/behavior).
+
+## Child segment YAML — different rule DSL from `tdx sg`
+
+Composable segment conditions use `leftValue`/`rightValue`/`operator` — **not** the `attribute`/`operator: {type, value}` shape standard `tdx sg` segments use. Get this wrong and the API returns a 400 naming exactly which field is missing/invalid.
+
+```yaml
+type: composable_segment
+name: High Value Customers
+folder: Marketing/VIP        # optional — created automatically if it doesn't exist yet
+rule:
+  type: And
+  conditions:
+    - type: Value
+      exclude: false
+      leftValue:
+        name: cdp_customer_id      # the attribute name, nested under leftValue
+      operator:
+        type: Equal                # Equal and other comparison types available
+        not: false
+        rightValue: "some-value"   # the comparison value, as a string
+activations:
+  - name: Export to Marketing
+    connection: salesforce-connection
+    all_columns: true               # or `columns:` — one of the two is required
+    schedule:
+      type: daily                   # none | daily | weekly | monthly
+      timezone: UTC
+```
+
+**Unlike standard `tdx sg` rules, nested `And`/`Or` condition groups ARE supported** here (composable segments don't have the nested-group restriction `validate-segment` documents for standard segments).
+
+For `activations[].connector_config` fields, **don't guess the field names** — run `tdx connection schema <connector_type>` first (see the **connector-config** skill) to discover them for the specific connector.
+
+## Legacy endpoint toggle
+
+`tdx cas` requests go to the current default CAS backend host. If a composable audience only exists on the older, standalone legacy host (rare — most accounts are fully migrated), set `TDX_CAS_LEGACY_ENDPOINT=1` before running the command. The two hosts do **not** share data — an audience visible on one is invisible on the other, so only toggle this if `tdx cas list` genuinely doesn't show an audience you expect to find.
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Push refuses with "would remove attribute(s)/behavior(s) ..." | Intentional drift protection — see "Pushing composable audiences safely" above. Update the YAML or use `--delete` deliberately. |
+| `CONNECTION_NOT_FOUND` | Check the `connection:` value against `tdx connections` (Databricks/BigQuery) or re-pull the audience to confirm the Snowflake zero-copy config ID (Snowflake). |
+| 400 with a Snowflake connection that matches a connector name | You used a connector name where a zero-copy config ID is required — pull an existing Snowflake audience to see the correct ID format. |
+| 400 naming a `type` mismatch on an attribute/behavior column | The YAML `type:` doesn't match the real CDW column type — check the source table's actual column type. |
+| `catalog is required` | Databricks/BigQuery connections need `catalog:` set alongside `connection:` in the same block. |
+| Segment rule 400 naming `leftValue`/`rightValue`/`operator` | Composable segment rules use a different shape than standard `tdx sg` — see "Child segment YAML" above, don't reuse a standard segment's rule YAML as-is. |
+| Non-interactive mode error | Add `-y`: `tdx cas push -y <path>` |
+| An audience you expect isn't in `tdx cas list` | It may only exist on the other host — try again with `TDX_CAS_LEGACY_ENDPOINT=1`. |
+
+## Related Skills
+
+- **connector-config** - Discover `connector_config` fields per connector type for activations
+- **segment** - Standard (non-composable) child segment management — note the different rule DSL
+- **parent-segment** - Standard (non-composable) parent segment management
+
+## Resources
+
+- https://tdx.treasuredata.com/commands/cas.html

--- a/tdx-skills/cas/SKILL.md
+++ b/tdx-skills/cas/SKILL.md
@@ -5,7 +5,7 @@ owner: william.gonzalez@treasure.ai
 tier: 1
 classification: product
 phase: 1
-last-validated: 2026-07-21
+last-validated: 2026-07-23
 validation-model: claude-sonnet-5
 known-limitations: |
   A push target can only contain one composable audience YAML file — every segment/activation
@@ -13,7 +13,11 @@ known-limitations: |
   connector-specific and not validated by `tdx cas validate`/`push` ahead of the API call; always
   run `tdx connection schema <type>` first (see the connector-config skill) rather than guessing
   field names. Snowflake schema/table name matching is case-sensitive; a lowercase `schema`/`table`
-  pulled from an older audience may not match the CDW's actual (often uppercase) names.
+  pulled from an older audience may not match the CDW's actual (often uppercase) names. Composable
+  segment YAML has no schema validation ahead of push (unlike composable audience YAML) — a
+  missing/malformed `rule:` surfaces as a raw backend error, not a clean client-side message.
+  `type: composable_segment` must be present verbatim or the file is validated against the wrong
+  (audience) schema entirely.
 ---
 
 # tdx CAS - Composable Audience Studio Management
@@ -40,6 +44,7 @@ tdx cas push <file_or_dir>                # Preview, confirm, then push
 tdx cas push <file_or_dir> --dry-run      # Preview only, no writes
 tdx cas push <file_or_dir> -y             # Skip confirmation (CI/CD)
 tdx cas push <file_or_dir> --delete       # Also apply a detected attribute/behavior removal
+tdx cas sg push <segment_file> --audience <name>  # Push one child segment standalone
 tdx cas preview <segment_name> --audience <name>  # Preview a segment query on the CDW
 ```
 
@@ -122,6 +127,22 @@ activations:
 
 For `activations[].connector_config` fields, **don't guess the field names** — run `tdx connection schema <connector_type>` first (see the **connector-config** skill) to discover them for the specific connector.
 
+**`type: composable_segment` at the top level is mandatory, exact literal** — not just documentation, it's how `tdx` tells this file apart from a composable audience file. Omit it and the file gets validated against the *audience* schema instead, producing a confusing error about an unrelated field (e.g. a missing `master:`) rather than anything about the segment itself. If you see an error naming `master` or other audience-only fields while pushing something you intend as a segment, check `type:` first.
+
+Composable segment YAML currently has **no schema validation ahead of push** (unlike composable audience YAML, which does). A missing `rule:` reaches the backend and comes back as a raw database error, not a clean client-side message — if you hit an unfamiliar low-level error pushing a segment, suspect a missing/malformed `rule` block first before assuming something else is wrong.
+
+## Pushing a single child segment standalone
+
+`tdx cas sg push <segment_file> --audience <name>` creates or updates **one** child segment without needing a co-located `audience.yml` in the same directory — the parent audience is resolved by name (via `--audience`, or the session context set by `tdx use cas <name>`). Same idempotent-by-name behavior as `tdx cas push`: pushing the same segment name again updates it in place, never creates a duplicate.
+
+```bash
+tdx cas sg push high-value-customers.yml --audience "Customer360 Snowflake"
+tdx cas sg push high-value-customers.yml --audience "Customer360 Snowflake" --dry-run
+tdx cas sg push high-value-customers.yml --audience "Customer360 Snowflake" -y
+```
+
+Use this instead of `tdx cas push <dir>` when you only need to manage one segment file independently — e.g. a CI/CD pipeline that touches one segment at a time, or when the parent audience is managed elsewhere and shouldn't be re-pushed alongside every segment change.
+
 ## Legacy endpoint toggle
 
 `tdx cas` requests go to the current default CAS backend host. If a composable audience only exists on the older, standalone legacy host (rare — most accounts are fully migrated), set `TDX_CAS_LEGACY_ENDPOINT=1` before running the command. The two hosts do **not** share data — an audience visible on one is invisible on the other, so only toggle this if `tdx cas list` genuinely doesn't show an audience you expect to find.
@@ -136,6 +157,8 @@ For `activations[].connector_config` fields, **don't guess the field names** —
 | 400 naming a `type` mismatch on an attribute/behavior column | The YAML `type:` doesn't match the real CDW column type — check the source table's actual column type. |
 | `catalog is required` | Databricks/BigQuery connections need `catalog:` set alongside `connection:` in the same block. |
 | Segment rule 400 naming `leftValue`/`rightValue`/`operator` | Composable segment rules use a different shape than standard `tdx sg` — see "Child segment YAML" above, don't reuse a standard segment's rule YAML as-is. |
+| `cas sg push` fails naming `master` or another audience-only field | The file is missing `type: composable_segment` at the top level and got validated as an audience file instead. Add the field — this isn't about the field the error names. |
+| Unfamiliar low-level/database error pushing a segment | Composable segment YAML has no schema validation ahead of push — check for a missing or malformed `rule:` block first. |
 | Non-interactive mode error | Add `-y`: `tdx cas push -y <path>` |
 | An audience you expect isn't in `tdx cas list` | It may only exist on the other host — try again with `TDX_CAS_LEGACY_ENDPOINT=1`. |
 

--- a/tdx-skills/cas/SKILL.meta.yml
+++ b/tdx-skills/cas/SKILL.meta.yml
@@ -19,3 +19,20 @@ validations:
       real existing segment's pulled YAML, since it isn't otherwise documented — differs from
       standard `tdx sg`'s `attribute`/`operator: {type, value}` shape and lack of nesting
       support.
+  - date: 2026-07-29
+    model: claude-sonnet-5
+    result: pass
+    tester: william.gonzalez@treasure.ai
+    notes: >
+      Re-validated against live dev-us01 following a round of client-side validation
+      hardening fixes to `tdx cas push`/`validate`. Confirmed live: (1) `boolean` and `date`
+      are genuinely accepted CDW column types, not just client-side schema additions;
+      (2) an empty/missing `attributes:` list is rejected before any API call; (3) renaming
+      an attribute/behavior (same source column, new name) is detected and pushed without
+      `--delete`, and the server-side id always changes on rename (backend destroys and
+      rebuilds the whole attributes/behaviors collection on any update — confirmed against
+      the backend's own source, not assumed); (4) `all_columns: true` for a behavior is
+      rejected for a brand-new behavior or a false->true flip, but accepted unchanged on a
+      behavior that already has it — this last case could not be live-tested further (the
+      backend rejects `all_columns` on any creation path now, even bypassing tdx), so it's
+      documented as a known limitation rather than demonstrated end-to-end.

--- a/tdx-skills/cas/SKILL.meta.yml
+++ b/tdx-skills/cas/SKILL.meta.yml
@@ -1,0 +1,21 @@
+# Re-validation log for cas
+# Record each validation run: date, model, result, and notes.
+
+validations:
+  - date: 2026-07-21
+    model: claude-sonnet-5
+    result: pass
+    tester: william.gonzalez@treasure.ai
+    notes: >
+      Validated the push-safety guidance against a live dev CDP environment. Confirmed:
+      (1) pushing an audience a second time unchanged updates the existing one rather than
+      creating a duplicate; (2) pushing a YAML missing an attribute/behavior the server has
+      refuses before any write, naming the exact field, and the field is confirmed still
+      present server-side afterward; (3) `--delete` authorizes the removal and reports it;
+      (4) re-pushing an unchanged child segment updates rather than duplicates; (5) segment/
+      activation/folder failures return specific error messages (naming the field/attribute
+      involved) rather than a generic failure. The composable child segment rule DSL
+      (`leftValue`/`rightValue`/`operator`, nested And/Or supported) was confirmed against a
+      real existing segment's pulled YAML, since it isn't otherwise documented — differs from
+      standard `tdx sg`'s `attribute`/`operator: {type, value}` shape and lack of nesting
+      support.

--- a/tdx-skills/cas/test.yml
+++ b/tdx-skills/cas/test.yml
@@ -61,3 +61,15 @@ scenarios:
     expect: >
       Reports "Updated: 1 segment(s)", not "Created". The audience still has only one
       segment with that name. Exit 0.
+
+  - name: standalone segment push resolves the parent audience by name, no audience.yml needed
+    description: >
+      `tdx cas sg push` creates or updates one child segment on its own, resolving the
+      parent audience via `--audience <name>` — no co-located audience.yml required the
+      way the generic `tdx cas push <dir>` needs one.
+    setup: []
+    run:
+      - tdx cas sg push ./high-value-customers.yml --audience "Customer360 Snowflake" -y
+    expect: >
+      Reports segment created or updated under "Customer360 Snowflake". Re-running the
+      same command updates in place — never creates a duplicate segment.

--- a/tdx-skills/cas/test.yml
+++ b/tdx-skills/cas/test.yml
@@ -1,0 +1,63 @@
+# Regression happy-path for the cas skill's push-safety guidance.
+# Proves the idempotency + drift-check flow the skill documents. Generic example
+# names/paths only (no real resources) — substitute a live composable audience to run.
+skill: cas
+scenarios:
+  - name: dry-run preview shows create vs update accurately
+    description: >
+      `cas push --dry-run` reports "would create" for a brand-new audience name and
+      "would update" for one that already exists — never assumes create.
+    setup: []
+    run:
+      - tdx cas push ./cas-audience/ --dry-run
+    expect: >
+      Prints "Would create: ..." or "Would update: ..." matching whether an audience
+      with that name already exists. No changes made. Exit 0.
+
+  - name: repeat push is idempotent, not duplicating
+    description: >
+      Pushing the same unchanged audience YAML twice updates the existing audience
+      both times — it never creates a second audience with the same name.
+    setup:
+      - tdx cas push ./cas-audience/ -y
+    run:
+      - tdx cas push ./cas-audience/ -y
+    expect: >
+      Reports "Updated: 1 audience(s)", not "Created". `tdx cas list` still shows only
+      one audience with that name. Exit 0.
+
+  - name: drift is refused before any write
+    description: >
+      A local YAML missing an attribute/behavior the server currently has must not
+      silently delete it — push refuses before writing, naming the field.
+    setup:
+      - tdx cas push ./cas-audience-full/ -y   # audience with attributes A and B
+    run:
+      - tdx cas push ./cas-audience-partial/ -y   # same audience YAML, missing attribute B
+    expect: >
+      Refuses with a message naming attribute B specifically and instructing to use
+      `--delete` if the removal is intentional. Non-zero exit. Attribute B is still
+      present on the server afterward (`tdx cas desc <name>` still shows it).
+
+  - name: --delete authorizes the removal
+    description: >
+      Re-running the same refused push with `--delete` applies the removal and reports it.
+    setup:
+      - tdx cas push ./cas-audience-full/ -y
+    run:
+      - tdx cas push ./cas-audience-partial/ -y --delete
+    expect: >
+      Succeeds, reports "Removed (--delete): attribute(s) B". `tdx cas desc <name>` no
+      longer shows attribute B. Exit 0.
+
+  - name: child segment repeat push is idempotent
+    description: >
+      Pushing the same unchanged child segment YAML twice updates the existing segment
+      both times — it never creates a duplicate segment under the audience.
+    setup:
+      - tdx cas push ./cas-segment/ -y
+    run:
+      - tdx cas push ./cas-segment/ -y
+    expect: >
+      Reports "Updated: 1 segment(s)", not "Created". The audience still has only one
+      segment with that name. Exit 0.

--- a/tdx-skills/cas/test.yml
+++ b/tdx-skills/cas/test.yml
@@ -73,3 +73,28 @@ scenarios:
     expect: >
       Reports segment created or updated under "Customer360 Snowflake". Re-running the
       same command updates in place — never creates a duplicate segment.
+
+  - name: sg push --delete removes exactly the one named segment
+    description: >
+      `tdx cas sg push <file> --delete` deletes the single segment named in that file —
+      single-named-target only, not a directory/bulk prune.
+    setup:
+      - tdx cas sg push ./high-value-customers.yml --audience "Customer360 Snowflake" -y
+    run:
+      - tdx cas sg push ./high-value-customers.yml --audience "Customer360 Snowflake" --delete -y
+    expect: >
+      Reports the segment deleted. `tdx cas sg list "Customer360 Snowflake"` no longer
+      shows it. Exit 0. Re-running the same delete command a second time fails cleanly
+      (segment not found) rather than crashing.
+
+  - name: sg push --delete against a directory is rejected, not silently guessed at
+    description: >
+      Passing a directory instead of a single file with `--delete` must not be
+      interpreted as "delete everything not in this directory" — there is no bulk-prune
+      mode for composable child segments.
+    setup: []
+    run:
+      - tdx cas sg push ./cas-segment/ --audience "Customer360 Snowflake" --delete -y
+    expect: >
+      Fails with a message saying it's a directory and `cas sg push` takes a single
+      file. Non-zero exit. Nothing on the server is touched.

--- a/tests/trigger-tests.yml
+++ b/tests/trigger-tests.yml
@@ -37,6 +37,12 @@ tests:
   - prompt: "Validate my segment YAML configuration"
     expected: validate-segment
 
+  - prompt: "Push a composable audience for our Snowflake zero-copy setup"
+    expected: cas
+
+  - prompt: "Create a child segment under a Composable Audience Studio parent segment"
+    expected: cas
+
   - prompt: "Create a customer journey with decision points and activations"
     expected: journey
 


### PR DESCRIPTION
## Summary
- New skill: `tdx-skills/cas` — teaches `tdx cas` (Composable Audience Studio) push/pull/validate, mirroring the `segment` skill's "safely" pattern for a recently-hardened command
- Covers audience/attribute/behavior YAML, per-CDW-platform connection resolution (Snowflake zero-copy config ID vs. Databricks/BigQuery connector+catalog), push safety (idempotent create/update, drift-check refusal + `--delete`), and the composable child segment rule DSL (distinct from standard `tdx sg` — not otherwise documented)
- Cross-links to the existing `connector-config` skill for activation `connector_config` discovery
- Registered in `marketplace.json` under the `tdx-skills` plugin; added two `trigger-tests.yml` entries per the required-per-skill convention

## Test plan
- [ ] Run `./tests/run-tests.sh` and confirm the two new `cas` trigger-test prompts route to the skill
- [ ] Load the skill and drive a live `tdx cas push` idempotency/drift-check scenario against a dev account, confirm the guidance matches actual CLI behavior
- [ ] Spot-check the composable segment rule DSL example against a real pulled segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)