### PR TITLE
tdx-skills/segment: surface `include`/`exclude` composition as the answer to "nested segments"

### DIFF
--- a/tdx-skills/segment/SKILL.md
+++ b/tdx-skills/segment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: segment
-description: Manages CDP child segments using `tdx sg` commands with YAML rule configs. Covers Value/Behavior condition types, all operators (Equal, In, Between, TimeWithinPast, etc.), behavior aggregations with filters, and nested condition group restrictions. Use when creating audience segments with filtering rules, configuring behavior-based conditions, managing segment hierarchies, or exploring available fields with `tdx sg fields`.
+description: Manages CDP child segments using `tdx sg` commands with YAML rule configs. Covers Value/Behavior condition types, all operators (Equal, In, Between, TimeWithinPast, etc.), behavior aggregations with filters, nested/composed segments via `include`/`exclude` segment references, and how to express nested AND/OR logic that the Console rejects. Use when creating audience segments with filtering rules, building a segment on top of or excluding another existing segment, configuring behavior-based conditions, managing segment hierarchies, or exploring available fields with `tdx sg fields`.
 owner: william.gonzalez@treasure.ai
 tier: 1
 classification: product
@@ -192,7 +192,8 @@ Query behavior table data with aggregations. Use `type: Value` with `source` and
 
 ## Segment References (Include/Exclude)
 
-Reference segments that already exist on the server by their exact name.
+This is how you build a **nested/composed segment** — a segment defined on top of another
+segment. Reference segments that already exist on the server by their exact name.
 
 ```yaml
 rule:
@@ -241,7 +242,28 @@ Or conditions across **different attributes** cannot be expressed without nested
 # (country = "US") OR (age > 30)
 ```
 
-For such cases, consider creating separate segments and using `include` references, or restructuring the business logic.
+### Workaround: decompose into referenced segments
+
+Push each branch of the Or into its own segment, then compose them with `include`. The
+composed rule is a flat `Or` of references, so it is not a nested condition group and
+`tdx sg validate` accepts it.
+
+```yaml
+# 1. us-visitors.yml        -> country = "US"
+# 2. over-30.yml            -> age > 30
+# 3. us-or-over-30.yml      -> the composition:
+rule:
+  type: Or
+  conditions:
+    - type: include
+      segment: "US Visitors"
+    - type: include
+      segment: "Over 30"
+```
+
+Push the branch segments before the composed one — a reference to an unpushed local segment
+fails. Prefer this over restructuring the business logic: it keeps the customer's original
+segment definition intact and reviewable.
 
 ## Array Matching
 
@@ -264,7 +286,7 @@ segments/customer-360/
 | Field not available | `tdx sg fields` or run parent workflow |
 | Between missing bounds | At least one of `min` or `max` required |
 | Behavior source unknown | Check parent segment behavior table names |
-| NESTED_CONDITION_GROUP | Use `In` operator or flatten; all nesting is rejected |
+| NESTED_CONDITION_GROUP | Use `In` operator, split into separate segments + `include` references, or flatten; all nesting is rejected |
 | Segment reference not found | Segment must exist on server; use exact name from Console |
 | Non-interactive mode error | Add `-y` flag: `tdx sg push -y "<file>"` |
 

--- a/tdx-skills/segment/test.yml
+++ b/tdx-skills/segment/test.yml
@@ -1,6 +1,6 @@
-# Regression happy-path for the segment skill's name-resolution guidance.
-# Proves the find -> move flow the skill documents. Generic example names only
-# (no real resources) — substitute a live parent segment / names to run.
+# Regression happy-path for the segment skill's name-resolution guidance and for
+# nested/composed segments via `include`/`exclude` references. Generic example
+# names only (no real resources) — substitute a live parent segment / names to run.
 skill: segment
 scenarios:
   - name: find a segment by name (substring, whole tree)
@@ -37,3 +37,59 @@ scenarios:
       If more than one segment is named "VIP Customers" across folders, the move
       refuses (non-zero exit) and lists each match's full path + id; nothing moves.
       If exactly one exists at the top level, it previews normally.
