### PR TITLE
APPS-5752: activation skill — migrate behavior export to plural behaviors (multi-table)

### DIFF
--- a/tdx-skills/activation/SKILL.md
+++ b/tdx-skills/activation/SKILL.md
@@ -120,7 +120,7 @@ Join event/history from **behavior tables** alongside audience columns. Use the 
 ```yaml
 behaviors:                         # Up to 4 entries
   - behavior_table: purchase_history
-    join_strategy: Last            # All | First | Last | Top-N
+    join_strategy: Top-N           # All | First | Last | Top-N
     join_row: 10                   # Row limit for Top-N (defaults to 1 for First/Last; unset for All)
     formatting: rows               # rows | cols
     order_by:

--- a/tdx-skills/activation/SKILL.md
+++ b/tdx-skills/activation/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: activation
 description: Configures CDP activations for exporting segment/journey audiences to external destinations. Covers connection discovery, activation YAML structure, schedule options (daily/weekly/monthly/cron), column selection with masking, multi-table behavior data export (join up to 4 behavior tables via `behaviors:`), and notifications. Use when setting up destination exports for segments, configuring journey activation steps, or setting up schedules and column mappings. Always run `tdx connection list` and `tdx connection schema` first.
+owner: tomohiro.ogoke@treasure.ai
+tier: 1
+classification: product
+phase: 1
+known-limitations: |
+  - `behaviors:` supports up to 4 tables; exceeding this limit causes an API error
+  - Setting both `behavior:` (singular, deprecated) and `behaviors:` in the same YAML is an error
+  - `join_row` is ignored for `All` strategy and defaults to 1 for `First`/`Last` — only meaningful for `Top-N`
+  - `order_by` is required on every entry (all strategies); `formatting` is required for `Top-N` but defaults to `rows` for `First`/`Last`. Omitting a required field is an API error
+  - `behavior_table` must be the behavior source name from `tdx sg fields` (e.g. `behavior_purchase_history`), not the console display name
+  - Each behavior table in `behaviors:` must also be referenced by a `Behavior` condition in the segment `rule:`, and the `order_by` key must be one of the entry's `columns`
 ---
 
 # tdx Activation - CDP Activation Configuration
@@ -117,24 +128,35 @@ notification:
 
 Join event/history from **behavior tables** alongside audience columns. Use the plural `behaviors:` list — each entry is its own mini-export (pick a table, how many rows per customer, which columns). Up to **4** behavior tables per activation.
 
+Rules the API enforces (each surfaces as a push error otherwise):
+- `order_by` is required on **every** entry (all strategies). `formatting` is required for `Top-N`; for `First`/`Last` it defaults to `rows` when omitted.
+- `behavior_table` must be the exact behavior source name from `tdx sg fields` (e.g. `behavior_purchase_history`).
+- The `order_by` `key` must also appear in that entry's `columns` (else: `'<key>' is not included in export columns`).
+- Each behavior table used here must also be referenced by a `Behavior` condition in the segment `rule:` (else: `is not included in Segment rules`).
+
 ```yaml
 behaviors:                         # Up to 4 entries
-  - behavior_table: purchase_history
+  - behavior_table: behavior_purchase_history   # Source name from `tdx sg fields`
     join_strategy: Top-N           # All | First | Last | Top-N
     join_row: 10                   # Row limit for Top-N (defaults to 1 for First/Last; unset for All)
-    formatting: rows               # rows | cols
-    order_by:
+    formatting: rows               # rows | cols — required for Top-N
+    order_by:                      # Required on every entry
       - key: timestamp
         order: descending          # ascending | descending — applied before the join
     columns:                       # Plain strings, or `- name: col` with `visibility: masked`
+      - timestamp                  # order_by key must be among the columns
       - product_name
       - order_total
-  - behavior_table: page_views     # Combine multiple tables in one export
+  - behavior_table: behavior_page_views         # Combine multiple tables in one export
     join_strategy: Top-N
     join_row: 5
+    formatting: rows
+    order_by:
+      - key: timestamp
+        order: descending
     columns:
-      - url
       - timestamp
+      - url
 ```
 
 **Prefer `behaviors:` (plural).** The singular `behavior:` (a single object, no list) is deprecated backward-compat and will be removed — emit `behaviors:` for new configs. Setting both `behavior` and `behaviors` is an error.

--- a/tdx-skills/activation/SKILL.md
+++ b/tdx-skills/activation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: activation
-description: Configures CDP activations for exporting segment/journey audiences to external destinations. Covers connection discovery, activation YAML structure, schedule options (daily/weekly/monthly/cron), column selection with masking, behavior data export, and notifications. Use when setting up destination exports for segments, configuring journey activation steps, or setting up schedules and column mappings. Always run `tdx connection list` and `tdx connection schema` first.
+description: Configures CDP activations for exporting segment/journey audiences to external destinations. Covers connection discovery, activation YAML structure, schedule options (daily/weekly/monthly/cron), column selection with masking, multi-table behavior data export (join up to 4 behavior tables via `behaviors:`), and notifications. Use when setting up destination exports for segments, configuring journey activation steps, or setting up schedules and column mappings. Always run `tdx connection list` and `tdx connection schema` first.
 ---
 
 # tdx Activation - CDP Activation Configuration
@@ -115,19 +115,29 @@ notification:
 
 ## Behavior Data Export
 
+Join event/history from **behavior tables** alongside audience columns. Use the plural `behaviors:` list — each entry is its own mini-export (pick a table, how many rows per customer, which columns). Up to **4** behavior tables per activation.
+
 ```yaml
