### PR TITLE
TAI-2041: docs(cas): document leftValue.name must match attribute name, not CDW column

### DIFF
--- a/tdx-skills/cas/SKILL.md
+++ b/tdx-skills/cas/SKILL.md
@@ -105,6 +105,8 @@ The `connection:` field is a single generic value in the YAML, but what it means
 
 Composable segment conditions use `leftValue` (the attribute) and `operator` (the comparison, which itself nests `type`, `not`, and `rightValue`) — **not** the `attribute`/`operator: {type, value}` shape standard `tdx sg` segments use. `rightValue` is not a sibling of `leftValue`/`operator`; it nests inside `operator`, as shown below. Get this wrong and the API returns a 400 naming exactly which field is missing/invalid.
 
+**`leftValue.name` must exactly match the parent audience's attribute/behavior `name:` field — not the underlying CDW column, and not a lowercased or otherwise reformatted version of it.** For example, if the audience attribute is `name: STATE` (mapped to CDW column `STATE`), the rule must use `leftValue: { name: STATE }`, not `name: state`. This match is case-sensitive. **There is no client- or push-time validation for this** — composable segment rules have no schema (unlike composable audience YAML), so a mismatched name doesn't error at all: the segment pushes successfully, then silently matches zero rows and shows a blank rule in the Console UI. If a pushed segment's rule looks blank in Console or a preview returns zero rows unexpectedly, check `leftValue.name` against the audience's actual attribute/behavior names (`tdx cas pull` the parent audience to see them) before assuming anything else is wrong.
+
 ```yaml
 type: composable_segment
 name: High Value Customers
@@ -175,6 +177,7 @@ This `--delete` means something different from `tdx cas push`'s own `--delete` (
 | 400 naming a `type` mismatch on an attribute/behavior column | The YAML `type:` doesn't match the real CDW column type — check the source table's actual column type. |
 | `catalog is required` | Databricks/BigQuery connections need `catalog:` set alongside `connection:` in the same block. |
 | Segment rule 400 naming `leftValue`/`rightValue`/`operator` | Composable segment rules use a different shape than standard `tdx sg` — see "Child segment YAML" above, don't reuse a standard segment's rule YAML as-is. |
+| Segment pushes fine but shows a blank rule in Console / preview returns 0 rows | `leftValue.name` doesn't exactly match the audience's attribute/behavior `name:` (case-sensitive) — there's no validation to catch this. `tdx cas pull` the parent audience and check the real attribute/behavior names. |
 | `cas sg push` fails naming `master` or another audience-only field | The file is missing `type: composable_segment` at the top level and got validated as an audience file instead. Add the field — this isn't about the field the error names. |
 | `cas sg push --delete` against a directory is rejected | Single-named-target delete only — point it at the one segment file to delete, not a directory. |
 | Unfamiliar low-level/database error pushing a segment | Composable segment YAML has no schema validation ahead of push — check for a missing or malformed `rule:` block first. |

--- a/tdx-skills/cas/SKILL.meta.yml
+++ b/tdx-skills/cas/SKILL.meta.yml
@@ -35,3 +35,16 @@ validations:
       behavior that already has it — this last case could not be live-tested further (the
       backend rejects `all_columns` on any creation path now, even bypassing tdx), so it's
       documented as a known limitation rather than demonstrated end-to-end.
+  - date: 2026-07-30
+    model: claude-sonnet-5
+    result: pass
+    tester: william.gonzalez@treasure.ai
+    notes: >
+      Documentation-only follow-up from a live agent-generated segment reported as silently
+      matching zero rows. Root cause confirmed against source (`src/sdk/cas/validate-files.ts`,
+      `src/sdk/types/cas.ts`): composable segment rules have no client-side schema, so
+      `leftValue.name` is passed through unchecked. It must exactly match the parent audience's
+      attribute/behavior `name:` (case-sensitive) rather than the underlying CDW column name —
+      a mismatch pushes successfully with no error and shows a blank rule in Console. Added an
+      explicit warning and a Common Issues entry; no code change, since the gap is the complete
+      absence of a schema for this YAML shape (also noted as a pre-existing limitation above).

--- a/tdx-skills/cas/SKILL.meta.yml
+++ b/tdx-skills/cas/SKILL.meta.yml
@@ -44,7 +44,12 @@ validations:
       matching zero rows. Root cause confirmed against source (`src/sdk/cas/validate-files.ts`,
       `src/sdk/types/cas.ts`): composable segment rules have no client-side schema, so
       `leftValue.name` is passed through unchecked. It must exactly match the parent audience's
-      attribute/behavior `name:` (case-sensitive) rather than the underlying CDW column name —
-      a mismatch pushes successfully with no error and shows a blank rule in Console. Added an
-      explicit warning and a Common Issues entry; no code change, since the gap is the complete
-      absence of a schema for this YAML shape (also noted as a pre-existing limitation above).
+      attribute/behavior `name:` (case-sensitive) rather than the underlying CDW column name.
+      Live-confirmed against a real dev CDP environment: pushing a segment with a mismatched-case
+      `leftValue.name` produces no error, warning, or non-zero exit — it succeeds identically to
+      a correct-case segment (3/3 runs). Did not additionally confirm the resulting row-count
+      divergence live — preview/population never materialized a non-zero count within the wait
+      window tried, even for a known-good baseline segment, so that comparison is inconclusive
+      rather than demonstrated; the silent-success behavior alone is sufficient to document the
+      footgun. No code change, since the gap is the complete absence of a schema for this YAML
+      shape (also noted as a pre-existing limitation above).


### PR DESCRIPTION
## Summary
Live feedback from agent-generated CAS segment testing: a rule using the CDW column name (`state`, lowercase) instead of the audience attribute's exact name (`STATE`) pushed successfully but silently matched zero rows, showing a blank rule in Console.

Root cause verified against source: composable segment rules have no client-side schema (`src/sdk/cas/validate-files.ts` says so explicitly), so `leftValue.name` is never checked against the audience's actual attribute/behavior names. This PR documents the requirement (exact, case-sensitive match) and adds a Common Issues entry so the failure mode is diagnosable without re-deriving it from source each time. No code change — the underlying gap is the complete absence of a rule schema, which is a larger, separate fix.

## Test plan
- [x] Verified the "no schema" claim against `src/sdk/cas/validate-files.ts:11` and `src/sdk/types/cas.ts`'s untyped `CASSegmentCondition`
- [x] Confirmed the existing example's `# the attribute name` comment was already directionally correct; this adds the case-sensitivity + silent-failure caveat that was missing