+
+  - name: nested segment via an include reference
+    description: >
+      A segment built on top of another segment — `type: include` with the referenced
+      segment's exact server name. This is the supported form of "nested segment".
+    setup:
+      - tdx sg use "Customer 360"
+      - |
+        cat > /tmp/vip-recent.yml <<'YAML'
+        name: VIP Recent Buyers
+        rule:
+          type: And
+          conditions:
+            - type: include
+              segment: "VIP Customers"
+            - type: Behavior
+              # ...purchased in the last 30 days
+        YAML
+    run:
+      - tdx sg validate /tmp/vip-recent.yml
+      - tdx sg push --dry-run -y /tmp/vip-recent.yml
+    expect: >
+      `validate` passes on syntax but does NOT resolve the reference (see
+      validate-segment: segment references are server-side only). `push --dry-run`
+      resolves "VIP Customers" against the server and previews the composed segment.
+      Exit 0 for both when the referenced segment exists.
+
+  - name: reference to a non-existent segment fails at push, not validate
+    description: >
+      Guards the documented limitation — unpushed/local-only segments cannot be
+      referenced, and the error surfaces only at push time.
+    setup:
+      - tdx sg use "Customer 360"
+    run:
+      - tdx sg push --dry-run -y /tmp/refs-missing-segment.yml
+    expect: >
+      Non-zero exit with a "segment reference not found" style error naming the
+      unresolved segment. `tdx sg validate` on the same file would have passed —
+      that asymmetry is the point of this scenario.
+
+  - name: cross-attribute Or decomposed into referenced segments
+    description: >
+      Nested Or is rejected by the validator (NESTED_CONDITION_GROUP). The documented
+      workaround is to push each branch as its own segment and compose with `include`.
+      Order matters: branches before the composition.
+    setup:
+      - tdx sg use "Customer 360"
+    run:
+      - tdx sg push -y segments/us-visitors.yml
+      - tdx sg push -y segments/over-30.yml
+      - tdx sg validate segments/us-or-over-30.yml
+      - tdx sg push --dry-run -y segments/us-or-over-30.yml
+    expect: >
+      The composed segment is a flat `Or` of two `include` references and is accepted —
+      no NESTED_CONDITION_GROUP error. Pushing the composition first (before its
+      branches) fails with an unresolved reference.

--- a/tests/trigger-tests.yml
+++ b/tests/trigger-tests.yml
@@ -31,6 +31,12 @@ tests:
   - prompt: "Create a segment for users who purchased in the last 30 days"
     expected: segment
 
+  - prompt: "I need a nested segment that builds on an existing segment"
+    expected: segment
+
+  - prompt: "Help me handle nested logic during segment creation"
+    expected: segment
+
   - prompt: "Create a parent segment with customer attributes"
     expected: parent-segment
 


### PR DESCRIPTION
## Why

A customer filed a product gap for "Nested Segment Creation" (tracked in HubSpot / #hs-product-gap-updates), and the tdx team was cc'd on the request. Tracing it back to the original thread, the triage there was "tdx has capability to create segment including referenced segment, but td-skills doesn't handle the referenced segment."

That last part isn't accurate — `include`/`exclude` references have been documented since #43 (2025-12-23), and the decomposition workaround for cross-attribute `Or` since #111 (2026-03-05). But the skill's `description` never mentioned references at all; it advertised only *"nested condition group restrictions."* Someone scanning the description sees what's forbidden, not the supported way to build a segment on top of another segment. Two people in that thread concluded "not supported."

## What changed

- **`description`** now names `include`/`exclude` composition, and reframes the nesting clause as *"how to express nested AND/OR logic that the Console rejects"* rather than a bare restriction.
- **Segment References section** says up front that this *is* how you build a nested/composed segment.
- **Cross-attribute `Or` limitation** gets the decomposition written out in YAML instead of a one-line "consider creating separate segments…", plus the push-order constraint (branches before the composition).
- **`NESTED_CONDITION_GROUP`** row in Common Issues now points at references, not just `In`/flatten — that's the line an agent lands on after a validation failure.
- **`test.yml`** gains three scenarios for the reference path: plain `include` nesting, the validate-passes/push-fails asymmetry on a missing reference, and the cross-attribute-`Or` decomposition. All three pre-existing scenarios covered only `sg move` name resolution.
- **`tests/trigger-tests.yml`** gains two nested-segment prompts.

## Scope — what this does *not* fix

I measured rather than assumed, and the results limit the claim:

| Check | Result |
|---|---|
| Skill selection for nested-segment prompts (old vs new description, 87 skills, haiku) | `segment` **both** ways |
| "Can you build `(country = US) OR (age > 30)`?" against old body, 3 runs | correct answer + `type: include` YAML **3/3** |
| Same against new body, 3 runs | correct answer + `type: include` YAML **3/3** |

So a model that actually loads this skill already answered correctly before this PR. This is a **discoverability and test-coverage fix, not a behavior fix**, and it does not by itself explain the downstream "not supported" answer that reached the customer. The likelier remaining suspect is whether this skill is in context at all on the Foundry Audience-agent / TAIS path — that's being followed up separately and is out of scope here.

The two new trigger tests pass before and after, so they're coverage, not regression guards for this change.

## Testing

`./tests/run-tests.sh` needs `yq`, which I don't have installed, so I replicated the runner's logic (same `extract-skills.sh` output, same prompt template, same `--model haiku`) to produce the table above. YAML frontmatter and both test files parse. `SKILL.md` is 302 lines, within the 500-line guidance.

Worth a second opinion on the `description` rewrite specifically — it's now noticeably longer, and description length trades off against the resolver's precision across 87 skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