-behavior:
-  behavior_table: purchase_history
-  join_strategy: Last              # All | First | Last | Top-N
-  join_row: 10                     # Rows for Top-N
-  formatting: rows                 # rows | cols
-  order_by:
-    - key: timestamp
-      order: desc
-  columns:
-    - name: product_name
-    - name: order_total
+behaviors:                         # Up to 4 entries
+  - behavior_table: purchase_history
+    join_strategy: Last            # All | First | Last | Top-N
+    join_row: 10                   # Row limit for Top-N (defaults to 1 for First/Last; unset for All)
+    formatting: rows               # rows | cols
+    order_by:
+      - key: timestamp
+        order: descending          # ascending | descending — applied before the join
+    columns:                       # Plain strings, or `- name: col` with `visibility: masked`
+      - product_name
+      - order_total
+  - behavior_table: page_views     # Combine multiple tables in one export
+    join_strategy: Top-N
+    join_row: 5
+    columns:
+      - url
+      - timestamp
 ```
+
+**Prefer `behaviors:` (plural).** The singular `behavior:` (a single object, no list) is deprecated backward-compat and will be removed — emit `behaviors:` for new configs. Setting both `behavior` and `behaviors` is an error.
 
 ## Common Issues
 

--- a/tdx-skills/activation/SKILL.meta.yml
+++ b/tdx-skills/activation/SKILL.meta.yml
@@ -1,0 +1,22 @@
+# Re-validation log for activation
+# Record each validation run: date, model, result, and notes.
+
+validations:
+  - date: 2026-08-13
+    model: claude-sonnet-5
+    result: pass
+    tester: tomohiro.ogoke@treasure.ai
+    notes: >
+      Independent BLIND validation (skill not loaded) on a live production CDP environment:
+      a Sonnet 5 agent, given only the tdx CLI's help/describe/error output, authored and
+      pushed a real segment activation whose `behaviors:` list joins two behavior tables in
+      one export. The production activation API accepted it (activation created,
+      `scheduleType: none`, did not auto-run). Independently reproduced the schema facts now
+      in SKILL.md: `behavior_table` must equal the `tdx sg fields` source name; `order_by`
+      (a `{key, order}` list) is required on every entry including `All`; `formatting`
+      (`rows`|`cols`) required; `join_row` is numeric for `Top-N` and null otherwise. Two
+      constraints newly surfaced and added to SKILL.md: (1) the `order_by` `key` must appear
+      in the entry's `columns` (else "'<key>' is not included in export columns"); (2) each
+      behavior table used in `behaviors:` must also be referenced by a `Behavior` condition in
+      the segment `rule:` (else "is not included in Segment rules"). One throwaway test segment
+      created on the dedicated test parent is being removed via the CDP console.

--- a/tdx-skills/activation/test.yml
+++ b/tdx-skills/activation/test.yml
@@ -1,0 +1,89 @@
+# Regression happy-path for the activation skill's multi-table behavior export guidance.
+# Proves the plural `behaviors:` schema the skill documents. Generic example
+# names/paths only (no real resources) — substitute a live segment/connection to run.
+#
+# Trigger matching lives in tests/trigger-tests.yml (multi-table prompt at "Export my
+# segment to S3 and join in each customer's recent purchases and page views ..." ->
+# expected: activation). The scenarios below cover the YAML/CLI behaviors the skill teaches.
+skill: activation
+scenarios:
+  - name: activation with no behaviors at all (baseline)
+    description: >
+      Behavior export is optional — a plain segment activation that exports only audience
+      columns (no `behavior:` and no `behaviors:` block) is valid.
+    setup: []
+    run:
+      - tdx sg validate ./segment-activation-no-behavior.yml
+    expect: >
+      Validates cleanly. The activation exports only the selected audience columns (or
+      `all_columns: true`); no behavior join is added. Exit 0.
+
+  - name: single behavior table via plural behaviors:
+    description: >
+      A segment activation with one behavior entry uses the plural `behaviors:` list
+      (not the deprecated singular `behavior:`), with `join_strategy`, `order_by`, and
+      plain-string `columns`. `join_row` is unset for the `All` strategy.
+    setup: []
+    run:
+      - tdx sg validate ./segment-activation-single-behavior.yml
+    expect: >
+      Validates cleanly. The activation exports audience columns plus the one behavior
+      table's columns. `order_by` is present; `join_row` is absent for `join_strategy: All`.
+      Exit 0.
+
+  - name: multi-table (2+) behaviors: config
+    description: >
+      Up to 4 behavior tables can be joined in one activation — e.g. purchase_history +
+      page_views — each its own entry under `behaviors:` with its own strategy/columns.
+      `Top-N` entries carry `formatting` and `order_by`.
+    setup: []
+    run:
+      - tdx sg validate ./segment-activation-multi-behavior.yml
+    expect: >
+      Validates cleanly with 2 entries under `behaviors:`. Each entry keeps its own
+      `behavior_table`, `join_strategy`, `join_row`, `formatting`, `order_by`, and
+      `columns`. Exit 0.
+
+  - name: Top-N entry without formatting/order_by is rejected by the API
+    description: >
+      `order_by` is required on every behavior entry; `formatting` is additionally
+      required for `Top-N` (unlike `First`/`Last`, where it defaults to `rows`). A Top-N
+      entry omitting both must be refused.
+    setup: []
+    run:
+      - tdx sg push ./segment-activation-topn-missing-fields.yml -y
+    expect: >
+      The activation is refused with `formatting` / `order_by` "can't be blank" errors
+      naming the Top-N behavior entry. Non-zero exit.
+
+  - name: deprecated singular behavior: is accepted with a deprecation warning
+    description: >
+      The singular `behavior:` object remains accepted for backward compat but is
+      deprecated — validation warns and points to the plural form rather than failing.
+    setup: []
+    run:
+      - tdx sg validate ./segment-activation-singular-behavior.yml
+    expect: >
+      Validates (exit 0) but emits a deprecation warning naming `behavior:` and advising
+      migration to the plural `behaviors:` list.
+
+  - name: setting both behavior: and behaviors: is an error
+    description: >
+      A single activation must not carry both the singular and plural forms — the two
+      are mutually exclusive.
+    setup: []
+    run:
+      - tdx sg validate ./segment-activation-both-behavior-forms.yml
+    expect: >
+      Refuses with a message that `behavior` and `behaviors` cannot both be set. Non-zero
+      exit. Nothing is pushed.
+
+  - name: exceeding 4 behavior tables is rejected
+    description: >
+      The `behaviors:` list caps at 4 entries per activation; a fifth is refused rather
+      than silently truncated.
+    setup: []
+    run:
+      - tdx sg validate ./segment-activation-five-behaviors.yml
+    expect: >
+      Refuses with a message stating the 4-table limit for `behaviors:`. Non-zero exit.

--- a/tests/trigger-tests.yml
+++ b/tests/trigger-tests.yml
@@ -67,6 +67,9 @@ tests:
   - prompt: "Set up an activation to export segment data to Google Ads"
     expected: activation
 
+  - prompt: "Export my segment to S3 and join in each customer's recent purchases and page views alongside the profile columns"
+    expected: activation
+
   - prompt: "Query parent segment data to analyze customer behaviors"
     expected: parent-segment-analysis
 


### PR DESCRIPTION
## Summary

Enhances the **activation** tdx skill to teach the multi-table behavior activation usage (APPS-5752), matching the CLI changes in tdx (as v2026.7.6)

- Migrate the "Behavior Data Export" section from the deprecated singular `behavior:` object to the plural **`behaviors:` list** (up to **4** behavior tables per activation).
- Add a multi-table example (combining, e.g., purchase history + page views in one export).
- Update `order_by` values from `asc`/`desc` → **`ascending`/`descending`** to match the new schema.
- Note behavior `columns` accept plain strings (same schema as top-level columns) and refine the `join_row` description (Top-N row limit; defaults to 1 for First/Last; unset for All).
- Document that singular `behavior:` is deprecated backward-compat and that setting both is an error.
- Update the frontmatter `description` to mention multi-table behavior export (improves triggering).
- Add a trigger test for the multi-table case.

## Scope

Only the **activation** skill documents behavior-export YAML (verified via repo-wide grep for `join_strategy` / `behavior_table` / `order: desc` — single hit). The **journey** skill centralizes behavior export by delegating to the activation skill (`templates/step3-activations.yml`), so no separate change is needed; journeys share the same `ActivationDef` schema. RT journey activations are a separate feature and out of scope.

## Verification

Ran 3 realistic prompts through the updated skill via subagents; all emitted the correct plural `behaviors:` form:
- Multi-table export (purchases + page views) → `behaviors:` list of 2, `order: descending`, `join_strategy: Top-N`.
- Single behavior addition → plural `behaviors:` with one entry (not singular), `join_row` unset for `All`.
- "Can I join 5 tables?" → correctly identified the 4-table cap and offered a split workaround.

## Dependency

tdx v2026.7.6 or later version is published as stable version and supports plural `behaviors:`; singular remains accepted for backward compat, so emitting plural is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)